### PR TITLE
test(commands): cover /loa Pattern A conversion (#110)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
 github.com/7cav/cavbot2/utils	46
-github.com/7cav/cavbot2/commands	30
+github.com/7cav/cavbot2/commands	36
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/commands/loa.go
+++ b/commands/loa.go
@@ -12,6 +12,17 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
+// loaCacheView is the minimal LOA-cache surface /loa consumes: per-member
+// entry lookup plus a health probe for the staleness guard. Production wires
+// *utils.LOACache (GlobalLOACache); tests substitute a fake with canned
+// entries and a forced health verdict so the handler stays deterministic
+// without touching the process-global singleton. Distinct from /awol's
+// loaCacheReader, which needs IsOnLOA but not IsHealthy.
+type loaCacheView interface {
+	GetEntry(username string) (utils.LOAEntry, bool)
+	IsHealthy(maxAge time.Duration) (bool, time.Time)
+}
+
 // loaUnavailableMessage formats the user-facing string shown when GlobalLOACache
 // is unhealthy. lastRefresh is the cache's last successful refresh (zero == never);
 // now is passed in so callers can read time.Now() once and tests stay deterministic.
@@ -51,27 +62,30 @@ func LOA() Command {
 }
 
 func handleLOACommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	runLoa(utils.NewSessionResponder(s), utils.GlobalLOACache, time.Now(), i)
+}
+
+func runLoa(r utils.InteractionResponder, cache loaCacheView, now time.Time, i *discordgo.InteractionCreate) {
 	utils.Info("🚀 Starting LOA check", "command", "LOA", "username", i.Member.User.Username, "discord_id", i.Member.User.ID)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	position := i.ApplicationCommandData().Options[0].StringValue()
 
-	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: fmt.Sprintf("Fetching LOA data for %s...", position),
 		},
 	})
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to respond to interaction: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to respond to interaction: %v", err))
 		return
 	}
 
 	const loaCacheMaxAge = 30 * time.Minute // 2× the 15-min refresh interval
-	healthy, lastRefresh := utils.GlobalLOACache.IsHealthy(loaCacheMaxAge)
+	healthy, lastRefresh := cache.IsHealthy(loaCacheMaxAge)
 	if !healthy {
-		now := time.Now() // single read; reused for message + log
 		msg := loaUnavailableMessage(lastRefresh, now)
 		utils.Debug("LOA command served unavailable message",
 			"command", "LOA",
@@ -81,29 +95,27 @@ func handleLOACommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			"served_at", now,
 			"staleness", now.Sub(lastRefresh),
 		)
-		_, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &msg})
-		if err != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+		if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &msg}); err != nil {
+			utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
 		}
 		return
 	}
 
 	roster, err := utils.GetRosterByFuzzyPositionSearch(ctx, position)
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to fetch roster: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to fetch roster: %v", err))
 		return
 	}
 	if len(roster.LiteProfiles) == 0 {
-		utils.HandleError(utils.NewSessionResponder(s), i, emptyRosterSearchMessage(position))
+		utils.HandleError(r, i, emptyRosterSearchMessage(position))
 		return
 	}
 
 	urlRe := regexp.MustCompile(`/\d+/(\d+)\.jpg`)
-	now := time.Now()
 	var activeLOAs, upcomingLOAs []LOAUser
 
 	for _, member := range roster.LiteProfiles {
-		entry, ok := utils.GlobalLOACache.GetEntry(member.User.Username)
+		entry, ok := cache.GetEntry(member.User.Username)
 		if !ok {
 			continue
 		}
@@ -132,11 +144,10 @@ func handleLOACommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	if len(activeLOAs) == 0 && len(upcomingLOAs) == 0 {
 		response := fmt.Sprintf("No active or upcoming LOAs found for \"%s\".", position)
-		_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 			Content: &response,
-		})
-		if err != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+		}); err != nil {
+			utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
 		}
 		return
 	}
@@ -192,12 +203,11 @@ func handleLOACommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	}
 
 	embeds := []*discordgo.MessageEmbed{embed}
-	_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+	if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 		Content: stringPtr(""),
 		Embeds:  &embeds,
-	})
-	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+	}); err != nil {
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
 		return
 	}
 

--- a/commands/loa_test.go
+++ b/commands/loa_test.go
@@ -1,10 +1,300 @@
 package commands
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/7cav/cavbot2/utils"
 )
+
+// loaRefDate pins "now" for /loa tests. Active = StartDate ≤ now ≤ EndDate;
+// Upcoming = StartDate > now. Cache entries below straddle this date.
+var loaRefDate = time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+
+// fakeLOAView is a deterministic loaCacheView for /loa integration tests.
+// entries are keyed by lowercased username (matches the production cache's
+// case-folding). healthy/lastRefresh drive the IsHealthy staleness guard.
+type fakeLOAView struct {
+	entries     map[string]utils.LOAEntry
+	healthy     bool
+	lastRefresh time.Time
+}
+
+func (f *fakeLOAView) GetEntry(username string) (utils.LOAEntry, bool) {
+	e, ok := f.entries[strings.ToLower(username)]
+	return e, ok
+}
+
+func (f *fakeLOAView) IsHealthy(_ time.Duration) (bool, time.Time) {
+	return f.healthy, f.lastRefresh
+}
+
+// healthyView builds a healthy fakeLOAView from the given entries (keyed by
+// lowercased username), with lastRefresh pinned at loaRefDate.
+func healthyView(entries map[string]utils.LOAEntry) *fakeLOAView {
+	return &fakeLOAView{entries: entries, healthy: true, lastRefresh: loaRefDate}
+}
+
+// loaMember builds a roster-shape LiteProfileResponse for /loa tests. The
+// uniformUrl matches the /<n>/<milpacID>.jpg regex the handler parses to
+// build the milpac profile link.
+func loaMember(username, milpacID string) utils.LiteProfileResponse {
+	return utils.LiteProfileResponse{
+		User:       utils.User{Username: username},
+		Rank:       utils.Rank{RankFull: "Specialist"},
+		UniformUrl: "https://7cav.us/data/roster_uniforms/0/" + milpacID + ".jpg",
+	}
+}
+
+func TestRunLoa_RosterFetch500SurfacesError(t *testing.T) {
+	serveAwolRoster(t, utils.LiteRosterResponse{}, http.StatusInternalServerError)
+
+	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
+	cache := healthyView(map[string]utils.LOAEntry{})
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runLoa(f, cache, loaRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls, got %d: %+v", len(calls), calls)
+	}
+	got := "<nil>"
+	if calls[2].Edit.Content != nil {
+		got = *calls[2].Edit.Content
+	}
+	if !strings.Contains(got, "Failed to fetch roster") {
+		t.Fatalf("expected 'Failed to fetch roster' in Edit fallback, got %q", got)
+	}
+}
+
+func TestRunLoa_StaleCacheShortCircuitsWithUnavailable(t *testing.T) {
+	// An empty roster is served as a tripwire: if the staleness guard failed to
+	// short-circuit, the handler would reach the empty-roster path (3 calls,
+	// format-hint content) instead of the 2-call unavailable edit below.
+	serveAwolRoster(t, utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{}}, http.StatusOK)
+
+	f := &fakeResponder{}
+	cache := &fakeLOAView{
+		entries:     map[string]utils.LOAEntry{},
+		healthy:     false,
+		lastRefresh: loaRefDate.Add(-45 * time.Minute),
+	}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runLoa(f, cache, loaRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (placeholder + unavailable Edit), got %d: %+v", len(calls), calls)
+	}
+	got := "<nil>"
+	if calls[1].Edit.Content != nil {
+		got = *calls[1].Edit.Content
+	}
+	if !strings.Contains(got, "LOA cache unavailable") || !strings.Contains(got, "45 minutes ago") {
+		t.Fatalf("expected unavailable message with staleness; got %q", got)
+	}
+}
+
+func TestRunLoa_NoMatchingLOAsReportsNone(t *testing.T) {
+	// Roster has a member, but the cache holds no entry for them → neither
+	// active nor upcoming, so the handler edits with the "no LOAs" message.
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": loaMember("Trooper.Present", "100"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	cache := healthyView(map[string]utils.LOAEntry{})
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runLoa(f, cache, loaRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (placeholder + Edit), got %d: %+v", len(calls), calls)
+	}
+	edit := calls[1].Edit
+	if edit.Embeds != nil && len(*edit.Embeds) > 0 {
+		t.Fatalf("expected no embeds for no-LOA result, got %d", len(*edit.Embeds))
+	}
+	got := "<nil>"
+	if edit.Content != nil {
+		got = *edit.Content
+	}
+	if !strings.Contains(got, "No active or upcoming LOAs found") || !strings.Contains(got, "1-7") {
+		t.Fatalf("expected no-LOA message mentioning position; got %q", got)
+	}
+}
+
+func TestRunLoa_EmptyRosterSurfacesFormatHint(t *testing.T) {
+	serveAwolRoster(t, utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{}}, http.StatusOK)
+
+	// Placeholder Respond succeeds; HandleError's Respond simulates "already
+	// acknowledged" so its Edit fallback fires with the empty-roster hint.
+	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
+	cache := healthyView(map[string]utils.LOAEntry{})
+	i := fakeAppCommandInteraction(stringOption("position", "Q/Z/9-9"))
+
+	runLoa(f, cache, loaRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls (placeholder + HandleError Respond + Edit fallback), got %d: %+v", len(calls), calls)
+	}
+	want := emptyRosterSearchMessage("Q/Z/9-9")
+	got := "<nil>"
+	if calls[2].Edit.Content != nil {
+		got = *calls[2].Edit.Content
+	}
+	if got != want {
+		t.Fatalf("Edit fallback content mismatch.\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestRunLoa_BothSectionsRenderActiveBeforeUpcoming(t *testing.T) {
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": loaMember("Trooper.Active", "100"),
+			"200": loaMember("Trooper.Soon", "200"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	cache := healthyView(map[string]utils.LOAEntry{
+		"trooper.active": {
+			Username:  "Trooper.Active",
+			StartDate: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:   time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		},
+		"trooper.soon": {
+			Username:  "Trooper.Soon",
+			StartDate: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:   time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runLoa(f, cache, loaRefDate, i)
+
+	edit := f.Calls()[1].Edit
+	desc := (*edit.Embeds)[0].Description
+	activeIdx := strings.Index(desc, "**Active LOAs**")
+	upcomingIdx := strings.Index(desc, "**Upcoming LOAs**")
+	if activeIdx == -1 || upcomingIdx == -1 {
+		t.Fatalf("expected both sections.\nGot:\n%s", desc)
+	}
+	if activeIdx > upcomingIdx {
+		t.Fatalf("Active section must precede Upcoming.\nGot:\n%s", desc)
+	}
+	footer := (*edit.Embeds)[0].Footer
+	if footer == nil || !strings.Contains(footer.Text, "Active: 1 | Upcoming: 1") {
+		got := "<nil>"
+		if footer != nil {
+			got = footer.Text
+		}
+		t.Fatalf("footer should report Active: 1 | Upcoming: 1; got %q", got)
+	}
+}
+
+func TestRunLoa_UpcomingOnlyRendersUpcomingSection(t *testing.T) {
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"200": loaMember("Trooper.Soon", "200"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	cache := healthyView(map[string]utils.LOAEntry{
+		"trooper.soon": {
+			Username:  "Trooper.Soon",
+			StartDate: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:   time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runLoa(f, cache, loaRefDate, i)
+
+	edit := f.Calls()[1].Edit
+	desc := (*edit.Embeds)[0].Description
+	if !strings.Contains(desc, "**Upcoming LOAs**") {
+		t.Fatalf("expected Upcoming LOAs section.\nGot:\n%s", desc)
+	}
+	if strings.Contains(desc, "**Active LOAs**") {
+		t.Fatalf("did not expect Active section for upcoming-only.\nGot:\n%s", desc)
+	}
+	footer := (*edit.Embeds)[0].Footer
+	if footer == nil || !strings.Contains(footer.Text, "Active: 0 | Upcoming: 1") {
+		got := "<nil>"
+		if footer != nil {
+			got = footer.Text
+		}
+		t.Fatalf("footer should report Active: 0 | Upcoming: 1; got %q", got)
+	}
+}
+
+func TestRunLoa_ActiveLOARendersActiveSection(t *testing.T) {
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": loaMember("Trooper.Active", "100"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	cache := healthyView(map[string]utils.LOAEntry{
+		"trooper.active": {
+			Username:  "Trooper.Active",
+			StartDate: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:   time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+			ThreadID:  4242,
+		},
+	})
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runLoa(f, cache, loaRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (placeholder Respond + Edit), got %d: %+v", len(calls), calls)
+	}
+	if calls[0].Method != "Respond" {
+		t.Fatalf("calls[0]: expected Respond, got %q", calls[0].Method)
+	}
+	edit := calls[1].Edit
+	if edit.Embeds == nil || len(*edit.Embeds) == 0 {
+		t.Fatalf("expected embeds on Edit; got %+v", edit)
+	}
+	desc := (*edit.Embeds)[0].Description
+	if !strings.Contains(desc, "**Active LOAs**") {
+		t.Fatalf("expected Active LOAs section.\nGot:\n%s", desc)
+	}
+	if strings.Contains(desc, "**Upcoming LOAs**") {
+		t.Fatalf("did not expect Upcoming section for active-only.\nGot:\n%s", desc)
+	}
+	if !strings.Contains(desc, "Trooper.Active") {
+		t.Fatalf("expected member name in description.\nGot:\n%s", desc)
+	}
+	if !strings.Contains(desc, "[[Thread]](https://7cav.us/threads/4242/)") {
+		t.Fatalf("expected thread link for non-zero ThreadID.\nGot:\n%s", desc)
+	}
+	footer := (*edit.Embeds)[0].Footer
+	if footer == nil || !strings.Contains(footer.Text, "Active: 1 | Upcoming: 0") {
+		got := "<nil>"
+		if footer != nil {
+			got = footer.Text
+		}
+		t.Fatalf("footer should report Active: 1 | Upcoming: 0; got %q", got)
+	}
+}
 
 func TestLOAUnavailableMessage(t *testing.T) {
 	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
Closes #110.

## Summary
- Convert `/loa` to `handleLOACommand → runLoa(responder, cache, now, i)`, mirroring `/afsm` + `/awol` (PRs #74, #87, #88, #112).
- Add minimal `loaCacheView` interface (`GetEntry` + `IsHealthy`) — satisfied by `utils.GlobalLOACache`; tests substitute a fake. Distinct from `/awol`'s `loaCacheReader` (which needs `IsOnLOA` but not `IsHealthy`), keeping each interface to the surface its handler actually uses.
- Inject `time.Now` so active/upcoming classification, the embed timestamp, and the staleness message are deterministic.
- Route every response through `utils.InteractionResponder` (no raw `*discordgo.Session` in the handler body).

## Tests (six acceptance cases + no-LOA branch)
- Active LOAs → `**Active LOAs**` section, `[[Thread]]` link, footer `Active: 1 | Upcoming: 0`.
- Upcoming-only → `**Upcoming LOAs**` section, footer `Active: 0 | Upcoming: 1`.
- Both → Active section rendered before Upcoming, footer `Active: 1 | Upcoming: 1`.
- Roster with no matching cache entries → `No active or upcoming LOAs found`.
- Empty roster → `emptyRosterSearchMessage(position)` via `HandleError` fallback.
- Roster fetch 500 → `Failed to fetch roster` fallback.
- Stale cache → short-circuits to the unavailable message before the roster fetch (empty-roster tripwire proves the short-circuit).

## Coverage
`commands` 31.7% → 37.0%; floor in `.github/scripts/check-coverage-floors.sh` bumped 30 → 36.

## Test plan
- [x] `golangci-lint run --timeout=5m` — 0 issues.
- [x] `go mod tidy` — no change.
- [x] `go test ./... -cover -covermode=atomic` — pass.
- [x] `./.github/scripts/check-coverage-floors.sh` — pass.
- [x] `go build -o cavbot2` — pass.
- [x] Manual smoke on test guild: ran the branch build against the live gateway + local Xenforo DB (808 active LOA entries). `/loa` active/upcoming/none + empty-roster paths rendered cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)