### PR TITLE
feat(commands): disambiguate empty roster-search reply with format hint

### DIFF
--- a/commands/awol.go
+++ b/commands/awol.go
@@ -81,7 +81,7 @@ func handleAwolCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 	if len(roster.LiteProfiles) == 0 {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ The search for \"%s\" returned no troopers. Please check your search for accuracy.", position))
+		utils.HandleError(utils.NewSessionResponder(s), i, emptyRosterSearchMessage(position))
 		return
 	}
 

--- a/commands/loa.go
+++ b/commands/loa.go
@@ -94,7 +94,7 @@ func handleLOACommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 	if len(roster.LiteProfiles) == 0 {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ The search for \"%s\" returned no troopers. Please check your search for accuracy.", position))
+		utils.HandleError(utils.NewSessionResponder(s), i, emptyRosterSearchMessage(position))
 		return
 	}
 

--- a/commands/roster_search.go
+++ b/commands/roster_search.go
@@ -1,0 +1,22 @@
+package commands
+
+import "fmt"
+
+// positionFormatExamples mirrors the canonical *Position* entry in CONTEXT.md.
+// Keep these in sync if CONTEXT.md ever broadens the example set.
+var positionFormatExamples = []string{"2/B/1-7", "Reservist", "S1"}
+
+// emptyRosterSearchMessage builds the user-facing reply for /awol and /loa when
+// GetRosterByFuzzyPositionSearch returns zero profiles. The API returns
+// HTTP 200 {"profiles":{}} for both legitimately-empty positions AND
+// unparseable input (probed 2026-05-27), so the message acknowledges both
+// causes rather than asserting the user got it wrong.
+func emptyRosterSearchMessage(position string) string {
+	return fmt.Sprintf(
+		"❌ No troopers found for \"%s\". The position may have no current members, or the input format may not be recognized. Examples of valid formats: `%s`, `%s`, `%s`.",
+		position,
+		positionFormatExamples[0],
+		positionFormatExamples[1],
+		positionFormatExamples[2],
+	)
+}

--- a/commands/roster_search.go
+++ b/commands/roster_search.go
@@ -1,22 +1,22 @@
 package commands
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
-// positionFormatExamples mirrors the canonical *Position* entry in CONTEXT.md.
-// Keep these in sync if CONTEXT.md ever broadens the example set.
+// positionFormatExamples mirrors the *Position* entry in CONTEXT.md.
 var positionFormatExamples = []string{"2/B/1-7", "Reservist", "S1"}
 
 // emptyRosterSearchMessage builds the user-facing reply for /awol and /loa when
-// GetRosterByFuzzyPositionSearch returns zero profiles. The API returns
-// HTTP 200 {"profiles":{}} for both legitimately-empty positions AND
-// unparseable input (probed 2026-05-27), so the message acknowledges both
-// causes rather than asserting the user got it wrong.
+// GetRosterByFuzzyPositionSearch returns zero profiles. The upstream API
+// returns HTTP 200 {"profiles":{}} for both legitimately-empty positions and
+// unparseable input, so the message has to cover both causes — there is no
+// signal to distinguish them.
 func emptyRosterSearchMessage(position string) string {
 	return fmt.Sprintf(
-		"❌ No troopers found for \"%s\". The position may have no current members, or the input format may not be recognized. Examples of valid formats: `%s`, `%s`, `%s`.",
+		"❌ No troopers found for \"%s\". The position may have no current members, or the input format may not be recognized. Examples of valid formats: `%s`.",
 		position,
-		positionFormatExamples[0],
-		positionFormatExamples[1],
-		positionFormatExamples[2],
+		strings.Join(positionFormatExamples, "`, `"),
 	)
 }

--- a/commands/roster_search_test.go
+++ b/commands/roster_search_test.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEmptyRosterSearchMessage(t *testing.T) {
+	got := emptyRosterSearchMessage("Q/Z/9-9")
+
+	if !strings.Contains(got, `"Q/Z/9-9"`) {
+		t.Errorf("message %q missing the quoted position", got)
+	}
+	// CONTEXT.md *Position* examples: 2/B/1-7, Reservist, S1. The acceptance
+	// criterion requires these be sourced from one place; this test pins them
+	// in the user-facing string so a future edit can't quietly drop one.
+	for _, example := range []string{"2/B/1-7", "Reservist", "S1"} {
+		if !strings.Contains(got, example) {
+			t.Errorf("message %q missing example %q", got, example)
+		}
+	}
+	// The criterion requires acknowledging *both* causes — no-match and
+	// unrecognized input — rather than asserting the input was wrong.
+	if strings.Contains(got, "Please check your search for accuracy") {
+		t.Errorf("message %q still asserts input was wrong", got)
+	}
+	if !strings.HasPrefix(got, "❌") {
+		t.Errorf("message %q missing the ❌ prefix used by other handle-error responses", got)
+	}
+}
+

--- a/commands/roster_search_test.go
+++ b/commands/roster_search_test.go
@@ -25,7 +25,14 @@ func TestEmptyRosterSearchMessage(t *testing.T) {
 		t.Errorf("message %q still asserts input was wrong", got)
 	}
 	if !strings.HasPrefix(got, "❌") {
-		t.Errorf("message %q missing the ❌ prefix used by other handle-error responses", got)
+		t.Errorf("message %q missing ❌ prefix", got)
 	}
 }
 
+func TestEmptyRosterSearchMessage_EmptyPosition(t *testing.T) {
+	// Defensive: empty input must not panic and must still render the hint.
+	got := emptyRosterSearchMessage("")
+	if !strings.Contains(got, "2/B/1-7") {
+		t.Errorf("message %q missing example for empty input", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/7cav/cavbot2
 go 1.25.0
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/getsentry/sentry-go v0.46.2
 	github.com/go-resty/resty/v2 v2.17.2
@@ -10,10 +11,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 )
 
-require (
-	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
-)
+require filippo.io/edwards25519 v1.2.0 // indirect
 
 require (
 	github.com/gorilla/websocket v1.5.3 // indirect


### PR DESCRIPTION
## Summary

`/awol` and `/loa` both fall back to the same message when `GetRosterByFuzzyPositionSearch` returns zero profiles. The old wording (*"Please check your search for accuracy"*) asserts the input was wrong even when the search ran cleanly with no matches. This PR replaces it with a shared helper that acknowledges both causes and anchors the user with valid-position examples.

- Adds `commands/roster_search.go` with `emptyRosterSearchMessage(position string) string`, plus a `positionFormatExamples` slice mirroring the *Position* entry in `CONTEXT.md` (`2/B/1-7`, `Reservist`, `S1`). Rendered via `strings.Join` so the slice is the single source of truth — adding a future example just works.
- `/awol` (`commands/awol.go:84`) and `/loa` (`commands/loa.go:97`) swap their empty-profile branches from a duplicated inline `fmt.Sprintf` to the helper.
- ADR 0002 compliance preserved: still routed through `utils.HandleError` (no Sentry). `/afsm` and `/s6-it-check` (the fixed-input branch) are correctly untouched.

Closes #65.

## API probe

Per the acceptance criteria, I probed `/milpacs/position/search/{position}` directly on 2026-05-27 with three inputs:

| Input | Response |
| --- | --- |
| `99/Z/9-9` (syntactically valid, no match) | `HTTP 200 {"profiles":{}}` |
| `!!!@@@$$$` (clearly garbage symbols) | `HTTP 200 {"profiles":{}}` |
| `xyzqqq` (random text) | `HTTP 200 {"profiles":{}}` |
| `S6` (real department) | `HTTP 200 {"profiles":{"104":...}}` |

The upstream API does not distinguish malformed input from valid-no-match — both return identical empty bodies. The fix is therefore a single combined hint covering both causes; no separate malformed-input plumbing was added.

## Rendered message

```
❌ No troopers found for "asdfgh". The position may have no current members, or the input format may not be recognized. Examples of valid formats: `2/B/1-7`, `Reservist`, `S1`.
```

## Out of scope

Per ADR 0002, `/afsm` and `/s6-it-check` are the fixed-input branch and keep their existing CaptureError-tagged empty-result message — not touched.

## go.mod

`go mod tidy` reclassified `DATA-DOG/go-sqlmock` from indirect to direct (it's imported by `utils/loa_test.go`). Benign cleanup bundled here so CI's tidy step doesn't leave the tree mutated post-build.

## Test plan

- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] `go mod tidy` — clean
- [x] `go test ./... -cover -covermode=atomic` — passing
- [x] Coverage floors held (`utils` 47.5% ≥ 46%, `commands` 20.0% ≥ 18%)
- [x] `go build -o cavbot2` — green
- [x] Self-review: `/pr-review-toolkit:review-pr all parallel` (code-reviewer, pr-test-analyzer, comment-analyzer, code-simplifier) — first pass found two Important items (indexed-slice footgun, doc-comment rot); addressed in commit 2; second pass returned zero Critical/Important
- [x] Local smoke on test guild: `/awol position:asdfgh` and `/awol position:ZZZ/Q/9-9` render the new message; `/awol position:S6` happy path unchanged. `/loa` empty-result path shares the identical helper call; full verification requires docker compose (forum DB only resolves inside `xenforo_internal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)