### PR TITLE
test(commands): cover /awol Pattern A conversion (#112)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
 github.com/7cav/cavbot2/utils	46
-github.com/7cav/cavbot2/commands	18
+github.com/7cav/cavbot2/commands	30
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/commands/awol.go
+++ b/commands/awol.go
@@ -3,12 +3,13 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/7cav/cavbot2/utils"
-	"github.com/bwmarrin/discordgo"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
 )
 
 func stringPtr(s string) *string {
@@ -21,6 +22,15 @@ const (
 	maxEmbedsPerMsg   = 10
 	awolThresholdDays = 8
 )
+
+// loaCacheReader is the minimal LOA-cache surface /awol (and /loa) consume.
+// Production wires *utils.LOACache (GlobalLOACache); tests substitute a fake
+// with canned entries so the handler stays deterministic without touching the
+// process-global singleton.
+type loaCacheReader interface {
+	IsOnLOA(username string) bool
+	GetEntry(username string) (utils.LOAEntry, bool)
+}
 
 type AwolUser struct {
 	Username          string
@@ -55,36 +65,42 @@ func Awol() Command {
 }
 
 func handleAwolCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	runAwol(utils.NewSessionResponder(s), utils.GlobalLOACache, time.Now(), i)
+}
+
+func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, i *discordgo.InteractionCreate) {
 	utils.Info("🚀 Starting AWOL check", "command", "Awol", "username", i.Member.User.Username, "discord_id", i.Member.User.ID)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: fmt.Sprintf("Fetching AWOL data for %s...", i.ApplicationCommandData().Options[0].StringValue()),
-		},
-	})
+	position := i.ApplicationCommandData().Options[0].StringValue()
 	forceFile := false
 	if len(i.ApplicationCommandData().Options) > 1 {
 		forceFile = i.ApplicationCommandData().Options[1].BoolValue()
 	}
+
+	err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("Fetching AWOL data for %s...", position),
+		},
+	})
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to respond to interaction: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to respond to interaction: %v", err))
 		return
 	}
 
-	position := i.ApplicationCommandData().Options[0].StringValue()
 	roster, err := utils.GetRosterByFuzzyPositionSearch(ctx, position)
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to fetch roster: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to fetch roster: %v", err))
 		return
 	}
 	if len(roster.LiteProfiles) == 0 {
-		utils.HandleError(utils.NewSessionResponder(s), i, emptyRosterSearchMessage(position))
+		utils.HandleError(r, i, emptyRosterSearchMessage(position))
 		return
 	}
 
+	awolThreshold := now.AddDate(0, 0, -awolThresholdDays)
 	awolUsers := []AwolUser{}
 	for _, member := range roster.LiteProfiles {
 		if member.User.Username == "Tester.B" || strings.Contains(member.Rank.RankFull, "General") {
@@ -92,13 +108,13 @@ func handleAwolCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		}
 		lastPostDate, err := time.Parse("2006-01-02 15:04:05", member.LastForumPostDate)
 		if err != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to parse last forum post date: %v", err))
+			utils.HandleError(r, i, fmt.Sprintf("❌ Failed to parse last forum post date: %v", err))
 			return
 		}
-		if lastPostDate.Before(time.Now().AddDate(0, 0, -awolThresholdDays)) {
+		if lastPostDate.Before(awolThreshold) {
 			matches := regexp.MustCompile(`/\d+/(\d+)\.jpg`).FindStringSubmatch(member.UniformUrl)
 			if len(matches) < 2 {
-				utils.HandleError(utils.NewSessionResponder(s), i, "❌ Failed to parse uniform URL")
+				utils.HandleError(r, i, "❌ Failed to parse uniform URL")
 				return
 			}
 			awolUsers = append(awolUsers, AwolUser{
@@ -106,7 +122,7 @@ func handleAwolCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 				MilpacUrl:         fmt.Sprintf("https://7cav.us/rosters/profile/%s", matches[1]),
 				TimeSinceLastPost: utils.FormatTimeSinceDuration(lastPostDate),
 				LastPostDate:      lastPostDate,
-				OnLOA:             utils.GlobalLOACache.IsOnLOA(member.User.Username),
+				OnLOA:             cache.IsOnLOA(member.User.Username),
 			})
 		}
 	}
@@ -117,11 +133,10 @@ func handleAwolCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	if len(awolUsers) == 0 {
 		response := fmt.Sprintf("Search completed successfully: no users matching \"%s\" are AWOL.", position)
-		_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 			Content: &response,
-		})
-		if err != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+		}); err != nil {
+			utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
 		}
 		return
 	}
@@ -138,7 +153,11 @@ func handleAwolCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	for _, user := range awolUsers {
 		loaTag := ""
 		if user.OnLOA {
-			if entry, ok := utils.GlobalLOACache.GetEntry(user.Username); ok && entry.ThreadID != 0 {
+			// NOTE: #96 — when the LOA cache is empty/unhealthy, every
+			// IsOnLOA returns false and this branch silently never fires,
+			// so the "On LOA" column reports incorrect (all-clear) status.
+			// Tracked separately; not in scope for #112.
+			if entry, ok := cache.GetEntry(user.Username); ok && entry.ThreadID != 0 {
 				loaTag = fmt.Sprintf("**[[LOA]](https://7cav.us/threads/%d/)** ", entry.ThreadID)
 			} else {
 				loaTag = "**[LOA]** "
@@ -163,47 +182,46 @@ func handleAwolCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	utils.Info("Debug chunks info", "chunks_length", len(chunks), "max_embeds", maxEmbedsPerMsg)
 	if len(chunks) > maxEmbedsPerMsg {
 		utils.Info("⚠️ Too many AWOL users for embeds, falling back to file upload", "count", len(awolUsers))
-		sendAwolFile(s, i, awolUsers, position, forceFile)
+		sendAwolFile(r, i, awolUsers, position, forceFile, now)
 		utils.Info("✨ Done!", "command", "Awol")
 		return
 	} else if forceFile {
 		utils.Info("⚠️ Force file output enabled, falling back to embeds", "count", len(awolUsers))
-		sendAwolFile(s, i, awolUsers, position, forceFile)
+		sendAwolFile(r, i, awolUsers, position, forceFile, now)
 		utils.Info("✨ Done!", "command", "Awol")
 		return
 	}
 
 	var embeds []*discordgo.MessageEmbed
-	for i, chunk := range chunks {
+	for idx, chunk := range chunks {
 		embed := &discordgo.MessageEmbed{
-			Title:       fmt.Sprintf("AWOL Users for %s (Page %d/%d)", position, i+1, len(chunks)),
+			Title:       fmt.Sprintf("AWOL Users for %s (Page %d/%d)", position, idx+1, len(chunks)),
 			Description: chunk,
 			Color:       0xfbcc29,
 			Footer: &discordgo.MessageEmbedFooter{
 				Text: fmt.Sprintf("Total AWOL: %d (%d on LOA)", len(awolUsers), loaCount),
 			},
-			Timestamp: time.Now().Format(time.RFC3339),
+			Timestamp: now.Format(time.RFC3339),
 		}
 		embeds = append(embeds, embed)
 	}
 
-	_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+	if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 		Content: nil,
 		Embeds:  &embeds,
-	})
-	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+	}); err != nil {
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
 		return
 	}
 
 	utils.Info("✨ Done!", "command", "Awol")
 }
 
-func sendAwolFile(s *discordgo.Session, i *discordgo.InteractionCreate, awolUsers []AwolUser, position string, forceFile bool) {
+func sendAwolFile(r utils.InteractionResponder, i *discordgo.InteractionCreate, awolUsers []AwolUser, position string, forceFile bool, now time.Time) {
 	var content strings.Builder
 	_, _ = fmt.Fprintf(&content, "AWOL Report for %s\nGenerated: %s\n\n",
 		position,
-		time.Now().Format("2006-01-02 15:04:05"))
+		now.Format("2006-01-02 15:04:05"))
 
 	for _, user := range awolUsers {
 		loaTag := ""
@@ -222,24 +240,16 @@ func sendAwolFile(s *discordgo.Session, i *discordgo.InteractionCreate, awolUser
 		ContentType: "text/plain",
 		Reader:      strings.NewReader(content.String()),
 	}
+	var prefix string
 	if forceFile {
-		_, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Content: stringPtr(fmt.Sprintf("Force File Set True, AWOL report for %s generated as file:", position)),
-			Files:   []*discordgo.File{file},
-		})
-		if err != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to send file: %v", err))
-			return
-		}
+		prefix = fmt.Sprintf("Force File Set True, AWOL report for %s generated as file:", position)
 	} else {
-		_, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Content: stringPtr(fmt.Sprintf("Large AWOL report for %s generated as file:", position)),
-			Files:   []*discordgo.File{file},
-		})
-		if err != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to send file: %v", err))
-			return
-		}
+		prefix = fmt.Sprintf("Large AWOL report for %s generated as file:", position)
 	}
-
+	if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: stringPtr(prefix),
+		Files:   []*discordgo.File{file},
+	}); err != nil {
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to send file: %v", err))
+	}
 }

--- a/commands/awol_test.go
+++ b/commands/awol_test.go
@@ -1,0 +1,320 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+// awolRefDate pins "now" for /awol tests. With awolThresholdDays=8 the AWOL
+// cutoff lands at 2026-05-07; LastForumPostDate values older than that are AWOL.
+var awolRefDate = mustParseAwolDate("2026-05-15 12:00:00")
+
+func mustParseAwolDate(s string) time.Time {
+	t, err := time.Parse("2006-01-02 15:04:05", s)
+	if err != nil {
+		panic("mustParseAwolDate: " + err.Error())
+	}
+	return t
+}
+
+// serveAwolRoster spins up an httptest server that returns the supplied roster
+// for /milpacs/position/search/* requests; rosterStatus lets a test simulate
+// upstream errors (e.g. 500). Other paths 404.
+func serveAwolRoster(t *testing.T, roster utils.LiteRosterResponse, rosterStatus int) {
+	t.Helper()
+	body, err := json.Marshal(roster)
+	if err != nil {
+		t.Fatalf("serveAwolRoster marshal: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/milpacs/position/search/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if rosterStatus != 0 && rosterStatus != http.StatusOK {
+			w.WriteHeader(rosterStatus)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+}
+
+// fakeLOACache is a deterministic loaCacheReader for /awol integration tests.
+// entries are keyed by lowercased username (matches the production cache's
+// case-folding); IsOnLOA returns true iff an entry exists, decoupling the test
+// from time.Now since the handler's "now" is already injected separately.
+type fakeLOACache struct {
+	entries map[string]utils.LOAEntry
+}
+
+func (f *fakeLOACache) GetEntry(username string) (utils.LOAEntry, bool) {
+	e, ok := f.entries[strings.ToLower(username)]
+	return e, ok
+}
+
+func (f *fakeLOACache) IsOnLOA(username string) bool {
+	_, ok := f.entries[strings.ToLower(username)]
+	return ok
+}
+
+func boolOption(name string, value bool) *discordgo.ApplicationCommandInteractionDataOption {
+	return &discordgo.ApplicationCommandInteractionDataOption{
+		Name:  name,
+		Type:  discordgo.ApplicationCommandOptionBoolean,
+		Value: value,
+	}
+}
+
+// awolMember builds a roster-shape LiteProfileResponse for /awol tests. The
+// uniformUrl pattern matches the /<n>/<milpacID>.jpg regex the handler parses.
+func awolMember(username, milpacID, lastForumPost string) utils.LiteProfileResponse {
+	return utils.LiteProfileResponse{
+		User:              utils.User{Username: username},
+		Rank:              utils.Rank{RankFull: "Specialist"},
+		UniformUrl:        "https://7cav.us/data/roster_uniforms/0/" + milpacID + ".jpg",
+		LastForumPostDate: lastForumPost,
+	}
+}
+
+func TestRunAwol_SmallResultRendersEmbedChunks(t *testing.T) {
+	// Two AWOL members (last post >8d before awolRefDate); no LOA; no force_file.
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+			"200": awolMember("Trooper.B", "200", "2026-04-01 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	f := &fakeResponder{}
+	cache := &fakeLOACache{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runAwol(f, cache, awolRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (placeholder Respond + Edit), got %d: %+v", len(calls), calls)
+	}
+	if calls[0].Method != "Respond" {
+		t.Fatalf("calls[0]: expected Respond, got %q", calls[0].Method)
+	}
+	if !strings.Contains(calls[0].Response.Data.Content, "1-7") {
+		t.Fatalf("placeholder should mention position; got %q", calls[0].Response.Data.Content)
+	}
+	if calls[1].Method != "Edit" {
+		t.Fatalf("calls[1]: expected Edit, got %q", calls[1].Method)
+	}
+	edit := calls[1].Edit
+	if edit.Embeds == nil || len(*edit.Embeds) == 0 {
+		t.Fatalf("expected embeds set on Edit; got Embeds=%v Files=%v Content=%v", edit.Embeds, edit.Files, edit.Content)
+	}
+	if len(edit.Files) > 0 {
+		t.Fatalf("expected no files for small-result path; got %d files", len(edit.Files))
+	}
+	desc := (*edit.Embeds)[0].Description
+	for _, want := range []string{"Trooper.A", "Trooper.B"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("embed description missing %q.\nGot:\n%s", want, desc)
+		}
+	}
+}
+
+func TestRunAwol_LargeResultFallsBackToFile(t *testing.T) {
+	// Inflate per-user line length with long padded usernames so a single user
+	// line saturates a chunk (~2.5KB each, threshold 4096). 11 such users yield
+	// 11 chunks, exceeding maxEmbedsPerMsg=10 and forcing the file fallback.
+	const padded = 2500
+	pad := strings.Repeat("x", padded)
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{},
+	}
+	for n := range 11 {
+		id := fmt.Sprintf("%d", 1000+n)
+		name := fmt.Sprintf("U%d_%s", n, pad)
+		roster.LiteProfiles[id] = awolMember(name, id, "2026-03-01 12:00:00")
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	f := &fakeResponder{}
+	cache := &fakeLOACache{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runAwol(f, cache, awolRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %+v", len(calls), calls)
+	}
+	edit := calls[1].Edit
+	if edit == nil {
+		t.Fatalf("calls[1].Edit is nil")
+	}
+	if len(edit.Files) != 1 {
+		t.Fatalf("expected exactly 1 file attachment, got %d", len(edit.Files))
+	}
+	if edit.Embeds != nil && len(*edit.Embeds) > 0 {
+		t.Fatalf("expected no embeds on file-fallback path, got %d", len(*edit.Embeds))
+	}
+	if edit.Content == nil || !strings.Contains(*edit.Content, "Large AWOL report") {
+		got := "<nil>"
+		if edit.Content != nil {
+			got = *edit.Content
+		}
+		t.Fatalf("expected 'Large AWOL report' prefix on file path, got %q", got)
+	}
+	if edit.Files[0].Name != "awol_report_1-7.txt" {
+		t.Fatalf("file name = %q, want awol_report_1-7.txt", edit.Files[0].Name)
+	}
+}
+
+func TestRunAwol_ForceFileOutputWithSmallResult(t *testing.T) {
+	// Two AWOL members — small enough to fit in embeds — but force_file_output
+	// flips the rendering to the file path with the "Force File Set True" prefix.
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+			"200": awolMember("Trooper.B", "200", "2026-04-01 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	f := &fakeResponder{}
+	cache := &fakeLOACache{}
+	i := fakeAppCommandInteraction(
+		stringOption("position", "1-7"),
+		boolOption("force_file_output", true),
+	)
+
+	runAwol(f, cache, awolRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %+v", len(calls), calls)
+	}
+	edit := calls[1].Edit
+	if len(edit.Files) != 1 {
+		t.Fatalf("expected exactly 1 file attachment, got %d", len(edit.Files))
+	}
+	if edit.Content == nil || !strings.Contains(*edit.Content, "Force File Set True") {
+		got := "<nil>"
+		if edit.Content != nil {
+			got = *edit.Content
+		}
+		t.Fatalf("expected 'Force File Set True' prefix, got %q", got)
+	}
+}
+
+func TestRunAwol_EmptyRosterSurfacesFormatHint(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{}}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	// First Respond is the placeholder (succeeds); HandleError's Respond
+	// simulates "already acknowledged" so its Edit fallback fires with the
+	// empty-roster format-hint message.
+	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
+	cache := &fakeLOACache{}
+	i := fakeAppCommandInteraction(stringOption("position", "Q/Z/9-9"))
+
+	runAwol(f, cache, awolRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls (placeholder + HandleError Respond + Edit fallback), got %d: %+v", len(calls), calls)
+	}
+	if calls[2].Method != "Edit" {
+		t.Fatalf("calls[2]: expected Edit, got %q", calls[2].Method)
+	}
+	want := emptyRosterSearchMessage("Q/Z/9-9")
+	got := "<nil>"
+	if calls[2].Edit.Content != nil {
+		got = *calls[2].Edit.Content
+	}
+	if got != want {
+		t.Fatalf("Edit fallback content mismatch.\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestRunAwol_RosterFetch500SurfacesError(t *testing.T) {
+	serveAwolRoster(t, utils.LiteRosterResponse{}, http.StatusInternalServerError)
+
+	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
+	cache := &fakeLOACache{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runAwol(f, cache, awolRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls, got %d: %+v", len(calls), calls)
+	}
+	got := "<nil>"
+	if calls[2].Edit.Content != nil {
+		got = *calls[2].Edit.Content
+	}
+	if !strings.Contains(got, "Failed to fetch roster") {
+		t.Fatalf("expected 'Failed to fetch roster' in Edit fallback, got %q", got)
+	}
+}
+
+func TestRunAwol_OnLOAAnnotationRenders(t *testing.T) {
+	// Two AWOL members; only Trooper.A has a matching LOA cache entry, with a
+	// non-zero ThreadID — so the row must render with **[[LOA]](...)** linked
+	// to that thread. Trooper.B has no entry → no LOA tag.
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+			"200": awolMember("Trooper.B", "200", "2026-04-01 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	cache := &fakeLOACache{
+		entries: map[string]utils.LOAEntry{
+			"trooper.a": {
+				Username:  "Trooper.A",
+				StartDate: mustParseAwolDate("2026-04-01 00:00:00"),
+				EndDate:   mustParseAwolDate("2026-06-01 00:00:00"),
+				ThreadID:  4242,
+			},
+		},
+	}
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runAwol(f, cache, awolRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %+v", len(calls), calls)
+	}
+	edit := calls[1].Edit
+	if edit.Embeds == nil || len(*edit.Embeds) == 0 {
+		t.Fatalf("expected embeds; got Embeds=%v", edit.Embeds)
+	}
+	desc := (*edit.Embeds)[0].Description
+	wantTag := "**[[LOA]](https://7cav.us/threads/4242/)**"
+	if !strings.Contains(desc, wantTag) {
+		t.Fatalf("expected LOA tag %q in description.\nGot:\n%s", wantTag, desc)
+	}
+	// Footer must reflect 1 of 2 on LOA.
+	footer := (*edit.Embeds)[0].Footer
+	if footer == nil || !strings.Contains(footer.Text, "Total AWOL: 2 (1 on LOA)") {
+		got := "<nil>"
+		if footer != nil {
+			got = footer.Text
+		}
+		t.Fatalf("footer should report 1 on LOA; got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #112.

## Summary
- Refactor `handleAwol → runAwol(responder, cache, now, i)` mirroring `/afsm` + `/s6-it-check` shape (PRs #87, #88).
- Add minimal `loaCacheReader` interface (`IsOnLOA`, `GetEntry`) — satisfied by `utils.GlobalLOACache`; ready for `/loa` to adopt in #110.
- Inject `time.Now` so the AWOL threshold + embed timestamp + file header are deterministic.
- `sendAwolFile` rewired off `*discordgo.Session` onto the responder so file path is testable too.
- Inline comment near the `[LOA]` annotation flags #96 (silent wrong column during cache outage) — explicitly out of scope here per the issue.

## Tests (all six acceptance cases)
- Small result → embed chunks (no files).
- Large result (>10 chunks via long padded usernames) → file fallback with "Large AWOL report" prefix.
- `force_file_output=true` + small result → file path with "Force File Set True" prefix.
- Empty roster → `emptyRosterSearchMessage(position)` via `HandleError` fallback.
- Roster fetch 500 → `Failed to fetch roster` via `HandleError` fallback.
- LOA cache hit → row renders `**[[LOA]](https://7cav.us/threads/N/)**` and footer reads `Total AWOL: 2 (1 on LOA)`.

## Coverage
`commands` 25.1% → 31.7%; floor in `.github/scripts/check-coverage-floors.sh` bumped 18 → 30.

## Test plan
- [x] `golangci-lint run --timeout=5m` — 0 issues.
- [x] `go test ./... -cover -covermode=atomic` — pass.
- [x] `./.github/scripts/check-coverage-floors.sh` — pass.
- [x] `go build -o cavbot2` — pass.
- [x] Manual smoke on test guild: `/awol position:1-7`, `/awol 1-7 force_file_output:true`, `/awol reservist`, `/awol 7` — all rendered cleanly, embed + force_file branches exercised (large-result branch not reproducible live; covered by integration test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)