### PR TITLE
ver bump

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-var Version = "0.6.5"
+var Version = "0.6.6"
 
 var (
 	Token    string


### PR DESCRIPTION
Bump version to 0.6.6 following dependency security updates (#35, #37, #43).