### PR TITLE
fix(utils): downgrade HandleError retry-as-edit log to debug

### DIFF
--- a/utils/handlers.go
+++ b/utils/handlers.go
@@ -59,7 +59,7 @@ func HandleError(r InteractionResponder, i *discordgo.InteractionCreate, message
 		})
 		if err != nil {
 			if isAlreadyAcknowledged(err) {
-				Info("Retrying error response as edit", "error", err)
+				Debug("Retrying error response as edit", "error", err)
 				if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 					Content: &message,
 				}); err != nil {
@@ -80,7 +80,7 @@ func HandleError(r InteractionResponder, i *discordgo.InteractionCreate, message
 	})
 	if err != nil {
 		if isAlreadyAcknowledged(err) {
-			Info("Retrying error response as edit", "error", err)
+			Debug("Retrying error response as edit", "error", err)
 			if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 				Content: &message,
 			}); err != nil {


### PR DESCRIPTION
## Summary
- Downgrade the `"Retrying error response as edit"` log line in `utils.HandleError` from `INFO` to `DEBUG` in both branches (application-command and message-component).
- The retry-as-edit path is the expected fallback for handlers that respond first and then route an error through `HandleError`; emitting it at `INFO` produced log spam on every error case where the interaction had already been acknowledged.
- Recovery behavior (the fallback `InteractionResponseEdit`) is unchanged.

Closes #66

## Test plan
- [x] `go test ./...` passes locally
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)