### PR TITLE
perf(commands): parallelize per-member milpac fetches in /afsm and /s6-it-check

### DIFF
--- a/commands/afsm.go
+++ b/commands/afsm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/7cav/cavbot2/utils"
 	"github.com/bwmarrin/discordgo"
+	"golang.org/x/sync/errgroup"
 	"sort"
 	"strings"
 	"time"
@@ -68,10 +69,9 @@ func runAFSM(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
 		return
 	}
 
-	// 5min accommodates the current serial-fetch shape (~1.4s per eligible member,
-	// rosters of 50+); well under Discord's 15min interaction-token cliff.
-	// Parallelizing the per-member fetches would let this drop back to 60s — see #86.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// Per-member milpac fetches fan out concurrently (see below), so wall-clock
+	// is roughly one fetch latency rather than the serial sum — 60s is ample.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	utils.Debug("📊 Fetching roster data", "department", choice)
@@ -96,11 +96,33 @@ func runAFSM(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
 	currentDate := time.Now()
 	utils.Debug("⏰ Current date set", "date", currentDate)
 
+	// Fan the per-member milpac fetches out concurrently — each takes ~1.4s and
+	// a department roster can hold 50+, so serial evaluation routinely blew past
+	// the timeout. errgroup with a concurrency cap bounds in-flight requests;
+	// results and errors are collected per-slot so a failed member is
+	// skipped-and-reported without aborting the others.
+	members := make([]utils.LiteProfileResponse, 0, len(Members.LiteProfiles))
+	for _, member := range Members.LiteProfiles {
+		members = append(members, member)
+	}
+	results := make([]*AFSMMember, len(members))
+	errs := make([]error, len(members))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for idx, member := range members {
+		idx, member := idx, member
+		g.Go(func() error {
+			results[idx], errs[idx] = evaluateAFSMMember(gctx, member, choice, currentDate)
+			return nil
+		})
+	}
+	_ = g.Wait()
+
 	eligibleMembers := []AFSMMember{}
 	skippedCount := 0
-	for _, member := range Members.LiteProfiles {
-		result, err := evaluateAFSMMember(ctx, member, choice, currentDate)
-		if err != nil {
+	for idx, member := range members {
+		if err := errs[idx]; err != nil {
 			utils.CaptureError(
 				"AFSM member evaluation failed",
 				err,
@@ -110,8 +132,8 @@ func runAFSM(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
 			skippedCount++
 			continue
 		}
-		if result != nil {
-			eligibleMembers = append(eligibleMembers, *result)
+		if results[idx] != nil {
+			eligibleMembers = append(eligibleMembers, *results[idx])
 		}
 	}
 

--- a/commands/afsm_test.go
+++ b/commands/afsm_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -593,6 +594,102 @@ func TestRunAFSM_HappyPathWithSkipped(t *testing.T) {
 	// Ensure ineligible Test.B is NOT mentioned.
 	if strings.Contains(got, "Test.B") {
 		t.Fatalf("Edit content should not mention ineligible Test.B; got: %s", got)
+	}
+}
+
+// serveRosterTrackingProfileConcurrency stands up a multiplexed server like
+// serveRosterAndProfiles, but instruments the per-profile endpoint so the test
+// can observe how many milpac fetches are in flight at once. Each profile
+// handler blocks on a barrier long enough that any concurrent fetches overlap,
+// then records the peak observed concurrency. A serial loop peaks at 1; a
+// fanned-out implementation peaks at >1.
+func serveRosterTrackingProfileConcurrency(
+	t *testing.T,
+	roster utils.LiteRosterResponse,
+	profilesByUsername map[string]utils.ProfileResponse,
+	peak *int32,
+) {
+	t.Helper()
+	rosterBody, err := json.Marshal(roster)
+	if err != nil {
+		t.Fatalf("marshal roster: %v", err)
+	}
+	encodedProfiles := make(map[string][]byte, len(profilesByUsername))
+	for name, p := range profilesByUsername {
+		b, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal profile %q: %v", name, err)
+		}
+		encodedProfiles[name] = b
+	}
+	var inFlight int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/milpacs/position/search/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(rosterBody)
+		case strings.HasPrefix(r.URL.Path, "/milpacs/profile/username/"):
+			cur := atomic.AddInt32(&inFlight, 1)
+			for {
+				old := atomic.LoadInt32(peak)
+				if cur <= old || atomic.CompareAndSwapInt32(peak, old, cur) {
+					break
+				}
+			}
+			// Hold the request open briefly so concurrent fetches genuinely
+			// overlap before any returns — makes the peak observation reliable.
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&inFlight, -1)
+
+			name := strings.TrimPrefix(r.URL.Path, "/milpacs/profile/username/")
+			body, ok := encodedProfiles[name]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+}
+
+func TestRunAFSM_FetchesConcurrently(t *testing.T) {
+	// Four members all eligible by position (S6 secondary, no primary
+	// disqualifier) so each forces a milpac fetch. A serial loop peaks at one
+	// in-flight fetch; the fanned-out implementation peaks above one.
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{}}
+	profiles := map[string]utils.ProfileResponse{}
+	for _, id := range []string{"1", "2", "3", "4"} {
+		name := "Member." + id
+		m := utils.LiteProfileResponse{
+			User:       utils.User{Username: name},
+			Primary:    utils.Position{PositionTitle: "Trooper 3/2/A/1-7"},
+			Secondary:  []utils.Position{{PositionTitle: "S6 Operations Staff IT"}},
+			UniformUrl: "https://7cav.us/data/roster_uniforms/0/" + id + ".jpg",
+		}
+		roster.LiteProfiles[id] = m
+		profiles[name] = utils.ProfileResponse{
+			User: m.User, Primary: m.Primary, Secondary: m.Secondary, UniformUrl: m.UniformUrl,
+			Records: []utils.Record{
+				{RecordType: "RECORD_TYPE_ASSIGNMENT", RecordDate: "2024-01-01", RecordDetails: "Assigned S6 Operations Staff IT"},
+			},
+		}
+	}
+
+	var peak int32
+	serveRosterTrackingProfileConcurrency(t, roster, profiles, &peak)
+
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("department", "S6"))
+
+	runAFSM(f, i)
+
+	if got := atomic.LoadInt32(&peak); got < 2 {
+		t.Fatalf("expected concurrent milpac fetches (peak >= 2), got peak %d — fetches ran serially", got)
 	}
 }
 

--- a/commands/s6_trackers.go
+++ b/commands/s6_trackers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/7cav/cavbot2/utils"
 	"github.com/bwmarrin/discordgo"
+	"golang.org/x/sync/errgroup"
 	"sort"
 	"strings"
 	"time"
@@ -47,10 +48,9 @@ func runS6ITCheck(r utils.InteractionResponder, i *discordgo.InteractionCreate) 
 		return
 	}
 
-	// 5min accommodates the current serial-fetch shape; well under Discord's
-	// 15min interaction-token cliff. Parallelizing the per-member fetches would
-	// let this drop back to 60s — see #86.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// Per-member milpac fetches fan out concurrently (see below), so wall-clock
+	// is roughly one fetch latency rather than the serial sum — 60s is ample.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	s6Members, err := utils.GetRosterByFuzzyPositionSearch(ctx, "S6")
@@ -70,11 +70,33 @@ func runS6ITCheck(r utils.InteractionResponder, i *discordgo.InteractionCreate) 
 	}
 
 	currentDate := time.Now()
+
+	// Fan the per-member milpac fetches out concurrently — each takes ~1.4s and
+	// serial evaluation routinely blew past the timeout. Results and errors are
+	// collected per-slot so a failed member is skipped-and-reported without
+	// aborting the others (preserving the per-member skip semantics).
+	members := make([]utils.LiteProfileResponse, 0, len(s6Members.LiteProfiles))
+	for _, member := range s6Members.LiteProfiles {
+		members = append(members, member)
+	}
+	results := make([][]ITMember, len(members))
+	errs := make([]error, len(members))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for idx, member := range members {
+		idx, member := idx, member
+		g.Go(func() error {
+			results[idx], errs[idx] = evaluateS6Member(gctx, member, currentDate)
+			return nil
+		})
+	}
+	_ = g.Wait()
+
 	eligibleMembers := []ITMember{}
 	skippedCount := 0
-	for _, member := range s6Members.LiteProfiles {
-		rows, err := evaluateS6Member(ctx, member, currentDate)
-		if err != nil {
+	for idx, member := range members {
+		if err := errs[idx]; err != nil {
 			utils.CaptureError(
 				"S6 IT member evaluation failed",
 				err,
@@ -83,7 +105,7 @@ func runS6ITCheck(r utils.InteractionResponder, i *discordgo.InteractionCreate) 
 			skippedCount++
 			continue
 		}
-		eligibleMembers = append(eligibleMembers, rows...)
+		eligibleMembers = append(eligibleMembers, results[idx]...)
 	}
 
 	sort.Slice(eligibleMembers, func(i, j int) bool {

--- a/commands/s6_trackers_test.go
+++ b/commands/s6_trackers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -531,6 +532,93 @@ func TestRunS6ITCheck_HappyPathWithSkipped(t *testing.T) {
 	// /s6-it-check, unlike /afsm, has no disclaimer.
 	if strings.Contains(got, "This command cannot be made completely accurate") {
 		t.Fatalf("Edit content should NOT contain AFSM disclaimer; got: %s", got)
+	}
+}
+
+// serveS6RosterTrackingProfileConcurrency mirrors serveS6RosterAndProfiles but
+// instruments the per-profile endpoint to record peak concurrent fetches. A
+// serial loop peaks at 1; a fanned-out implementation peaks above 1.
+func serveS6RosterTrackingProfileConcurrency(
+	t *testing.T,
+	roster utils.LiteRosterResponse,
+	profilesByUsername map[string]utils.ProfileResponse,
+	peak *int32,
+) {
+	t.Helper()
+	rosterBody, err := json.Marshal(roster)
+	if err != nil {
+		t.Fatalf("marshal roster: %v", err)
+	}
+	encodedProfiles := make(map[string][]byte, len(profilesByUsername))
+	for name, p := range profilesByUsername {
+		b, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal profile %q: %v", name, err)
+		}
+		encodedProfiles[name] = b
+	}
+	var inFlight int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/milpacs/position/search/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(rosterBody)
+		case strings.HasPrefix(r.URL.Path, "/milpacs/profile/username/"):
+			cur := atomic.AddInt32(&inFlight, 1)
+			for {
+				old := atomic.LoadInt32(peak)
+				if cur <= old || atomic.CompareAndSwapInt32(peak, old, cur) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&inFlight, -1)
+
+			name := strings.TrimPrefix(r.URL.Path, "/milpacs/profile/username/")
+			body, ok := encodedProfiles[name]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+}
+
+func TestRunS6ITCheck_FetchesConcurrently(t *testing.T) {
+	// evaluateS6Member fetches the milpac for every roster entry up front, so
+	// four members force four fetches. A serial loop peaks at one in-flight
+	// fetch; the fanned-out implementation peaks above one.
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{}}
+	profiles := map[string]utils.ProfileResponse{}
+	for _, id := range []string{"1", "2", "3", "4"} {
+		name := "Member." + id
+		m := utils.LiteProfileResponse{
+			User:       utils.User{Username: name},
+			UniformUrl: "https://7cav.us/data/roster_uniforms/0/" + id + ".jpg",
+		}
+		roster.LiteProfiles[id] = m
+		profiles[name] = utils.ProfileResponse{
+			User: m.User, UniformUrl: m.UniformUrl,
+			Primary: utils.Position{PositionTitle: "Trooper 3/2/A/1-7"},
+		}
+	}
+
+	var peak int32
+	serveS6RosterTrackingProfileConcurrency(t, roster, profiles, &peak)
+
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction()
+
+	runS6ITCheck(f, i)
+
+	if got := atomic.LoadInt32(&peak); got < 2 {
+		t.Fatalf("expected concurrent milpac fetches (peak >= 2), got peak %d — fetches ran serially", got)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-resty/resty/v2 v2.17.2
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	golang.org/x/sync v0.20.0
 )
 
 require filippo.io/edwards25519 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
 golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
Closes #86.

## What
Fan the per-member milpac fetches in `/afsm` and `/s6-it-check` out concurrently with `golang.org/x/sync/errgroup` (`SetLimit(10)`) instead of the serial loop. Wall-clock drops from the serial sum (~60-70s for a large department) to roughly one fetch latency (~2s).

## How
- `runAFSM` / `runS6ITCheck`: snapshot the roster map into a slice, spawn one `g.Go` closure per member, collect results + errors into per-index slots, then iterate slots to build `eligibleMembers` + `skippedCount`.
- Closures never return an error to the group — per-member failures are collected per-slot and skipped-and-Sentry-reported afterward, preserving PR #83 semantics.
- Context timeout dropped 5min → 60s in both commands; the interim cross-reference comments removed.
- `golang.org/x/sync` promoted to a direct dependency (was already in the module graph at v0.20.0).

## Acceptance criteria
- [x] `/afsm` and `/s6-it-check` return in ~seconds (fan-out)
- [x] Timeout back to 60s in both; #83 cross-ref comments removed
- [x] Skip-and-Sentry per-member error semantics preserved
- [x] `sort.Slice` stability preserved (unchanged)
- [x] AFSM disclaimer preserved (unchanged)
- [x] Existing PR #87/#88 integration tests pass unmodified

## Tests
New behavioral tests (`TestRunAFSM_FetchesConcurrently`, `TestRunS6ITCheck_FetchesConcurrently`) assert peak concurrent fetches > 1 via an instrumented httptest profile endpoint — a serial loop peaks at 1. Verified clean under `go test -race`. Full CI gate (lint + coverage floors + build) passes locally.

## Manual review gate
Smoke test on the test guild still recommended — CI cannot exercise the live Discord gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)