### PR TITLE
test: add makeAPIRequest table-driven tests and wire go test into CI

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -40,5 +40,8 @@ jobs:
       - name: Install dependencies
         run: go mod tidy
 
+      - name: Run tests
+        run: go test ./...
+
       - name: Test build
         run: go build -o cavbot2

--- a/utils/milpacs.go
+++ b/utils/milpacs.go
@@ -99,6 +99,8 @@ var rosterMap = map[string]string{
 	"ROSTER_TYPE_PAST_MEMBERS":  "Past Members",
 }
 
+var apiBaseURL = "https://api.7cav.us/api/v1"
+
 func makeAPIRequest[T any](ctx context.Context, path string, identifier string) (*T, error) {
 	start := time.Now()
 	client := resty.New()
@@ -108,7 +110,7 @@ func makeAPIRequest[T any](ctx context.Context, path string, identifier string) 
 		SetContext(ctx).
 		SetAuthToken(os.Getenv("BEARER")).
 		SetResult(&result).
-		Get(fmt.Sprintf("https://api.7cav.us/api/v1/%s", path))
+		Get(fmt.Sprintf("%s/%s", apiBaseURL, path))
 
 	if response != nil {
 		Info("API Call Finished", "duration", time.Since(start), "status", response.StatusCode(), "path", strings.Split(path, "/")[0], "identifier", identifier)

--- a/utils/milpacs_test.go
+++ b/utils/milpacs_test.go
@@ -1,0 +1,194 @@
+package utils
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type sampleResponse struct {
+	Name string `json:"name"`
+}
+
+func TestMakeAPIRequest_StatusMatrix(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		body           string
+		wantNilResult  bool
+		wantErrSubstr  string // empty means error must be nil
+		wantResultName string // expected sampleResponse.Name when result is non-nil
+	}{
+		{
+			name:           "200 OK with valid JSON returns parsed result",
+			status:         http.StatusOK,
+			body:           `{"name":"alice"}`,
+			wantNilResult:  false,
+			wantResultName: "alice",
+		},
+		{
+			name:          "200 OK with empty body returns non-nil zero-value result",
+			status:        http.StatusOK,
+			body:          "",
+			wantNilResult: false,
+		},
+		{
+			name:          "204 No Content is treated as 2xx",
+			status:        http.StatusNoContent,
+			body:          "",
+			wantNilResult: false,
+		},
+		{
+			name:          "404 returns nil result and friendly 'no <X> found' error",
+			status:        http.StatusNotFound,
+			body:          "",
+			wantNilResult: true,
+			wantErrSubstr: "no milpacs found",
+		},
+		{
+			name:          "401 returns nil result and API-returned-401 error",
+			status:        http.StatusUnauthorized,
+			body:          `{"error":"unauthorized"}`,
+			wantNilResult: true,
+			wantErrSubstr: "milpacs API returned 401 Unauthorized",
+		},
+		{
+			name:          "500 returns nil result and API-returned-500 error",
+			status:        http.StatusInternalServerError,
+			body:          "boom",
+			wantNilResult: true,
+			wantErrSubstr: "milpacs API returned 500 Internal Server Error",
+		},
+		{
+			name:          "418 (arbitrary 4xx) is treated as non-2xx",
+			status:        http.StatusTeapot,
+			body:          "",
+			wantNilResult: true,
+			wantErrSubstr: "milpacs API returned 418",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tc.body != "" {
+					w.Header().Set("Content-Type", "application/json")
+				}
+				w.WriteHeader(tc.status)
+				if tc.body != "" {
+					_, _ = io.WriteString(w, tc.body)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			withTestAPIServer(t, srv)
+
+			got, err := makeAPIRequest[sampleResponse](context.Background(), "milpacs/profile/username/alice", "alice")
+
+			if tc.wantErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("expected nil err, got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.wantErrSubstr, err)
+				}
+			}
+
+			if tc.wantNilResult {
+				if got != nil {
+					t.Fatalf("expected nil result, got: %+v", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil result, got nil")
+			}
+			if tc.wantResultName != "" && got.Name != tc.wantResultName {
+				t.Fatalf("expected name=%q, got %q", tc.wantResultName, got.Name)
+			}
+		})
+	}
+}
+
+func TestMakeAPIRequest_SendsBearerFromEnv(t *testing.T) {
+	t.Setenv("BEARER", "test-token-123")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	t.Cleanup(srv.Close)
+	withTestAPIServer(t, srv)
+
+	if _, err := makeAPIRequest[sampleResponse](context.Background(), "milpacs/x", "x"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "Bearer test-token-123"; gotAuth != want {
+		t.Fatalf("Authorization header = %q, want %q", gotAuth, want)
+	}
+}
+
+func TestMakeAPIRequest_BuildsRequestPathFromBaseURL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	t.Cleanup(srv.Close)
+	withTestAPIServer(t, srv)
+
+	if _, err := makeAPIRequest[sampleResponse](context.Background(), "milpacs/profile/username/alice", "alice"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "/milpacs/profile/username/alice"; gotPath != want {
+		t.Fatalf("request path = %q, want %q", gotPath, want)
+	}
+}
+
+func TestMakeAPIRequest_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	withTestAPIServer(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := makeAPIRequest[sampleResponse](ctx, "milpacs/profile/username/alice", "alice")
+	if got != nil {
+		t.Fatalf("expected nil result on context cancel, got %+v", *got)
+	}
+	if err == nil {
+		t.Fatalf("expected non-nil error on context cancel")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch milpacs") {
+		t.Fatalf("expected wrapped 'failed to fetch milpacs' error, got: %v", err)
+	}
+}
+
+func TestMakeAPIRequest_TransportError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	srv.Close() // close immediately so connect attempts fail
+	withTestAPIServer(t, srv)
+
+	got, err := makeAPIRequest[sampleResponse](context.Background(), "milpacs/profile/username/alice", "alice")
+	if got != nil {
+		t.Fatalf("expected nil result on transport error, got %+v", *got)
+	}
+	if err == nil {
+		t.Fatalf("expected non-nil error on transport error")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch milpacs") {
+		t.Fatalf("expected wrapped 'failed to fetch milpacs' error, got: %v", err)
+	}
+}

--- a/utils/setup_test.go
+++ b/utils/setup_test.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// TestMain initializes the package-level Logger so calls to Info/Warn/Debug
+// inside the code under test don't panic on a nil *slog.Logger.
+func TestMain(m *testing.M) {
+	Logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	os.Exit(m.Run())
+}
+
+// withTestAPIServer redirects makeAPIRequest at the given httptest.Server for
+// the duration of the test, then restores the production URL on cleanup.
+func withTestAPIServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	prev := apiBaseURL
+	apiBaseURL = srv.URL
+	t.Cleanup(func() { apiBaseURL = prev })
+}


### PR DESCRIPTION
## Summary

First slice of the multi-phase testing suite effort. Repo had zero ``*_test.go`` files and CI ran ``go build`` + ``go vet`` + ``golangci-lint`` but no ``go test`` — every regression was caught manually on the test guild.

- Adds 11 table-driven tests for ``utils.makeAPIRequest`` covering the 200 / 204 / 404 / 401 / 418 / 500 matrix from the 2026-05-10 non-2xx Learnings (PR #62), plus auth-header forwarding, request-path construction, context cancellation, and transport errors.
- Extracts ``apiBaseURL`` to a package-level var in ``utils/milpacs.go`` (default unchanged, prod URL preserved) so tests can redirect at an ``httptest.Server``.
- Wires ``go test ./...`` into ``.github/workflows/build_test.yml`` as a step in the existing build job.

Out of scope for this PR (tracked for follow-up):
- Phase 2: command-level integration tests via a mock Discord layer. ``*discordgo.Session`` call-surface audit is done — handler hot path is just 3 methods (``InteractionRespond`` / ``InteractionResponseEdit`` / ``FollowupMessageCreate``); ``warden.go`` is an outlier with ~10 guild role/member methods. Suggests a two-tier interface split.
- Phase 3: CI coverage floor.
- Other ``utils/`` helpers (``loa.go``, ``github.go``, ``time_util.go``, ``HandleValidateBranchName``) — easy follow-ups now that the harness is in place.

## Test plan

- [x] ``go test ./...`` passes locally (11/11)
- [x] ``go vet ./...`` clean
- [x] ``golangci-lint run --timeout=5m`` clean
- [x] ``go build -o cavbot2`` succeeds
- [x] CI lint job passes
- [x] CI build job (now including ``go test ./...``) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)