### PR TITLE
chore: ignore docs/superpowers/ working notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 WARP.md
 CLAUDE.md
 .claude/
+docs/superpowers/


### PR DESCRIPTION
## Summary

Adds `docs/superpowers/` to `.gitignore`. These are plan and spec transcripts generated by the [superpowers](https://github.com/anthropic-experimental/superpowers) Claude Code workflow — local working notes, not user-facing documentation. Without this, every Claude Code contributor has to re-resolve the same gitignore tweak in their working tree.

`CLAUDE.md` and `.claude/` were already gitignored on develop, so no change there.

## Test plan
- [x] `.gitignore` syntactically valid (trivial — one new line)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)