### PR TITLE
chore: add dependabot config with weekly cadence + 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Dependabot config — weekly cadence with a 7-day cooldown so version bumps
+# wait for supply-chain-attack flagging before hitting the review queue.
+# Minor + patch updates are grouped per ecosystem to keep PR volume down;
+# major bumps land as individual PRs so they get scrutinized on their own.
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      go-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      docker-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering all three ecosystems used in this repo: **gomod**, **github-actions**, and **docker**.
- Weekly schedule, **7-day cooldown** per ecosystem so version bumps wait long enough for supply-chain-attack flagging before they land on our review queue, without letting packages stagnate.
- Minor + patch updates are **grouped** per ecosystem (one PR per group per week) to keep PR volume down. Major updates still arrive as individual PRs so they get scrutiny.
- Open-PR caps: 5 for gomod / github-actions, 3 for docker.
- Each group labelled with `dependencies` + ecosystem tag for easy filtering.

This is the **first implementation of a planned global rollout** — once we're happy with the shape here, the same config gets copied to the other ~8 syniron-maintained repos (`7cav/adr`, `7cav/api`, the various `syni-*` repos).

## Test plan
- [ ] Dependabot picks up the new config on first scheduled run (or trigger via repo Insights → Dependency graph → Dependabot → "Check for updates")
- [ ] First weekly run produces grouped PRs rather than one-per-dep
- [ ] Confirm `cooldown` is honored (no PR opened for a release younger than 7 days)
- [ ] No syntax errors reported on the Dependabot settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)