### PR TITLE
docs: seed CONTEXT.md, ADRs, and agent-skills scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 
 .env
 WARP.md
-CLAUDE.md
 .claude/
 docs/superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Go Discord bot (module `github.com/7cav/cavbot2`) for the 7th Cavalry Gaming Regiment, built on `bwmarrin/discordgo`. It exposes slash commands that integrate with the 7Cav milpacs API, the Xenforo forum MySQL DB, and the GitHub Apps API.
+
+## Common commands
+
+```bash
+go build -o cavbot2 .                     # build the binary (CI uses this exact command)
+go run .                                  # run locally (requires env vars; see below)
+go mod tidy                               # sync deps after changing imports
+golangci-lint run --timeout=5m            # lint (no .golangci config; uses defaults — same as CI)
+docker compose up --build                 # run via Docker (requires .env; image must be built locally first or pulled)
+```
+
+Tests live in `*_test.go` files alongside the code they cover. Run them with `go test ./...`. CI runs the suite with coverage enforcement — see the Testing section of README.md and `.github/scripts/check-coverage-floors.sh` for the floor policy.
+
+## Required environment variables
+
+`init()` in `main.go` panics if any of these are missing:
+
+- `DISCORD_TOKEN`, `GUILD_ID`, `BM_TOKEN`
+
+Optional but feature-gating:
+
+- `BEARER` — bearer token for `api.7cav.us` (milpacs lookups will fail without it)
+- `FORUM_DB_DSN` — MySQL DSN for the Xenforo forum DB. The production DSN points at host `xenforo-db`, which resolves **only inside the `xenforo_internal` Docker network** (declared `external: true` in `docker-compose.yml`). Running `go run .` outside that network won't error at startup — `sql.Open` defers the connection — but every `Refresh` will log `"LOA cache refresh failed"` at WARN and the cache will stay empty. To test LOA locally, either run via `docker compose` or substitute a reachable DSN.
+- `LOA_NODE_IDS` — comma-separated Xenforo node IDs to scan for LOA threads. Code default is `180`; **production scans 5 nodes** (`180,400,540,178,369`). `.env.example` is out of date here (it shows `LOA_NODE_ID=180`, singular and wrong-named).
+- `GITHUB_APP_KEY` (base64-encoded PEM), `GITHUB_APP_CLIENT_ID` — needed for `/apps_beta_deploy`
+- `LOG_LEVEL` — `DEBUG` / `INFO` / `WARN` / `ERROR` (default `INFO`)
+
+`.env.example` lists all of these but is partly stale (see `LOA_NODE_IDS` above). Copy to `.env` for local Docker runs.
+
+## Architecture
+
+For command registration, interaction routing, and error-handling conventions, see `docs/adr/` (notably 0004, 0006, 0007). The notes below cover code areas without a dedicated ADR.
+
+### LOA cache (utils/loa.go)
+
+`utils.GlobalLOACache` is a process-global, mutex-guarded cache of forum LOA posts. `initLOACache()` in `main.go` does an initial refresh on startup, then runs `Refresh` every 15 minutes in a goroutine. Refresh is **incremental** — `lastSyncedPostDate` tracks the high-water mark and subsequent queries only pull newer posts. Entries whose `EndDate` has passed are pruned each refresh.
+
+Parsing depends on a specific Xenforo BBCode template (yellow `[COLOR=rgb(213, 185, 0)]` labels for `Username`, `Start Date`, `End Date`). If the forum template changes, the regexes in `utils/loa.go` will silently stop matching — `parseLOAPost` returns `false` and the post is logged at DEBUG level.
+
+### External integrations
+
+- **7Cav API** (`utils/milpacs.go`): generic `makeAPIRequest[T]` against `https://api.7cav.us/api/v1/`, auth via `BEARER`. Use this for any new milpac/profile lookup rather than rolling your own resty client.
+- **GitHub Apps** (`utils/github.go`): `GithubAuth(clientID, pem)` → installation token. Used by `/apps_beta_deploy` to dispatch the `dev_deploy.yml` workflow on `7cav/adr`. The PEM key is read from env as base64 and decoded at use site.
+- **Xenforo MySQL**: read-only queries against `xf_thread` / `xf_post`. Connection pool deliberately tiny (`SetMaxOpenConns(2)`) since this is a low-rate background scan.
+
+## Versioning & deploy
+
+`Version` is injected at Docker build via ldflags (see ADR 0003). Local `go build` / `go run` show `dev`.
+
+- `build_and_push.yml` runs **only on GitHub Releases**, builds the Docker image tagged with the release ref (and injects the same ref as `Version`), pushes to Docker Hub as `7cav/cavbot2:<tag>` and `:latest`, then pings a Watchtower endpoint to force-pull on the prod host.
+- `build_test.yml` runs lint + test (with coverage floor enforcement) + build on push/PR to `develop`. **Default branch is `develop`, not `main`.** PRs target `develop`.
+
+## Conventions worth knowing
+
+- Logging is `slog` via `utils.Info/Warn/Error/Debug` — always use these wrappers, not the stdlib `slog` directly, so log level routing stays consistent.
+- Commands log a `"🚀 Starting ..."` line at entry and `"✨ Done!"` at successful exit, with `"command"`, `"username"`, and `"discord_id"` fields. Match this pattern when adding commands so log greps stay uniform.
+- Prefer ephemeral responses for admin/management commands (`MessageFlagsEphemeral`) — see `warden.go` for the deferred-ephemeral pattern (`deferEphemeral` + `editEphemeral`).
+
+## Build/deploy quirks
+
+### Docker compose `environment:` allowlist vs `.env` (2026-05-14)
+
+The compose service uses an explicit `environment:` block listing each variable as `KEY: ${KEY}`. **Only those keys reach the container.** Adding a var to `.env` alone (without a matching compose-block line) means `.env` feeds compose's interpolator but the var never propagates into the running process — the bot will log `"Sentry disabled (SENTRY_DSN not set)"` despite the value being in `.env`.
+
+Two-line fix: add the key to both files. 5-second debug check: `docker compose exec <svc> env | grep <KEY>` — empty output proves the var didn't make the trip.
+
+## See also (durable docs)
+
+For load-bearing decisions, see `docs/adr/`. For domain terminology, see `CONTEXT.md`.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues at `7cav/cavbot2` (`gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical names used verbatim (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,85 @@
+# CONTEXT.md — CavBot2
+
+Domain language used throughout the codebase. New terms that need explanation
+belong here, not inline in code comments.
+
+## Organization
+
+- **7Cav / 7th Cavalry Gaming Regiment** — the gaming community this bot
+  serves. Project lives at `github.com/7Cav/cavbot2`. Member-facing reference
+  for org structure and terminology is the [7Cav wiki](https://wiki.7cav.us/).
+- **Departments (AFSM enum)** — the fixed set of departments `/afsm` checks
+  for award eligibility: `S1` (Personnel), `S2` (Intelligence), `S3`
+  (Operations), `S5` (Public Affairs), `S6` (Information Systems), `S7`
+  (Training), `WAG` (Wiki Admin Group), `RTC` (Recruit Training Command),
+  `RRD` (Regimental Recruiting Department), `MP` (Military Police), `ODS`
+  (Officer Development School), `NCOA` (Non-Commissioned Officer Academy).
+  Canonicalized in `commands/afsm.go`.
+- **Position** — free-text string like `2/B/1-7`, `Reservist`, or a
+  department name (`S1`).
+
+## Member records
+
+- **MILPACS / milpac** — the regiment's personnel record system served by
+  `api.7cav.us`; colloquially, "milpac" means one trooper's record.
+- **Forum username** — the user's Xenforo handle, also stored on the milpac.
+  Used as the lookup key for `GetMilpacByUsername` (the post-Keycloak path).
+- **Keycloak ID** — legacy identity field on profile responses; removed in
+  0.7.9 after the upstream Keycloak path was retired. Use
+  `GetMilpacByUsername` (forum username) instead.
+- **Roster** — a department- or position-scoped list returned by
+  `GetRosterByFuzzyPositionSearch`. Empty rosters from fixed-input commands
+  (`/afsm`, `/s6-it-check`) are structurally a bug, not a user-input issue —
+  see ADR 0002.
+
+## Forum + LOA
+
+- **Xenforo forum** — the regiment's web forum. The bot reads its MySQL DB
+  (`xf_thread`, `xf_post`) for LOA scanning.
+- **LOA (Leave of Absence)** — a forum thread declaring a member away from
+  duty for a date range. Parsed from a specific Xenforo BBCode template
+  (yellow `[COLOR=rgb(213, 185, 0)]` labels around `Username`, `Start Date`,
+  `End Date`). Template drift silently breaks parsing.
+- **LOA node** — a Xenforo forum section that hosts LOA threads. Production
+  scans five (`180,400,540,178,369`); the code default is `180`.
+- **LOA cache** — `utils.GlobalLOACache`, the in-process cache populated by a
+  15-minute background refresh. Tracks per-cache health via
+  `IsHealthy(maxAge) → (bool, lastSuccess)`. `/loa` and `/awol` consult this
+  rather than hitting the forum DB synchronously.
+- **Incremental refresh** — refreshes walk forward from `lastSyncedPostDate`,
+  not a full re-scan. Expired entries (past `EndDate`) are pruned each pass.
+
+## Eligibility / tracker concepts
+
+- **AFSM (Armed Forces Service Medal)** — an award. `/afsm` reports members
+  whose milpac record indicates they meet the bar for the medal but haven't
+  received it yet, scoped to one of the departments in the AFSM enum above.
+- **S6-IT full status** — promotion from probationary to full member of the
+  S6 IT team. `/s6-it-check` enumerates eligible members.
+- **AWOL** — a trooper flagged absent without leave in their milpac. `/awol`
+  lists current AWOLs for a position, with an "On LOA" indicator sourced
+  from the LOA cache.
+- **Accuracy disclaimer** — because milpac records are user-entered free
+  text, parsing can drift. `/afsm` always renders the disclaimer, regardless
+  of whether the eligibles list is empty — see ADR 0002.
+
+## External systems
+
+- **7Cav API** (`https://api.7cav.us/api/v1/`) — bearer-auth REST API. All
+  milpac/profile traffic goes through `utils.makeAPIRequest[T]`; never roll
+  a fresh `resty.Client` for new endpoints.
+- **Xenforo MySQL** — read-only access to the forum DB. Connection pool
+  deliberately tiny (`SetMaxOpenConns(2)`) because this is a low-rate
+  background scan.
+- **GitHub Apps API** — `utils.GithubAuth(clientID, pem)` mints an
+  installation token. Only consumer right now is `/apps_beta_deploy`,
+  dispatching a workflow on `7Cav/adr`.
+
+## Observability
+
+- **Sentry** — wired in 0.7.7. Captured manually at `utils.CaptureError`
+  call sites — not via a blanket slog bridge. See ADR 0001.
+- **`utils.Error` vs `utils.HandleError`** — load-bearing distinction.
+  `utils.Error` is for genuine internal failures (Sentry-eligible).
+  `utils.HandleError` is for user-facing responses (often expected outcomes
+  like "no troopers found", not Sentry-eligible).

--- a/docs/adr/0001-manual-sentry-capture.md
+++ b/docs/adr/0001-manual-sentry-capture.md
@@ -1,0 +1,26 @@
+# ADR 0001: Manual Sentry capture at chosen sites, not a slog bridge
+
+## Status
+
+Accepted (0.7.7).
+
+## Decision
+
+Sentry is wired manually via `utils.CaptureError(msg, err, kv...)` at
+chosen call sites — not as a slog handler that auto-forwards every WARN/
+ERROR log.
+
+## Why
+
+A blanket slog→Sentry bridge would forward expected, non-actionable noise
+(e.g. the LOA refresh job's `"LOA cache refresh failed"` × N nodes on every
+dev startup where the forum DB isn't reachable). Manual capture keeps Sentry
+signal-rich.
+
+## How to apply
+
+- New genuine internal failure → `utils.CaptureError`.
+- New user-facing response (incl. "no troopers found", "no LOAs") →
+  `utils.HandleError`. Never wire Sentry into the user-facing path.
+- The `utils.Error` vs `utils.HandleError` split is load-bearing; preserve it
+  on refactors.

--- a/docs/adr/0002-empty-result-handling.md
+++ b/docs/adr/0002-empty-result-handling.md
@@ -1,0 +1,28 @@
+# ADR 0002: Empty-result handling — early return only vs. early return + Sentry
+
+## Status
+
+Accepted (0.7.8 / 0.7.9).
+
+## Decision
+
+When a command's roster/lookup returns zero results:
+
+- **User-supplied input** (`/awol`, `/loa` — user types a position) → tell the
+  user "no troopers found" and return. No Sentry.
+- **Fixed input** (`/afsm`, `/s6-it-check` — Discord choice list or
+  hardcoded position) → tell the user "shouldn't happen, reported" **and**
+  `utils.CaptureError`. Tag the fixed-input value (e.g. `department`) so each
+  choice fingerprints separately.
+
+## Why
+
+Empty is a plausible user outcome when input is user-supplied. Empty from
+fixed input is structurally a bug (API regression, roster drift, fuzzy-match
+drift, deleted node).
+
+## How to apply
+
+When adding an empty-result early return, ask: *is empty a legitimate outcome
+here?* If no, route a synthetic error through `utils.CaptureError` alongside
+the user-facing message.

--- a/docs/adr/0003-version-injection-via-ldflags.md
+++ b/docs/adr/0003-version-injection-via-ldflags.md
@@ -1,0 +1,27 @@
+# ADR 0003: Version injected via ldflags from the release tag
+
+## Status
+
+Accepted (0.7.4 / PR #70). Replaces the prior `var Version = "X.Y.Z"`
+manual-bump convention.
+
+## Decision
+
+`var Version = "dev"` in `main.go` is overwritten at Docker build via
+`-ldflags "-X main.Version=${VERSION}"`. `VERSION` is passed as a
+`docker build --build-arg` from `github.ref_name` in `build_and_push.yml`.
+
+The release tag is the single source of truth for the running version.
+
+## Why
+
+The previous flow required a separate `ver bump` PR before each release —
+easy to forget, which would ship the wrong version string. Tying `Version` to
+the tag removes the human step.
+
+## How to apply
+
+- Cutting a release: `gh release create <tag> --target develop --generate-notes`.
+- Local `go build` / `go run` will show `dev` unless you pass the ldflag
+  yourself. That's the intended signal: any prod log showing `version=dev`
+  means the deploy didn't go through `build_and_push.yml`.

--- a/docs/adr/0004-interaction-responder-and-placeholder.md
+++ b/docs/adr/0004-interaction-responder-and-placeholder.md
@@ -1,0 +1,38 @@
+# ADR 0004: `InteractionResponder` interface + placeholder-vs-Defer convention
+
+## Status
+
+Accepted (0.7.6 / PR #74).
+
+## Decision
+
+Commands take an `InteractionResponder` interface, not `*discordgo.Session`
+directly. The interface exposes only the 3 hot-path methods actually used
+(`InteractionRespond`, `InteractionResponseEdit`, `FollowupMessageCreate`)
+and drops the universally-ignored `*Message` return values.
+
+Two response patterns coexist:
+
+- **Placeholder** (most commands) — `InteractionRespond` immediately with
+  `"Fetching X for Y..."`, then `InteractionResponseEdit` to replace.
+- **Defer** (`s3aar`, `warden`) — `Defer` then `FollowupMessageCreate`.
+
+The placeholder pattern is a deliberate UX choice: echo back the parsed
+argument inside ~200ms so typos are visible before the long upstream call
+returns.
+
+## Why
+
+The interface keeps test plumbing minimal and forces deliberate choice of
+dependencies. The placeholder/Defer split is documented because tests must
+pin `InteractionResponse.Type` faithfully — a placeholder-vs-Defer regression
+shouldn't slip past.
+
+## How to apply
+
+- New command → take `InteractionResponder`, not `*discordgo.Session`.
+- Default to the placeholder pattern; pick Defer only when there's no
+  argument worth echoing back (or the work is sub-200ms).
+- Use `errors.As` with `*discordgo.RESTError` code 40060 to detect
+  "interaction already acknowledged" (wording-proof rather than matching the
+  error string).

--- a/docs/adr/0005-per-package-coverage-floors.md
+++ b/docs/adr/0005-per-package-coverage-floors.md
@@ -1,0 +1,30 @@
+# ADR 0005: Per-package coverage floors with ratchet policy
+
+## Status
+
+Accepted (0.7.6 / PR #75).
+
+## Decision
+
+CI enforces **per-package** coverage floors via
+`.github/scripts/check-coverage-floors.sh` — a pure-bash script that parses
+`go test -cover` on stdin and applies inlined per-package floors. `main` is
+excluded.
+
+When a PR raises a package's coverage by more than a point or two, raise its
+floor in the same PR.
+
+## Why
+
+A single global floor either sandbags well-covered packages or false-alarms
+on refactor dips elsewhere. Per-package floors set just-below baseline let
+the suite ratchet up organically without anyone having to remember to bump
+a number.
+
+## How to apply
+
+- Local check matches CI: `go test ./... -cover | .github/scripts/check-coverage-floors.sh`.
+- After a PR that raises a package's coverage non-trivially, edit the floor
+  for that package in the script in the same PR. That's the ratchet.
+- Don't add new packages without a starter floor — even `1%` is enough to
+  begin the ratchet.

--- a/docs/adr/0006-command-registry-single-source-of-truth.md
+++ b/docs/adr/0006-command-registry-single-source-of-truth.md
@@ -1,0 +1,31 @@
+# ADR 0006: Command registry is the single source of truth
+
+## Status
+
+Accepted.
+
+## Decision
+
+`commands/registry.go` `NewRegistry()` is the **only** place commands are
+declared. On startup `main.go`:
+
+1. Fetches all currently-registered guild commands from Discord.
+2. **Deletes any Discord command not present in the registry.**
+3. Re-registers every command in the registry.
+
+Commands are registered **per-guild** (not globally), so they appear instantly.
+
+## Why
+
+A divergence between Discord's command list and the in-repo registry is
+silently confusing — orphaned commands keep working until someone notices.
+The startup sync makes the registry authoritative and removes any manual
+cleanup step when a command is removed or renamed.
+
+## How to apply
+
+- Adding a command: write `func MyCmd() Command` returning `{Definition,
+  Handler}` and append to the `RegisterCommands(...)` call in
+  `NewRegistry()`. Nothing else.
+- Removing or renaming a command: delete it from the registry. The next
+  startup cleans up the Discord side automatically.

--- a/docs/adr/0007-message-component-customid-routing.md
+++ b/docs/adr/0007-message-component-customid-routing.md
@@ -1,0 +1,31 @@
+# ADR 0007: Message-component routing via `<command>::<action>::<payload>` CustomID
+
+## Status
+
+Accepted.
+
+## Decision
+
+Commands and message components share one handler in `main.go`, routed by
+name:
+
+- `InteractionApplicationCommand` → registry lookup by
+  `ApplicationCommandData().Name`.
+- `InteractionMessageComponent` → split `CustomID` on `::`, look up the
+  **first segment** in the registry.
+
+Stateful component flows use `CustomID` like
+`apps_beta_deploy::confirm::<branch>`. Discord caps `CustomID` at 100 chars;
+validate at the call site (see `apps_deployer.go`).
+
+## Why
+
+One handler + one routing rule keeps the dispatch table flat. The
+`<command>::*` convention means a command's component callbacks land back at
+the same registry entry, so state and handler live together.
+
+## How to apply
+
+- New stateful component → `CustomID` is `<command-name>::<action>::<payload>`.
+- Validate the assembled `CustomID` length (≤100) before sending. A truncated
+  ID silently misroutes.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

Stands up the durable-docs scaffolding the engineering skills assume:

- `CONTEXT.md` and seven seed ADRs under `docs/adr/` (existing commit on this branch)
- `docs/agents/` — issue-tracker conventions, canonical triage label vocabulary, single-context domain-doc layout (output of `/setup-matt-pocock-skills`)
- `CLAUDE.md` removed from `.gitignore` so the pointer block to `docs/agents/` travels with the repo; trimmed to remove content already covered by the ADRs

Triage labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`) created on the repo separately — labels are GitHub state, not git state.

## Test plan

- [ ] CI green (lint + test + build)
- [ ] `CLAUDE.md` renders correctly on github.com
- [ ] `docs/agents/*.md` render correctly on github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)