### PR TITLE
fix(loa): guard /loa with cache freshness check (#67)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -17,8 +17,8 @@ set -euo pipefail
 # heredoc, read returns 1 at EOF. Without `|| true`, `set -e` would kill the
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
-github.com/7cav/cavbot2/utils	20
-github.com/7cav/cavbot2/commands	17
+github.com/7cav/cavbot2/utils	46
+github.com/7cav/cavbot2/commands	18
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/commands/loa.go
+++ b/commands/loa.go
@@ -12,6 +12,17 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
+// loaUnavailableMessage formats the user-facing string shown when GlobalLOACache
+// is unhealthy. lastRefresh is the cache's last successful refresh (zero == never);
+// now is passed in so callers can read time.Now() once and tests stay deterministic.
+func loaUnavailableMessage(lastRefresh, now time.Time) string {
+	if lastRefresh.IsZero() {
+		return "❌ LOA cache unavailable (never successfully refreshed). Try again shortly."
+	}
+	mins := int(now.Sub(lastRefresh).Minutes())
+	return fmt.Sprintf("❌ LOA cache unavailable (last refresh: %d minutes ago). Try again shortly.", mins)
+}
+
 type LOAUser struct {
 	Username  string
 	MilpacUrl string

--- a/commands/loa.go
+++ b/commands/loa.go
@@ -68,6 +68,26 @@ func handleLOACommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
+	const loaCacheMaxAge = 30 * time.Minute // 2× the 15-min refresh interval
+	healthy, lastRefresh := utils.GlobalLOACache.IsHealthy(loaCacheMaxAge)
+	if !healthy {
+		now := time.Now() // single read; reused for message + log
+		msg := loaUnavailableMessage(lastRefresh, now)
+		utils.Debug("LOA command served unavailable message",
+			"command", "LOA",
+			"username", i.Member.User.Username,
+			"discord_id", i.Member.User.ID,
+			"last_success", lastRefresh,
+			"served_at", now,
+			"staleness", now.Sub(lastRefresh),
+		)
+		_, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &msg})
+		if err != nil {
+			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+		}
+		return
+	}
+
 	roster, err := utils.GetRosterByFuzzyPositionSearch(ctx, position)
 	if err != nil {
 		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to fetch roster: %v", err))

--- a/commands/loa_test.go
+++ b/commands/loa_test.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLOAUnavailableMessage(t *testing.T) {
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		lastRefresh time.Time
+		wantSubstr  string
+	}{
+		{
+			name:        "never refreshed reports never",
+			lastRefresh: time.Time{},
+			wantSubstr:  "never successfully refreshed",
+		},
+		{
+			name:        "31 minutes ago reports 31 minutes",
+			lastRefresh: now.Add(-31 * time.Minute),
+			wantSubstr:  "last refresh: 31 minutes ago",
+		},
+		{
+			name:        "90 minutes ago reports 90 minutes",
+			lastRefresh: now.Add(-90 * time.Minute),
+			wantSubstr:  "last refresh: 90 minutes ago",
+		},
+		{
+			name:        "exactly 30 minutes ago reports 30 minutes",
+			lastRefresh: now.Add(-30 * time.Minute),
+			wantSubstr:  "last refresh: 30 minutes ago",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := loaUnavailableMessage(tt.lastRefresh, now)
+			if !strings.Contains(got, tt.wantSubstr) {
+				t.Fatalf("loaUnavailableMessage = %q, want substring %q", got, tt.wantSubstr)
+			}
+			if !strings.HasPrefix(got, "❌ LOA cache unavailable") {
+				t.Fatalf("loaUnavailableMessage = %q, want prefix %q",
+					got, "❌ LOA cache unavailable")
+			}
+			if !strings.HasSuffix(strings.TrimSpace(got), "Try again shortly.") {
+				t.Fatalf("loaUnavailableMessage = %q, want suffix %q",
+					got, "Try again shortly.")
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,10 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 )
 
-require filippo.io/edwards25519 v1.2.0 // indirect
+require (
+	filippo.io/edwards25519 v1.2.0 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
+)
 
 require (
 	github.com/gorilla/websocket v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -19,6 +21,7 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/utils/loa.go
+++ b/utils/loa.go
@@ -24,9 +24,10 @@ type LOAEntry struct {
 }
 
 type LOACache struct {
-	mu                 sync.RWMutex
-	entries            map[string]LOAEntry
-	lastSyncedPostDate int64
+	mu                    sync.RWMutex
+	entries               map[string]LOAEntry
+	lastSyncedPostDate    int64
+	lastSuccessfulRefresh time.Time // zero == never
 }
 
 var GlobalLOACache = &LOACache{
@@ -51,6 +52,19 @@ func (c *LOACache) IsOnLOA(username string) bool {
 	}
 	now := time.Now()
 	return !now.Before(entry.StartDate) && !now.After(entry.EndDate)
+}
+
+// IsHealthy reports whether the cache has been successfully refreshed within
+// maxAge. The returned timestamp is the last-successful-refresh time (zero if
+// the cache has never refreshed successfully) so callers can render diagnostic
+// messages without a second lock acquisition.
+func (c *LOACache) IsHealthy(maxAge time.Duration) (bool, time.Time) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.lastSuccessfulRefresh.IsZero() {
+		return false, time.Time{}
+	}
+	return time.Since(c.lastSuccessfulRefresh) <= maxAge, c.lastSuccessfulRefresh
 }
 
 // Refresh fetches LOA posts from the forum DB incrementally and updates the cache.

--- a/utils/loa.go
+++ b/utils/loa.go
@@ -93,6 +93,7 @@ func (c *LOACache) Refresh(db *sql.DB, nodeIDs []int) {
 
 	maxPostDate := c.lastSyncedPostDate
 	totalParsed := 0
+	successfulNodes := 0
 
 	for _, nodeID := range nodeIDs {
 		rows, err := db.Query(`
@@ -129,14 +130,29 @@ func (c *LOACache) Refresh(db *sql.DB, nodeIDs []int) {
 			}
 			nodeParsed++
 		}
+		rowsErr := rows.Err()
 		_ = rows.Close()
+
+		if rowsErr != nil {
+			Warn("LOA cache refresh failed mid-stream", "node_id", nodeID, "error", rowsErr)
+			continue
+		}
 
 		Info("LOA node refreshed", "node_id", nodeID, "new_parsed", nodeParsed)
 		totalParsed += nodeParsed
+		successfulNodes++
 	}
 
 	c.lastSyncedPostDate = maxPostDate
-	Info("LOA cache refreshed", "new_parsed", totalParsed, "total_active", len(c.entries))
+	if successfulNodes > 0 {
+		c.lastSuccessfulRefresh = time.Now()
+	}
+	Info("LOA cache refreshed",
+		"new_parsed", totalParsed,
+		"total_active", len(c.entries),
+		"successful_nodes", successfulNodes,
+		"total_nodes", len(nodeIDs),
+	)
 }
 
 func parseLOAPost(msg string) (LOAEntry, bool) {

--- a/utils/loa_test.go
+++ b/utils/loa_test.go
@@ -1,8 +1,12 @@
 package utils
 
 import (
+	"database/sql"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestIsHealthy(t *testing.T) {
@@ -60,5 +64,129 @@ func TestIsHealthy(t *testing.T) {
 				t.Fatalf("IsHealthy time = %v, want zero", gotTime)
 			}
 		})
+	}
+}
+
+// loaQueryRegex is the regex sqlmock matches against the raw SELECT Refresh issues.
+// QueryMatcherRegexp matches against the raw query string (whitespace/newlines intact),
+// so we pin a substring that lives on a single line within the actual SQL — the
+// column-list line — and escape the dots. That stays robust against later changes
+// to FROM/WHERE/ORDER BY formatting while still rejecting an entirely different query.
+const loaQueryRegex = `SELECT p\.message, t\.post_date, t\.thread_id`
+
+func newMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db, mock
+}
+
+// validLOAMessage returns a forum post body that parseLOAPost accepts.
+func validLOAMessage(username string) string {
+	return "[B][COLOR=rgb(213, 185, 0)]Username[/COLOR][/B]: " + username + "\n" +
+		"[B][COLOR=rgb(213, 185, 0)]Start Date[/COLOR][/B]\nJan 1, 2099\n" +
+		"[B][COLOR=rgb(213, 185, 0)]End Date[/COLOR][/B]\nJan 31, 2099\n"
+}
+
+func TestRefresh_AllNodesFail_DoesNotUpdateTimestamp(t *testing.T) {
+	db, mock := newMockDB(t)
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	seed := time.Now().Add(-2 * time.Hour)
+	c.lastSuccessfulRefresh = seed
+
+	nodeIDs := []int{180, 400, 540}
+	for range nodeIDs {
+		mock.ExpectQuery(loaQueryRegex).WillReturnError(sql.ErrConnDone)
+	}
+
+	c.Refresh(db, nodeIDs)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+	if !c.lastSuccessfulRefresh.Equal(seed) {
+		t.Fatalf("lastSuccessfulRefresh moved to %v, want unchanged %v",
+			c.lastSuccessfulRefresh, seed)
+	}
+}
+
+func TestRefresh_PartialSuccess_UpdatesTimestamp(t *testing.T) {
+	db, mock := newMockDB(t)
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	seed := time.Now().Add(-2 * time.Hour)
+	c.lastSuccessfulRefresh = seed
+
+	rows := sqlmock.NewRows([]string{"message", "post_date", "thread_id"}).
+		AddRow(validLOAMessage("alice"), time.Now().Unix(), int64(12345))
+	mock.ExpectQuery(loaQueryRegex).WillReturnRows(rows)
+	mock.ExpectQuery(loaQueryRegex).WillReturnError(sql.ErrConnDone)
+
+	before := time.Now()
+	c.Refresh(db, []int{180, 400})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+	if !c.lastSuccessfulRefresh.After(seed) {
+		t.Fatalf("lastSuccessfulRefresh = %v, expected later than seed %v",
+			c.lastSuccessfulRefresh, seed)
+	}
+	if c.lastSuccessfulRefresh.Before(before) {
+		t.Fatalf("lastSuccessfulRefresh = %v, expected >= %v",
+			c.lastSuccessfulRefresh, before)
+	}
+}
+
+func TestRefresh_RowsErrMidStream_DoesNotCount(t *testing.T) {
+	db, mock := newMockDB(t)
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	seed := time.Now().Add(-2 * time.Hour)
+	c.lastSuccessfulRefresh = seed
+
+	// Node 1: Query succeeds, returns a row, then rows.Err() is non-nil at end.
+	// Node 2: Query fails outright.
+	streamErr := errors.New("simulated stream failure")
+	rows := sqlmock.NewRows([]string{"message", "post_date", "thread_id"}).
+		AddRow(validLOAMessage("bob"), time.Now().Unix(), int64(999)).
+		RowError(0, streamErr) // injected: surfaces via rows.Err() after iteration
+	mock.ExpectQuery(loaQueryRegex).WillReturnRows(rows)
+	mock.ExpectQuery(loaQueryRegex).WillReturnError(sql.ErrConnDone)
+
+	c.Refresh(db, []int{180, 400})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+	if !c.lastSuccessfulRefresh.Equal(seed) {
+		t.Fatalf("lastSuccessfulRefresh moved to %v, want unchanged %v "+
+			"(mid-stream failures must not count as success)",
+			c.lastSuccessfulRefresh, seed)
+	}
+}
+
+func TestRefresh_RowParseFailure_StillCountsNodeAsSuccess(t *testing.T) {
+	db, mock := newMockDB(t)
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	seed := time.Now().Add(-2 * time.Hour)
+	c.lastSuccessfulRefresh = seed
+
+	// Single node returns one well-formed row + one row whose body parseLOAPost rejects.
+	// Both rows complete; rows.Err() is nil. The node should still count as successful.
+	rows := sqlmock.NewRows([]string{"message", "post_date", "thread_id"}).
+		AddRow(validLOAMessage("carol"), time.Now().Unix(), int64(1)).
+		AddRow("not-a-loa-post-body", time.Now().Unix(), int64(2))
+	mock.ExpectQuery(loaQueryRegex).WillReturnRows(rows)
+
+	c.Refresh(db, []int{180})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+	if !c.lastSuccessfulRefresh.After(seed) {
+		t.Fatalf("lastSuccessfulRefresh = %v, expected updated (row-level parse "+
+			"noise must not invalidate the node)", c.lastSuccessfulRefresh)
 	}
 }

--- a/utils/loa_test.go
+++ b/utils/loa_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsHealthy(t *testing.T) {
+	tests := []struct {
+		name       string
+		seed       time.Time // zero value means "never refreshed"
+		maxAge     time.Duration
+		wantOK     bool
+		wantSeeded bool // true means returned timestamp must equal seed; false means must be zero
+	}{
+		{
+			name:       "never refreshed returns false and zero time",
+			seed:       time.Time{},
+			maxAge:     30 * time.Minute,
+			wantOK:     false,
+			wantSeeded: false,
+		},
+		{
+			name:       "just inside the threshold is healthy",
+			seed:       time.Now().Add(-30*time.Minute + 5*time.Second),
+			maxAge:     30 * time.Minute,
+			wantOK:     true,
+			wantSeeded: true,
+		},
+		{
+			name:       "just outside the threshold is unhealthy",
+			seed:       time.Now().Add(-30*time.Minute - 5*time.Second),
+			maxAge:     30 * time.Minute,
+			wantOK:     false,
+			wantSeeded: true,
+		},
+		{
+			name:       "well past threshold is unhealthy",
+			seed:       time.Now().Add(-2 * time.Hour),
+			maxAge:     30 * time.Minute,
+			wantOK:     false,
+			wantSeeded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &LOACache{entries: map[string]LOAEntry{}}
+			c.lastSuccessfulRefresh = tt.seed
+
+			gotOK, gotTime := c.IsHealthy(tt.maxAge)
+			if gotOK != tt.wantOK {
+				t.Fatalf("IsHealthy ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if tt.wantSeeded {
+				if !gotTime.Equal(tt.seed) {
+					t.Fatalf("IsHealthy time = %v, want %v", gotTime, tt.seed)
+				}
+			} else if !gotTime.IsZero() {
+				t.Fatalf("IsHealthy time = %v, want zero", gotTime)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `lastSuccessfulRefresh time.Time` to `LOACache` and a read-locked `IsHealthy(maxAge) (bool, time.Time)` accessor.
- `Refresh` now sets the timestamp when at least one node's `db.Query` and post-iteration `rows.Err()` both return nil — row-level `Scan` and `parseLOAPost` failures remain row-level noise.
- `/loa` calls `IsHealthy(30 * time.Minute)` after its placeholder Respond. On unhealthy cache it replies with `"❌ LOA cache unavailable (never successfully refreshed). Try again shortly."` (or `"... (last refresh: N minutes ago) ..."`) instead of falling through to the per-member `GetEntry` loop that would otherwise produce a false-empty `"No active or upcoming LOAs found"`.
- No `CaptureError` on the unavailable branch — every `/loa` during an outage would otherwise fire a Sentry event; the refresh job's existing per-node `Warn` is the right signal site (matches the 0.7.7 hookpoint policy).
- Coverage floors ratcheted to lock in the gains: `utils` 20→46, `commands` 17→18.

Fixes #67.

## Implementation notes

- Threshold is a function-scoped `const loaCacheMaxAge = 30 * time.Minute` (2× the 15-min refresh ticker). No env knob — YAGNI.
- New field write co-locates with `c.lastSyncedPostDate = maxPostDate` under the existing `c.mu.Lock()` scope; `IsHealthy` uses `RLock`. The brief queue behind an in-flight `Refresh` is accepted — the placeholder Respond has already fired, the edit has the full 15-min token window, and each refresh is ~5 fast internal-DB queries.
- ` GlobalLOACache` is initialized at package-var time (never nil), so the DSN-unset path correctly yields `(false, zero)` and renders the "never successfully refreshed" branch without a nil guard.
- sqlmock added as a test dep to pin the per-node success-counting policy (4 tests cover all-fail, partial-success, `rows.Err()` mid-stream, and row-parse-failure cases).

## Test Plan

- [x] `go test ./... -race` — all pass.
- [x] `golangci-lint run --timeout=5m` — 0 issues.
- [x] `.github/scripts/check-coverage-floors.sh` — utils 47.5% ≥ 46%, commands 19.9% ≥ 18%.
- [x] Local smoke against dev guild with `FORUM_DB_DSN` unset → `/loa` returned the "never successfully refreshed" message (previously returned false "No active or upcoming LOAs").
- [ ] Post-merge: file follow-up issue for `/awol`, which calls `IsOnLOA` and will silently render `On LOA: false` for everyone during a cache outage (same root cause, lower severity — column wrongness vs whole-command false-empty).

## Spec / plan

- Spec: \`docs/superpowers/specs/2026-05-22-loa-cache-freshness-guard-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-22-loa-cache-freshness-guard.md\`