### PR TITLE
fix(s6-it-check): add CaptureError at three non-loop HandleError sites

### DIFF
--- a/commands/s6_trackers.go
+++ b/commands/s6_trackers.go
@@ -42,6 +42,7 @@ func runS6ITCheck(r utils.InteractionResponder, i *discordgo.InteractionCreate) 
 		},
 	})
 	if err != nil {
+		utils.CaptureError("❌ Interaction response failed", err)
 		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to respond to interaction: %v", err))
 		return
 	}
@@ -54,6 +55,7 @@ func runS6ITCheck(r utils.InteractionResponder, i *discordgo.InteractionCreate) 
 
 	s6Members, err := utils.GetRosterByFuzzyPositionSearch(ctx, "S6")
 	if err != nil {
+		utils.CaptureError("❌ Roster fetch failed", err)
 		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to fetch S6 Members: %v", err))
 		return
 	}
@@ -112,6 +114,7 @@ func runS6ITCheck(r utils.InteractionResponder, i *discordgo.InteractionCreate) 
 	if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 		Content: &response,
 	}); err != nil {
+		utils.CaptureError("❌ Response edit failed", err)
 		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
 		return
 	}


### PR DESCRIPTION
## Summary

Resolves #85 — surfaced by final reviewer on PR #83.

`/s6-it-check` had three `HandleError` sites lacking a preceding `CaptureError` (interaction-response failure, roster-fetch failure, response-edit failure). AFSM's parallel sites all had one since 0.7.9 — these three were the asymmetric gap. Sentry was blind to infra failures on this command; now matches AFSM.

No behavior change beyond observability. Three two-line additions in `commands/s6_trackers.go`.

## Test plan

- [x] `go build -o cavbot2 .` succeeds
- [x] `go test ./commands/...` passes
- [x] `golangci-lint run --timeout=5m` clean
- [x] `rg -n "CaptureError|HandleError" commands/s6_trackers.go` confirms `CaptureError` immediately precedes `HandleError` at all three target sites