### PR TITLE
fix(commands): treat empty preset rosters as Sentry-reported bugs

### DIFF
--- a/commands/afsm.go
+++ b/commands/afsm.go
@@ -77,6 +77,16 @@ func handleAFSMCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	}
 	utils.Info("📋 Retrieved roster", "member_count", len(Members.LiteProfiles))
 
+	if len(Members.LiteProfiles) == 0 {
+		utils.CaptureError(
+			"AFSM roster lookup returned zero members",
+			fmt.Errorf("empty roster for department %q", choice),
+			"department", choice,
+		)
+		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("⚠️ The %s roster came back empty — this shouldn't happen for a preset department. The issue has been reported.", choice))
+		return
+	}
+
 	eligibleMembers := []AFSMMember{}
 	currentDate := time.Now()
 	utils.Debug("⏰ Current date set", "date", currentDate)

--- a/commands/s6_trackers.go
+++ b/commands/s6_trackers.go
@@ -52,6 +52,15 @@ func handleS6ITCheckCommand(s *discordgo.Session, i *discordgo.InteractionCreate
 		return
 	}
 
+	if len(s6Members.LiteProfiles) == 0 {
+		utils.CaptureError(
+			"S6 IT roster lookup returned zero members",
+			fmt.Errorf("empty roster for S6 fuzzy search"),
+		)
+		utils.HandleError(utils.NewSessionResponder(s), i, "⚠️ The S6 roster came back empty — this shouldn't happen. The issue has been reported.")
+		return
+	}
+
 	eligibleMembers := []ITMember{}
 	currentDate := time.Now()
 	var matches []string


### PR DESCRIPTION
## Summary
- `/afsm` and `/s6-it-check` use fixed-choice or hardcoded position searches, so an empty roster from `utils.GetRosterByFuzzyPositionSearch` is never user input error — it's a real bug (API regression, roster data issue, fuzzy-match drift).
- Previously, both commands iterated zero times and either returned no follow-up or a confusingly empty result.
- Both handlers now bail early with a user-facing "shouldn't happen, reported" message and route a synthetic error through `utils.CaptureError` so the team is paged via Sentry. AFSM tags the `department` so each choice (S1/S2/.../NCOA) fingerprints separately in Sentry.

Fixes #63

## Test plan
- [x] `go build` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run --timeout=5m ./commands/...` — 0 issues
- [x] `go test ./commands/...` passes
- [ ] Manual repro post-deploy: confirm Sentry receives an event if either command ever returns an empty roster (not easily reproducible without mocking the upstream API; relying on the Sentry plumbing already verified in #77)

🤖 Generated with [Claude Code](https://claude.com/claude-code)