### PR TITLE
docs: add CONTEXT.md and seed docs/adr/

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,85 @@
+# CONTEXT.md — CavBot2
+
+Domain language used throughout the codebase. New terms that need explanation
+belong here, not inline in code comments.
+
+## Organization
+
+- **7Cav / 7th Cavalry Gaming Regiment** — the gaming community this bot
+  serves. Project lives at `github.com/7Cav/cavbot2`. Member-facing reference
+  for org structure and terminology is the [7Cav wiki](https://wiki.7cav.us/).
+- **Departments (AFSM enum)** — the fixed set of departments `/afsm` checks
+  for award eligibility: `S1` (Personnel), `S2` (Intelligence), `S3`
+  (Operations), `S5` (Public Affairs), `S6` (Information Systems), `S7`
+  (Training), `WAG` (Wiki Admin Group), `RTC` (Recruit Training Command),
+  `RRD` (Regimental Recruiting Department), `MP` (Military Police), `ODS`
+  (Officer Development School), `NCOA` (Non-Commissioned Officer Academy).
+  Canonicalized in `commands/afsm.go`.
+- **Position** — free-text string like `2/B/1-7`, `Reservist`, or a
+  department name (`S1`).
+
+## Member records
+
+- **MILPACS / milpac** — the regiment's personnel record system served by
+  `api.7cav.us`; colloquially, "milpac" means one trooper's record.
+- **Forum username** — the user's Xenforo handle, also stored on the milpac.
+  Used as the lookup key for `GetMilpacByUsername` (the post-Keycloak path).
+- **Keycloak ID** — legacy identity field on profile responses; removed in
+  0.7.9 after the upstream Keycloak path was retired. Use
+  `GetMilpacByUsername` (forum username) instead.
+- **Roster** — a department- or position-scoped list returned by
+  `GetRosterByFuzzyPositionSearch`. Empty rosters from fixed-input commands
+  (`/afsm`, `/s6-it-check`) are structurally a bug, not a user-input issue —
+  see ADR 0002.
+
+## Forum + LOA
+
+- **Xenforo forum** — the regiment's web forum. The bot reads its MySQL DB
+  (`xf_thread`, `xf_post`) for LOA scanning.
+- **LOA (Leave of Absence)** — a forum thread declaring a member away from
+  duty for a date range. Parsed from a specific Xenforo BBCode template
+  (yellow `[COLOR=rgb(213, 185, 0)]` labels around `Username`, `Start Date`,
+  `End Date`). Template drift silently breaks parsing.
+- **LOA node** — a Xenforo forum section that hosts LOA threads. Production
+  scans five (`180,400,540,178,369`); the code default is `180`.
+- **LOA cache** — `utils.GlobalLOACache`, the in-process cache populated by a
+  15-minute background refresh. Tracks per-cache health via
+  `IsHealthy(maxAge) → (bool, lastSuccess)`. `/loa` and `/awol` consult this
+  rather than hitting the forum DB synchronously.
+- **Incremental refresh** — refreshes walk forward from `lastSyncedPostDate`,
+  not a full re-scan. Expired entries (past `EndDate`) are pruned each pass.
+
+## Eligibility / tracker concepts
+
+- **AFSM (Armed Forces Service Medal)** — an award. `/afsm` reports members
+  whose milpac record indicates they meet the bar for the medal but haven't
+  received it yet, scoped to one of the departments in the AFSM enum above.
+- **S6-IT full status** — promotion from probationary to full member of the
+  S6 IT team. `/s6-it-check` enumerates eligible members.
+- **AWOL** — a trooper flagged absent without leave in their milpac. `/awol`
+  lists current AWOLs for a position, with an "On LOA" indicator sourced
+  from the LOA cache.
+- **Accuracy disclaimer** — because milpac records are user-entered free
+  text, parsing can drift. `/afsm` always renders the disclaimer, regardless
+  of whether the eligibles list is empty — see ADR 0002.
+
+## External systems
+
+- **7Cav API** (`https://api.7cav.us/api/v1/`) — bearer-auth REST API. All
+  milpac/profile traffic goes through `utils.makeAPIRequest[T]`; never roll
+  a fresh `resty.Client` for new endpoints.
+- **Xenforo MySQL** — read-only access to the forum DB. Connection pool
+  deliberately tiny (`SetMaxOpenConns(2)`) because this is a low-rate
+  background scan.
+- **GitHub Apps API** — `utils.GithubAuth(clientID, pem)` mints an
+  installation token. Only consumer right now is `/apps_beta_deploy`,
+  dispatching a workflow on `7Cav/adr`.
+
+## Observability
+
+- **Sentry** — wired in 0.7.7. Captured manually at `utils.CaptureError`
+  call sites — not via a blanket slog bridge. See ADR 0001.
+- **`utils.Error` vs `utils.HandleError`** — load-bearing distinction.
+  `utils.Error` is for genuine internal failures (Sentry-eligible).
+  `utils.HandleError` is for user-facing responses (often expected outcomes
+  like "no troopers found", not Sentry-eligible).

--- a/docs/adr/0001-manual-sentry-capture.md
+++ b/docs/adr/0001-manual-sentry-capture.md
@@ -1,0 +1,26 @@
+# ADR 0001: Manual Sentry capture at chosen sites, not a slog bridge
+
+## Status
+
+Accepted (0.7.7).
+
+## Decision
+
+Sentry is wired manually via `utils.CaptureError(msg, err, kv...)` at
+chosen call sites — not as a slog handler that auto-forwards every WARN/
+ERROR log.
+
+## Why
+
+A blanket slog→Sentry bridge would forward expected, non-actionable noise
+(e.g. the LOA refresh job's `"LOA cache refresh failed"` × N nodes on every
+dev startup where the forum DB isn't reachable). Manual capture keeps Sentry
+signal-rich.
+
+## How to apply
+
+- New genuine internal failure → `utils.CaptureError`.
+- New user-facing response (incl. "no troopers found", "no LOAs") →
+  `utils.HandleError`. Never wire Sentry into the user-facing path.
+- The `utils.Error` vs `utils.HandleError` split is load-bearing; preserve it
+  on refactors.

--- a/docs/adr/0002-empty-result-handling.md
+++ b/docs/adr/0002-empty-result-handling.md
@@ -1,0 +1,28 @@
+# ADR 0002: Empty-result handling — early return only vs. early return + Sentry
+
+## Status
+
+Accepted (0.7.8 / 0.7.9).
+
+## Decision
+
+When a command's roster/lookup returns zero results:
+
+- **User-supplied input** (`/awol`, `/loa` — user types a position) → tell the
+  user "no troopers found" and return. No Sentry.
+- **Fixed input** (`/afsm`, `/s6-it-check` — Discord choice list or
+  hardcoded position) → tell the user "shouldn't happen, reported" **and**
+  `utils.CaptureError`. Tag the fixed-input value (e.g. `department`) so each
+  choice fingerprints separately.
+
+## Why
+
+Empty is a plausible user outcome when input is user-supplied. Empty from
+fixed input is structurally a bug (API regression, roster drift, fuzzy-match
+drift, deleted node).
+
+## How to apply
+
+When adding an empty-result early return, ask: *is empty a legitimate outcome
+here?* If no, route a synthetic error through `utils.CaptureError` alongside
+the user-facing message.

--- a/docs/adr/0003-version-injection-via-ldflags.md
+++ b/docs/adr/0003-version-injection-via-ldflags.md
@@ -1,0 +1,27 @@
+# ADR 0003: Version injected via ldflags from the release tag
+
+## Status
+
+Accepted (0.7.4 / PR #70). Replaces the prior `var Version = "X.Y.Z"`
+manual-bump convention.
+
+## Decision
+
+`var Version = "dev"` in `main.go` is overwritten at Docker build via
+`-ldflags "-X main.Version=${VERSION}"`. `VERSION` is passed as a
+`docker build --build-arg` from `github.ref_name` in `build_and_push.yml`.
+
+The release tag is the single source of truth for the running version.
+
+## Why
+
+The previous flow required a separate `ver bump` PR before each release —
+easy to forget, which would ship the wrong version string. Tying `Version` to
+the tag removes the human step.
+
+## How to apply
+
+- Cutting a release: `gh release create <tag> --target develop --generate-notes`.
+- Local `go build` / `go run` will show `dev` unless you pass the ldflag
+  yourself. That's the intended signal: any prod log showing `version=dev`
+  means the deploy didn't go through `build_and_push.yml`.

--- a/docs/adr/0004-interaction-responder-and-placeholder.md
+++ b/docs/adr/0004-interaction-responder-and-placeholder.md
@@ -1,0 +1,38 @@
+# ADR 0004: `InteractionResponder` interface + placeholder-vs-Defer convention
+
+## Status
+
+Accepted (0.7.6 / PR #74).
+
+## Decision
+
+Commands take an `InteractionResponder` interface, not `*discordgo.Session`
+directly. The interface exposes only the 3 hot-path methods actually used
+(`InteractionRespond`, `InteractionResponseEdit`, `FollowupMessageCreate`)
+and drops the universally-ignored `*Message` return values.
+
+Two response patterns coexist:
+
+- **Placeholder** (most commands) — `InteractionRespond` immediately with
+  `"Fetching X for Y..."`, then `InteractionResponseEdit` to replace.
+- **Defer** (`s3aar`, `warden`) — `Defer` then `FollowupMessageCreate`.
+
+The placeholder pattern is a deliberate UX choice: echo back the parsed
+argument inside ~200ms so typos are visible before the long upstream call
+returns.
+
+## Why
+
+The interface keeps test plumbing minimal and forces deliberate choice of
+dependencies. The placeholder/Defer split is documented because tests must
+pin `InteractionResponse.Type` faithfully — a placeholder-vs-Defer regression
+shouldn't slip past.
+
+## How to apply
+
+- New command → take `InteractionResponder`, not `*discordgo.Session`.
+- Default to the placeholder pattern; pick Defer only when there's no
+  argument worth echoing back (or the work is sub-200ms).
+- Use `errors.As` with `*discordgo.RESTError` code 40060 to detect
+  "interaction already acknowledged" (wording-proof rather than matching the
+  error string).

--- a/docs/adr/0005-per-package-coverage-floors.md
+++ b/docs/adr/0005-per-package-coverage-floors.md
@@ -1,0 +1,30 @@
+# ADR 0005: Per-package coverage floors with ratchet policy
+
+## Status
+
+Accepted (0.7.6 / PR #75).
+
+## Decision
+
+CI enforces **per-package** coverage floors via
+`.github/scripts/check-coverage-floors.sh` — a pure-bash script that parses
+`go test -cover` on stdin and applies inlined per-package floors. `main` is
+excluded.
+
+When a PR raises a package's coverage by more than a point or two, raise its
+floor in the same PR.
+
+## Why
+
+A single global floor either sandbags well-covered packages or false-alarms
+on refactor dips elsewhere. Per-package floors set just-below baseline let
+the suite ratchet up organically without anyone having to remember to bump
+a number.
+
+## How to apply
+
+- Local check matches CI: `go test ./... -cover | .github/scripts/check-coverage-floors.sh`.
+- After a PR that raises a package's coverage non-trivially, edit the floor
+  for that package in the script in the same PR. That's the ratchet.
+- Don't add new packages without a starter floor — even `1%` is enough to
+  begin the ratchet.

--- a/docs/adr/0006-command-registry-single-source-of-truth.md
+++ b/docs/adr/0006-command-registry-single-source-of-truth.md
@@ -1,0 +1,31 @@
+# ADR 0006: Command registry is the single source of truth
+
+## Status
+
+Accepted.
+
+## Decision
+
+`commands/registry.go` `NewRegistry()` is the **only** place commands are
+declared. On startup `main.go`:
+
+1. Fetches all currently-registered guild commands from Discord.
+2. **Deletes any Discord command not present in the registry.**
+3. Re-registers every command in the registry.
+
+Commands are registered **per-guild** (not globally), so they appear instantly.
+
+## Why
+
+A divergence between Discord's command list and the in-repo registry is
+silently confusing — orphaned commands keep working until someone notices.
+The startup sync makes the registry authoritative and removes any manual
+cleanup step when a command is removed or renamed.
+
+## How to apply
+
+- Adding a command: write `func MyCmd() Command` returning `{Definition,
+  Handler}` and append to the `RegisterCommands(...)` call in
+  `NewRegistry()`. Nothing else.
+- Removing or renaming a command: delete it from the registry. The next
+  startup cleans up the Discord side automatically.

--- a/docs/adr/0007-message-component-customid-routing.md
+++ b/docs/adr/0007-message-component-customid-routing.md
@@ -1,0 +1,31 @@
+# ADR 0007: Message-component routing via `<command>::<action>::<payload>` CustomID
+
+## Status
+
+Accepted.
+
+## Decision
+
+Commands and message components share one handler in `main.go`, routed by
+name:
+
+- `InteractionApplicationCommand` → registry lookup by
+  `ApplicationCommandData().Name`.
+- `InteractionMessageComponent` → split `CustomID` on `::`, look up the
+  **first segment** in the registry.
+
+Stateful component flows use `CustomID` like
+`apps_beta_deploy::confirm::<branch>`. Discord caps `CustomID` at 100 chars;
+validate at the call site (see `apps_deployer.go`).
+
+## Why
+
+One handler + one routing rule keeps the dispatch table flat. The
+`<command>::*` convention means a command's component callbacks land back at
+the same registry entry, so state and handler live together.
+
+## How to apply
+
+- New stateful component → `CustomID` is `<command-name>::<action>::<payload>`.
+- Validate the assembled `CustomID` length (≤100) before sending. A truncated
+  ID silently misroutes.


### PR DESCRIPTION
## Summary

- Add `CONTEXT.md` — 7Cav-specific terminology (departments, milpac, LOA cache, AFSM, etc.).
- Seed `docs/adr/` with 7 records covering shipped, load-bearing conventions not derivable from code.

No code changes.