### PR TITLE
chore(ci): harden build test workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,6 +1,7 @@
 name: Lint and Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop
@@ -35,13 +36,17 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
 
-      - name: Install dependencies
-        run: go mod tidy
+      - name: Verify module files are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
 
       - name: Run tests with coverage
-        run: go test ./... -cover -covermode=atomic | tee /tmp/cover.log
+        run: |
+          set -euo pipefail
+          go test ./... -cover -covermode=atomic | tee /tmp/cover.log
 
       - name: Enforce coverage floors
         run: ./.github/scripts/check-coverage-floors.sh < /tmp/cover.log

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/7cav/cavbot2
 go 1.25.0
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/getsentry/sentry-go v0.46.2
 	github.com/go-resty/resty/v2 v2.17.2
@@ -10,10 +11,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 )
 
-require (
-	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
-)
+require filippo.io/edwards25519 v1.2.0 // indirect
 
 require (
 	github.com/gorilla/websocket v1.5.3 // indirect


### PR DESCRIPTION
## Summary
- add manual dispatch to the build/test workflow
- pin Go setup to go.mod instead of floating stable
- verify go.mod/go.sum stay tidy in CI
- add pipefail to the coverage test pipeline

## Verification
- golangci-lint run --timeout=5m
- go test ./... -cover -covermode=atomic
- ./.github/scripts/check-coverage-floors.sh
- go build -o cavbot2