### PR TITLE
chore(commands): normalize /afsm log strings to house style

### DIFF
--- a/commands/afsm.go
+++ b/commands/afsm.go
@@ -52,7 +52,7 @@ func handleAFSMCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 }
 
 func runAFSM(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
-	utils.Info("🎯 AFSM Check requested", "command", "AFSM", "username", i.Member.User.Username, "discord_id", i.Member.User.ID)
+	utils.Info("🚀 Starting AFSM Check", "command", "AFSM", "username", i.Member.User.Username, "discord_id", i.Member.User.ID)
 	choice := i.ApplicationCommandData().Options[0].StringValue()
 	utils.Debug("🔍 Processing department choice", "department", choice)
 
@@ -156,7 +156,7 @@ func runAFSM(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
 		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
 		return
 	}
-	utils.Info("✨ Command completed successfully", "command", "AFSM", "department", choice)
+	utils.Info("✨ Done!", "command", "AFSM", "department", choice)
 }
 
 // evaluateAFSMMember returns (member, nil) when the roster entry is eligible


### PR DESCRIPTION
Fixes #84.

Aligns `/afsm` entry/exit log lines with the house-style convention documented in CLAUDE.md and used by every other command (awol, loa, s6_trackers, milpac, zulu, gamertag_search, apps_deployer):

- Entry: `"🎯 AFSM Check requested"` → `"🚀 Starting AFSM Check"`
- Exit:  `"✨ Command completed successfully"` → `"✨ Done!"`

`department` field preserved on the exit log. No behavior change; tests do not assert on log message text.

## Test plan

- [x] `go build -o cavbot2 .` — clean
- [x] `go test ./commands/...` — pass
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] Coverage floors: commands 19.7% ≥ 17%, utils 28.0% ≥ 20%
- [x] `rg "🎯 AFSM Check requested|Command completed successfully" .` — 0 hits
- [x] `rg "🚀 Starting AFSM Check" commands/afsm.go` — 1 hit
- [x] `rg "✨ Done!" commands/afsm.go` — 1 hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)