### PR TITLE
test(commands): cover /apps_beta_deploy Pattern D conversion (#111)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
 github.com/7cav/cavbot2/utils	46
-github.com/7cav/cavbot2/commands	36
+github.com/7cav/cavbot2/commands	41
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/commands/apps_deployer.go
+++ b/commands/apps_deployer.go
@@ -3,10 +3,11 @@ package commands
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/7cav/cavbot2/utils"
-	"github.com/bwmarrin/discordgo"
 	"os"
 	"strings"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
 )
 
 func AppsBetaDeploy() Command {
@@ -24,28 +25,33 @@ func AppsBetaDeploy() Command {
 			},
 		},
 
-		Handler: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-			utils.Info("Apps Beta Deployer called", "command", "AppsBetaDeploy", "username", i.Member.User.Username, "discord_id", i.Member.User.ID)
-			switch i.Type {
-			case discordgo.InteractionApplicationCommand:
-				handleInitialCommand(s, i)
-			case discordgo.InteractionMessageComponent:
-				handleComponentInteraction(s, i)
-			}
-
-		},
+		Handler: handleAppsBetaDeploy,
 	}
 }
 
-func handleInitialCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	utils.Info("Initial command handler called", "command", "Milpac")
+func handleAppsBetaDeploy(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	runAppsBetaDeploy(utils.NewSessionResponder(s), i)
+}
+
+func runAppsBetaDeploy(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
+	utils.Info("Apps Beta Deployer called", "command", "AppsBetaDeploy", "username", i.Member.User.Username, "discord_id", i.Member.User.ID)
+	switch i.Type {
+	case discordgo.InteractionApplicationCommand:
+		runAppsBetaInitialCommand(r, i)
+	case discordgo.InteractionMessageComponent:
+		runAppsBetaComponentInteraction(r, i)
+	}
+}
+
+func runAppsBetaInitialCommand(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
+	utils.Info("Initial command handler called", "command", "AppsBetaDeploy")
 	branch := i.ApplicationCommandData().Options[0].StringValue()
 	if err := utils.HandleValidateBranchName(branch); err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Invalid branch name: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Invalid branch name: %v", err))
 		return
 	}
 	if len(fmt.Sprintf("apps_beta_deploy::confirm::%s", branch)) > 100 {
-		utils.HandleError(utils.NewSessionResponder(s), i, "❌ branch name exceeds Discord's limit")
+		utils.HandleError(r, i, "❌ branch name exceeds Discord's limit")
 		return
 	}
 	confirmButton := discordgo.Button{
@@ -64,7 +70,7 @@ func handleInitialCommand(s *discordgo.Session, i *discordgo.InteractionCreate) 
 			cancelButton,
 		},
 	}
-	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: fmt.Sprintf("⚠️ Are you sure you want to deploy branch `%s` to apps-beta?", branch),
@@ -75,23 +81,23 @@ func handleInitialCommand(s *discordgo.Session, i *discordgo.InteractionCreate) 
 		},
 	})
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to respond to initial command: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to respond to initial command: %v", err))
 		return
 	}
 }
 
-func handleComponentInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func runAppsBetaComponentInteraction(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
 	utils.Info("Component interaction received")
 	customID := i.MessageComponentData().CustomID
 	parts := strings.Split(customID, "::")
 	if len(parts) != 3 {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Invalid custom ID format: expected 3 parts, got %d parts: %v", len(parts), parts))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Invalid custom ID format: expected 3 parts, got %d parts: %v", len(parts), parts))
 		return
 	}
 	action, branch := parts[1], parts[2]
 
 	if action == "cancel" {
-		err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
 			Data: &discordgo.InteractionResponseData{
 				Content:    fmt.Sprintf("❌ Deployment cancelled for branch `%s`", branch),
@@ -99,12 +105,12 @@ func handleComponentInteraction(s *discordgo.Session, i *discordgo.InteractionCr
 			},
 		})
 		if err != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Error responding to cancel interaction: %v", err))
+			utils.HandleError(r, i, fmt.Sprintf("❌ Error responding to cancel interaction: %v", err))
 			return
 		}
 		return
 	}
-	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
 			Content:    "✅ Deployment initiated, please wait...",
@@ -112,27 +118,27 @@ func handleComponentInteraction(s *discordgo.Session, i *discordgo.InteractionCr
 		},
 	})
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to update initial message: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to update initial message: %v", err))
 		return
 	}
 	encodedPrivateKey := os.Getenv("GITHUB_APP_KEY")
 	if encodedPrivateKey == "" {
-		utils.HandleError(utils.NewSessionResponder(s), i, "❌ GitHub App key not configured")
+		utils.HandleError(r, i, "❌ GitHub App key not configured")
 		return
 	}
 	privateKeyPEM, err := base64.StdEncoding.DecodeString(encodedPrivateKey)
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to decode private key: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to decode private key: %v", err))
 		return
 	}
 	clientID := os.Getenv("GITHUB_APP_CLIENT_ID")
 	if clientID == "" {
-		utils.HandleError(utils.NewSessionResponder(s), i, "❌ GitHub App client ID not configured")
+		utils.HandleError(r, i, "❌ GitHub App client ID not configured")
 		return
 	}
 	token, err := utils.GithubAuth(clientID, privateKeyPEM)
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to authenticate with GitHub: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to authenticate with GitHub: %v", err))
 		return
 	}
 	owner := "7cav"
@@ -141,24 +147,23 @@ func handleComponentInteraction(s *discordgo.Session, i *discordgo.InteractionCr
 	ref := "main"
 	err = utils.CheckGithubBranchExists(branch, token, owner, repo)
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Branch does not exist: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Branch does not exist: %v", err))
 		return
 	}
 	err = utils.TriggerGithubDeployment(branch, token, owner, repo, workflow, ref)
 	var response string
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to trigger Apps Beta deployment: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to trigger Apps Beta deployment: %v", err))
 		return
 	} else {
 		utils.Info("Deployment triggered successfully", "command", "AppsBetaDeploy")
 		response = fmt.Sprintf("✅ Apps Beta deployment started for branch `%s` by <@%s> \nCheck status at: https://github.com/7cav/adr/actions/workflows/dev_deploy.yml", branch, i.Member.User.ID)
 	}
 
-	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+	if err = r.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 		Content: response,
-	})
-	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Error sending interaction response: %v", err))
+	}); err != nil {
+		utils.HandleError(r, i, fmt.Sprintf("❌ Error sending interaction response: %v", err))
 		return
 	}
 	utils.Info("✨ Done!", "command", "AppsBetaDeploy")

--- a/commands/apps_deployer_test.go
+++ b/commands/apps_deployer_test.go
@@ -1,0 +1,250 @@
+package commands
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+// testGithubPEM generates an RSA private key and returns it base64-encoded the
+// way GITHUB_APP_KEY ships in the environment (PEM bytes, base64-wrapped).
+// GithubAuth parses the decoded PEM with jwt.ParseRSAPrivateKeyFromPEM, so the
+// key must be a real, parseable RSA key.
+func testGithubPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return base64.StdEncoding.EncodeToString(pemBytes)
+}
+
+// setGithubEnv wires the env vars runAppsBetaComponentInteraction reads, with a
+// valid PEM, restoring prior values on cleanup.
+func setGithubEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("GITHUB_APP_KEY", testGithubPEM(t))
+	t.Setenv("GITHUB_APP_CLIENT_ID", "Iv1.testclientid")
+}
+
+// githubMux is a configurable fake GitHub Apps API. Each phase can be made to
+// fail by status code; the happy path returns the canonical success codes.
+type githubMux struct {
+	installStatus  int // GET /app/installations           (want 200)
+	tokenStatus    int // POST .../access_tokens            (want 201)
+	branchStatus   int // GET .../branches/<branch>         (want 200)
+	dispatchStatus int // POST .../dispatches               (want 204)
+}
+
+func (g githubMux) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	or := func(v, def int) int {
+		if v == 0 {
+			return def
+		}
+		return v
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/app/installations":
+			st := or(g.installStatus, http.StatusOK)
+			w.WriteHeader(st)
+			if st == http.StatusOK {
+				_, _ = w.Write([]byte(`[{"id": 42}]`))
+			}
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/access_tokens"):
+			st := or(g.tokenStatus, http.StatusCreated)
+			w.WriteHeader(st)
+			if st == http.StatusCreated {
+				_, _ = w.Write([]byte(`{"token": "ghs_testtoken"}`))
+			}
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
+			w.WriteHeader(or(g.branchStatus, http.StatusOK))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/dispatches"):
+			w.WriteHeader(or(g.dispatchStatus, http.StatusNoContent))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetGithubBaseURLForTest(srv.URL))
+	return srv
+}
+
+// findRespond returns the first recorded InteractionRespond call, or fails.
+func findRespond(t *testing.T, calls []recordedCall) recordedCall {
+	t.Helper()
+	for _, c := range calls {
+		if c.Method == "Respond" {
+			return c
+		}
+	}
+	t.Fatalf("no Respond call recorded; got %d calls", len(calls))
+	return recordedCall{}
+}
+
+func TestRunAppsBetaDeploy_SuccessfulDispatch(t *testing.T) {
+	setGithubEnv(t)
+	githubMux{}.server(t)
+
+	r := &fakeResponder{}
+	i := fakeMessageComponentInteraction("apps_beta_deploy::confirm::feature-x")
+	runAppsBetaDeploy(r, i)
+
+	calls := r.Calls()
+	// First call acknowledges via InteractionResponseUpdateMessage.
+	ack := findRespond(t, calls)
+	if ack.Response == nil || !strings.Contains(ack.Response.Data.Content, "Deployment initiated") {
+		t.Fatalf("expected acknowledge content, got %+v", ack.Response)
+	}
+	// Final success is delivered as a followup.
+	var followup *recordedCall
+	for idx := range calls {
+		if calls[idx].Method == "Followup" {
+			followup = &calls[idx]
+		}
+	}
+	if followup == nil {
+		t.Fatalf("expected a Followup call on success; calls=%+v", calls)
+	}
+	if !strings.Contains(followup.Params.Content, "deployment started for branch `feature-x`") {
+		t.Fatalf("unexpected followup content: %q", followup.Params.Content)
+	}
+}
+
+func TestRunAppsBetaDeploy_AuthFailure(t *testing.T) {
+	setGithubEnv(t)
+	// Installations lookup returns 500 -> GithubAuth fails.
+	githubMux{installStatus: http.StatusInternalServerError}.server(t)
+
+	r := &fakeResponder{}
+	i := fakeMessageComponentInteraction("apps_beta_deploy::confirm::feature-x")
+	runAppsBetaDeploy(r, i)
+
+	if !errorContent(r.Calls(), "Failed to authenticate with GitHub") {
+		t.Fatalf("expected auth-failure error; calls=%+v", r.Calls())
+	}
+	if hasFollowup(r.Calls()) {
+		t.Fatalf("auth failure must not send a success followup")
+	}
+}
+
+func TestRunAppsBetaDeploy_DispatchHTTPError(t *testing.T) {
+	setGithubEnv(t)
+	// Auth + branch-check succeed; dispatch returns a non-204.
+	githubMux{dispatchStatus: http.StatusUnprocessableEntity}.server(t)
+
+	r := &fakeResponder{}
+	i := fakeMessageComponentInteraction("apps_beta_deploy::confirm::feature-x")
+	runAppsBetaDeploy(r, i)
+
+	if !errorContent(r.Calls(), "Failed to trigger Apps Beta deployment") {
+		t.Fatalf("expected dispatch-failure error; calls=%+v", r.Calls())
+	}
+	if hasFollowup(r.Calls()) {
+		t.Fatalf("dispatch failure must not send a success followup")
+	}
+}
+
+func TestRunAppsBetaDeploy_CancelAcknowledge(t *testing.T) {
+	// Cancel path must acknowledge the component interaction and never touch
+	// GitHub. No env / server configured proves no GitHub call is made.
+	r := &fakeResponder{}
+	i := fakeMessageComponentInteraction("apps_beta_deploy::cancel::feature-x")
+	runAppsBetaDeploy(r, i)
+
+	calls := r.Calls()
+	ack := findRespond(t, calls)
+	if ack.Response.Type != discordgo.InteractionResponseUpdateMessage {
+		t.Fatalf("cancel must use InteractionResponseUpdateMessage, got %v", ack.Response.Type)
+	}
+	if !strings.Contains(ack.Response.Data.Content, "Deployment cancelled for branch `feature-x`") {
+		t.Fatalf("unexpected cancel content: %q", ack.Response.Data.Content)
+	}
+	if hasFollowup(calls) {
+		t.Fatalf("cancel must not send a followup")
+	}
+}
+
+func TestRunAppsBetaDeploy_BranchDoesNotExist(t *testing.T) {
+	setGithubEnv(t)
+	githubMux{branchStatus: http.StatusNotFound}.server(t)
+
+	r := &fakeResponder{}
+	i := fakeMessageComponentInteraction("apps_beta_deploy::confirm::ghost")
+	runAppsBetaDeploy(r, i)
+
+	if !errorContent(r.Calls(), "Branch does not exist") {
+		t.Fatalf("expected branch-missing error; calls=%+v", r.Calls())
+	}
+}
+
+func TestRunAppsBetaInitialCommand_InvalidBranch(t *testing.T) {
+	r := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("branch", "../evil"))
+	runAppsBetaDeploy(r, i)
+
+	if !errorContent(r.Calls(), "Invalid branch name") {
+		t.Fatalf("expected invalid-branch error; calls=%+v", r.Calls())
+	}
+}
+
+func TestRunAppsBetaInitialCommand_ConfirmPrompt(t *testing.T) {
+	r := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("branch", "feature-x"))
+	runAppsBetaDeploy(r, i)
+
+	resp := findRespond(t, r.Calls())
+	if !strings.Contains(resp.Response.Data.Content, "deploy branch `feature-x`") {
+		t.Fatalf("unexpected confirm content: %q", resp.Response.Data.Content)
+	}
+	if len(resp.Response.Data.Components) == 0 {
+		t.Fatalf("confirm prompt must include action-row buttons")
+	}
+}
+
+func TestRunAppsBetaComponent_MalformedCustomID(t *testing.T) {
+	r := &fakeResponder{}
+	i := fakeMessageComponentInteraction("apps_beta_deploy::confirm") // only 2 parts
+	runAppsBetaDeploy(r, i)
+
+	if !errorContent(r.Calls(), "Invalid custom ID format") {
+		t.Fatalf("expected malformed-id error; calls=%+v", r.Calls())
+	}
+}
+
+// errorContent reports whether any recorded call carries the given substring,
+// covering both the Respond (HandleError) and Edit retry paths.
+func errorContent(calls []recordedCall, want string) bool {
+	for _, c := range calls {
+		if c.Response != nil && c.Response.Data != nil && strings.Contains(c.Response.Data.Content, want) {
+			return true
+		}
+		if c.Edit != nil && c.Edit.Content != nil && strings.Contains(*c.Edit.Content, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFollowup(calls []recordedCall) bool {
+	for _, c := range calls {
+		if c.Method == "Followup" {
+			return true
+		}
+	}
+	return false
+}

--- a/commands/responder_test.go
+++ b/commands/responder_test.go
@@ -89,6 +89,25 @@ func fakeAppCommandInteraction(opts ...*discordgo.ApplicationCommandInteractionD
 	}
 }
 
+// fakeMessageComponentInteraction builds the minimum *InteractionCreate that a
+// component (button/select) handler reads: type, a MessageComponentInteractionData
+// carrying the CustomID, and a Member with a User. Mirrors
+// fakeAppCommandInteraction for the component-interaction (Pattern D) path.
+func fakeMessageComponentInteraction(customID string) *discordgo.InteractionCreate {
+	return &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionMessageComponent,
+			Data: discordgo.MessageComponentInteractionData{
+				CustomID:      customID,
+				ComponentType: discordgo.ButtonComponent,
+			},
+			Member: &discordgo.Member{
+				User: &discordgo.User{ID: "999", Username: "tester"},
+			},
+		},
+	}
+}
+
 func stringOption(name, value string) *discordgo.ApplicationCommandInteractionDataOption {
 	return &discordgo.ApplicationCommandInteractionDataOption{
 		Name:  name,

--- a/utils/github.go
+++ b/utils/github.go
@@ -10,6 +10,11 @@ import (
 	"time"
 )
 
+// ghAppsBaseURL is the GitHub REST API root. It's a package-level var (not a
+// const) so tests can redirect GithubAuth/TriggerGithubDeployment/
+// CheckGithubBranchExists at an httptest.Server via SetGithubBaseURLForTest.
+var ghAppsBaseURL = "https://api.github.com"
+
 func GithubAuth(clientID string, privateKey []byte) (string, error) {
 	now := time.Now()
 	jwtToken := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
@@ -40,7 +45,7 @@ func GithubAuth(clientID string, privateKey []byte) (string, error) {
 		SetContext(ctx).
 		SetHeader("Accept", "application/vnd.github+json").
 		SetHeader("Authorization", "Bearer "+signedToken).
-		Get("https://api.github.com/app/installations")
+		Get(ghAppsBaseURL + "/app/installations")
 
 	if err != nil {
 		return "", fmt.Errorf("failed to get installations: %w", err)
@@ -67,7 +72,7 @@ func GithubAuth(clientID string, privateKey []byte) (string, error) {
 		SetContext(ctx).
 		SetHeader("Accept", "application/vnd.github+json").
 		SetHeader("Authorization", "Bearer "+signedToken).
-		Post(fmt.Sprintf("https://api.github.com/app/installations/%s/access_tokens", installationID))
+		Post(fmt.Sprintf("%s/app/installations/%s/access_tokens", ghAppsBaseURL, installationID))
 
 	if err != nil {
 		return "", fmt.Errorf("failed to get installation jwtToken: %w", err)
@@ -107,7 +112,7 @@ func TriggerGithubDeployment(branch string, token string, owner string, repo str
 				"branch": branch,
 			},
 		}).
-		Post(fmt.Sprintf("https://api.github.com/repos/%s/%s/actions/workflows/%s/dispatches", owner, repo, workflow))
+		Post(fmt.Sprintf("%s/repos/%s/%s/actions/workflows/%s/dispatches", ghAppsBaseURL, owner, repo, workflow))
 
 	if err != nil {
 		return fmt.Errorf("failed to trigger github workflow: %w", err)
@@ -131,7 +136,7 @@ func CheckGithubBranchExists(branch, token, owner, repo string) error {
 		SetContext(ctx).
 		SetHeader("Accept", "application/vnd.github+json").
 		SetHeader("Authorization", "Bearer "+token).
-		Get(fmt.Sprintf("https://api.github.com/repos/%s/%s/branches/%s", owner, repo, branch))
+		Get(fmt.Sprintf("%s/repos/%s/%s/branches/%s", ghAppsBaseURL, owner, repo, branch))
 
 	if err != nil {
 		return fmt.Errorf("failed to check branch: %w", err)

--- a/utils/testapi.go
+++ b/utils/testapi.go
@@ -12,3 +12,15 @@ func SetAPIBaseURLForTest(url string) (restore func()) {
 	apiBaseURL = url
 	return func() { apiBaseURL = prev }
 }
+
+// SetGithubBaseURLForTest replaces the GitHub Apps API base URL and returns a
+// function that restores the previous value. Tests call it to redirect
+// GithubAuth / TriggerGithubDeployment / CheckGithubBranchExists at an
+// httptest.Server.
+//
+// Production code MUST NOT call this. The ForTest suffix is the review signal.
+func SetGithubBaseURLForTest(url string) (restore func()) {
+	prev := ghAppsBaseURL
+	ghAppsBaseURL = url
+	return func() { ghAppsBaseURL = prev }
+}


### PR DESCRIPTION
Closes #111.

Converts `/apps_beta_deploy` to the `handleX → runX(responder, i)` test harness (Pattern D — component interaction) and adds integration coverage.

## Changes
- `utils/github.go`: extract hardcoded base URL → package-level `var ghAppsBaseURL`; route `GithubAuth`/`TriggerGithubDeployment`/`CheckGithubBranchExists` through it (public signatures unchanged). **Unblocks #113.**
- `utils/testapi.go`: add `SetGithubBaseURLForTest` (mirrors `SetAPIBaseURLForTest`).
- `commands/apps_deployer.go`: `handleAppsBetaDeploy → runAppsBetaDeploy(r, i)`; update-message + followups flow through `utils.InteractionResponder` (no new interface method needed — Pattern D is just a different response Type).
- `commands/responder_test.go`: add `fakeMessageComponentInteraction` builder.
- `commands/apps_deployer_test.go` (new): 8 httptest-driven tests — dispatch success, GitHub Apps auth failure, dispatch HTTP error, component ack/cancel, branch-missing, invalid-branch, confirm-prompt, malformed custom-ID.
- `.github/scripts/check-coverage-floors.sh`: commands floor 36 → 41 (measured 41.7%).

## Test plan
- `golangci-lint run` clean, `go test ./... -cover` green, floor check green, `go build` OK, `go test ./commands/ -race` clean.

## Manual review gate
- Smoke test `/apps_beta_deploy` on the test guild (CI can't exercise the live Discord gateway / GitHub Apps dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)