### PR TITLE
ci: enforce per-package test coverage floors

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# .github/scripts/check-coverage-floors.sh
+#
+# Reads `go test -cover` output on stdin and fails (exit 1) if any tracked
+# package's coverage is below its declared floor. Tracked packages and floors
+# are inlined below — when a PR adds tests that meaningfully raise a package's
+# coverage, the floor should be raised in the same PR.
+#
+# The `main` package is intentionally not tracked: it's entrypoint wiring
+# (DISCORD_TOKEN check, gateway open, command registration) and is not
+# realistically unit-testable without a substantial refactor.
+
+set -euo pipefail
+
+# Inline floor table: pkg<TAB>min-percent. Bump these when tests land.
+# `read -d '' ... || true`: -d '' reads until NUL; since no NUL appears in the
+# heredoc, read returns 1 at EOF. Without `|| true`, `set -e` would kill the
+# script before any check runs. Don't "clean up" the `|| true`.
+read -r -d '' FLOORS <<'EOF' || true
+github.com/7cav/cavbot2/utils	20
+github.com/7cav/cavbot2/commands	1
+EOF
+
+# Read `go test -cover` output from stdin.
+output=$(cat)
+
+fail=0
+while IFS=$'\t' read -r pkg floor; do
+    [[ -z "$pkg" ]] && continue
+    # Extract the "coverage: X.X% of statements" for this package.
+    line=$(grep -E "^(ok|---)[[:space:]]+${pkg//./\\.}([[:space:]]|$)" <<<"$output" || true)
+    if [[ -z "$line" ]]; then
+        echo "ERROR: package $pkg not found in test output" >&2
+        fail=1
+        continue
+    fi
+    if [[ "$line" =~ coverage:[[:space:]]+([0-9]+\.[0-9]+)% ]]; then
+        cov="${BASH_REMATCH[1]}"
+        if awk -v c="$cov" -v f="$floor" 'BEGIN { exit (c < f) ? 0 : 1 }'; then
+            echo "FAIL: $pkg coverage ${cov}% < floor ${floor}%" >&2
+            fail=1
+        else
+            echo "OK:   $pkg coverage ${cov}% >= floor ${floor}%"
+        fi
+    else
+        echo "ERROR: could not parse coverage for $pkg from: $line" >&2
+        fail=1
+    fi
+done <<<"$FLOORS"
+
+if [[ $fail -ne 0 ]]; then
+    echo
+    echo "Coverage floor check failed. To raise a floor, edit this script:"
+    echo "  .github/scripts/check-coverage-floors.sh"
+    exit 1
+fi

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -40,8 +40,11 @@ jobs:
       - name: Install dependencies
         run: go mod tidy
 
-      - name: Run tests
-        run: go test ./...
+      - name: Run tests with coverage
+        run: go test ./... -cover -covermode=atomic | tee /tmp/cover.log
+
+      - name: Enforce coverage floors
+        run: ./.github/scripts/check-coverage-floors.sh < /tmp/cover.log
 
       - name: Test build
         run: go build -o cavbot2

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ A Discord bot built for the 7th Cavalry Gaming Regiment using Go and DiscordGo, 
 Under Construction due to rewrite of bot
 TODO: Add setup steps and list out functionality
 
+## Testing
+
+Run the suite:
+
+```bash
+go test ./...
+```
+
+CI enforces per-package coverage floors via `.github/scripts/check-coverage-floors.sh`. When a PR meaningfully raises a package's coverage, raise its floor in the same PR — that's how the suite ratchets up without the team having to think about it.
+
 ## Contributing
 
 Contributions are welcome through issues and pull requests on our GitHub repository.

--- a/README.md
+++ b/README.md
@@ -18,13 +18,19 @@ TODO: Add setup steps and list out functionality
 
 ## Testing
 
-Run the suite:
+Run the tests:
 
 ```bash
 go test ./...
 ```
 
-CI enforces per-package coverage floors via `.github/scripts/check-coverage-floors.sh`. When a PR meaningfully raises a package's coverage, raise its floor in the same PR — that's how the suite ratchets up without the team having to think about it.
+Run tests with the coverage floor check (matches CI):
+
+```bash
+go test ./... -cover | .github/scripts/check-coverage-floors.sh
+```
+
+CI enforces per-package coverage floors via `.github/scripts/check-coverage-floors.sh`. When a PR raises a package's coverage by more than a point or two, raise its floor in the same PR — that's how the suite ratchets up without the team having to think about it.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Adds per-package coverage floors to CI so future PRs can't silently regress the test coverage Phases 1 and 2 built up.

- New script `.github/scripts/check-coverage-floors.sh` parses `go test -cover` output on stdin and exits 1 if any tracked package drops below its declared floor.
- `build_test.yml` test step now runs `go test ./... -cover -covermode=atomic | tee /tmp/cover.log`, followed by a new "Enforce coverage floors" step that runs the script with that log as stdin.
- README documents the local invocation (matches CI) and the social-contract ratchet: when a PR raises a package's coverage by more than a point or two, raise its floor in the same PR.

## Initial floors

Set just below baseline so refactor dips don't false-alarm:

| Package | Baseline | Floor |
|---|---|---|
| `github.com/7cav/cavbot2/utils` | 21.0% | 20% |
| `github.com/7cav/cavbot2/commands` | 1.8% | 1% |
| `github.com/7cav/cavbot2` (main) | 0.0% | excluded |

The `main` package is entrypoint wiring (DISCORD_TOKEN check, gateway open, command registration) and is not realistically unit-testable without a substantial refactor.

## Tracks #73

This is Phase 3 of the testing-suite project. **Does not close #73** — the umbrella issue closes when all Phase 2 command conversions are also done. Phase 3 is purely the floor mechanism; coverage itself keeps growing via Phase 2 plans.

## Test plan

- [x] `go test ./... -cover | .github/scripts/check-coverage-floors.sh` passes locally (both packages above floor)
- [x] `go vet ./...` clean
- [x] `golangci-lint run --timeout=5m` clean
- [x] `go build -o cavbot2 .` succeeds
- [x] Floor check verified to fail when artificially tripped (regression guard for the script itself)
- [x] CI Lint job passes
- [x] CI Build job passes (now including the floor check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)