### PR TITLE
chore(compose): pass SENTRY_DSN and APP_ENV through to the container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       LOG_LEVEL: ${LOG_LEVEL}
       FORUM_DB_DSN: ${FORUM_DB_DSN}
       LOA_NODE_IDS: ${LOA_NODE_IDS}
+      SENTRY_DSN: ${SENTRY_DSN}
+      APP_ENV: ${APP_ENV}
     networks:
       - xenforo_internal
 


### PR DESCRIPTION
## Summary

Follow-up to #77. The compose service uses an explicit \`environment:\` allowlist, so vars added to \`.env\` alone don't reach the container — they need a corresponding \`KEY: \${KEY}\` line in the compose file too. Hit this in prod immediately on 0.7.7 deploy (logs said "Sentry disabled" despite \`.env\` having the DSN). Backporting the fix so future clean deploys from a fresh checkout don't regress.

## Test plan

- [x] Already verified live on prod after the manual hotfix — logs now show \`Sentry initialized environment=production release=0.7.7\`
- [x] Post-merge: confirm prod still healthy on next Watchtower pull (no-op change to the running container since the env values are unchanged — only the source-of-truth file is being aligned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)