### PR TITLE
fix(commands): survive panics in star citizen joiner scheduler loop (#119)

### DIFF
--- a/commands/star_citizen_joiners.go
+++ b/commands/star_citizen_joiners.go
@@ -203,20 +203,29 @@ func StartJoinerReportScheduler(s *discordgo.Session, guildID string) {
 // runJoinerReportSchedulerLoop is the body of the scheduler goroutine. Split
 // out for the testable seam on `now`; the loop itself never returns under
 // normal operation, so it's exercised end-to-end rather than unit-tested.
+//
+// Panic recovery is scoped to each per-fire execution (the inner func below),
+// NOT the outer loop. A panic in one report fire is captured to Sentry and the
+// loop survives to compute the next weekly fire — matching the ordinary-error
+// continuity policy (no in-cycle retry; next Sunday is the retry). If recover
+// were at the loop scope instead, a single panic would unwind the for and
+// permanently disable the weekly report until process restart (issue #119).
 func runJoinerReportSchedulerLoop(s joinerReportSession, guildID string, now func() time.Time) {
-	defer utils.RecoverPanic("star-citizen-joiner-report")
 	for {
 		fire := nextJoinerReportFire(now())
 		utils.Info("Star Citizen joiner report scheduled",
 			"next_fire_utc", fire.Format(time.RFC3339))
 		time.Sleep(time.Until(fire))
-		// Anchor the rolling window to the scheduled fire time, not the
-		// wall clock at wakeup. Host suspend / GC delays would otherwise
-		// drift the cutoff forward across cycles and silently drop
-		// joiners who landed in the gap.
-		if err := runJoinerReport(s, guildID, fire); err != nil {
-			utils.CaptureError("Star Citizen joiner report failed", err,
-				"guild_id", guildID, "fire_utc", fire.Format(time.RFC3339))
-		}
+		func() {
+			defer utils.RecoverPanic("star-citizen-joiner-report")
+			// Anchor the rolling window to the scheduled fire time, not the
+			// wall clock at wakeup. Host suspend / GC delays would otherwise
+			// drift the cutoff forward across cycles and silently drop
+			// joiners who landed in the gap.
+			if err := runJoinerReport(s, guildID, fire); err != nil {
+				utils.CaptureError("Star Citizen joiner report failed", err,
+					"guild_id", guildID, "fire_utc", fire.Format(time.RFC3339))
+			}
+		}()
 	}
 }

--- a/commands/star_citizen_joiners_test.go
+++ b/commands/star_citizen_joiners_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -415,49 +416,123 @@ func TestMustWeeklyFireTime_BoundsAndHappyPath(t *testing.T) {
 }
 
 // panickingFakeSession panics on the first GuildMembers call, used to
-// exercise the scheduler loop's defer-recover.
+// exercise the scheduler loop's per-fire defer-recover. Subsequent calls
+// return cleanly so a test can assert the loop reached a later iteration.
 type panickingFakeSession struct {
-	called bool
+	mu    sync.Mutex
+	calls int
 }
 
 func (p *panickingFakeSession) GuildMembers(string, string, int, ...discordgo.RequestOption) ([]*discordgo.Member, error) {
-	p.called = true
-	panic("simulated discord-side panic")
+	p.mu.Lock()
+	p.calls++
+	n := p.calls
+	p.mu.Unlock()
+	if n == 1 {
+		panic("simulated discord-side panic")
+	}
+	return nil, nil
+}
+
+func (p *panickingFakeSession) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
 }
 
 func (p *panickingFakeSession) UserChannelCreate(string, ...discordgo.RequestOption) (*discordgo.Channel, error) {
-	panic("unreachable: panic should have fired before DM")
+	return &discordgo.Channel{ID: "dm"}, nil
 }
 
 func (p *panickingFakeSession) ChannelMessageSend(string, string, ...discordgo.RequestOption) (*discordgo.Message, error) {
-	panic("unreachable: panic should have fired before DM")
+	return &discordgo.Message{ID: "m"}, nil
 }
 
-// TestRunJoinerReportSchedulerLoop_PanicIsRecovered verifies the
-// defer utils.RecoverPanic at the top of the loop actually catches a
-// runJoinerReport panic so the goroutine exits cleanly rather than
-// crashing the process. Uses a year-old "now" so the computed fire time
-// is far in the past, making time.Sleep(time.Until(fire)) return
-// immediately.
+// TestRunJoinerReportSchedulerLoop_PanicIsRecovered verifies the per-fire
+// defer utils.RecoverPanic catches a runJoinerReport panic WITHOUT exiting
+// the scheduler loop: the outer for survives and proceeds to the next
+// weekly fire.
+//
+// Determinism: the injected clock returns a far-past time on the first
+// call so the first time.Sleep returns immediately and the panicking fire
+// runs; on the second call it returns a far-FUTURE time so the second
+// time.Sleep blocks well past the test timeout. The test waits for the
+// second-iteration signal (the clock's 2nd invocation), proving the loop
+// advanced past the panic, then returns — leaving the goroutine parked in
+// its long sleep (harmless; no resources held, no process crash).
 func TestRunJoinerReportSchedulerLoop_PanicIsRecovered(t *testing.T) {
 	fake := &panickingFakeSession{}
-	pastNow := func() time.Time {
-		return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	var nowMu sync.Mutex
+	nowCalls := 0
+	secondIter := make(chan struct{})
+	now := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		nowCalls++
+		switch nowCalls {
+		case 1:
+			// Far past → first fire is overdue → sleep returns immediately.
+			return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		case 2:
+			// Reaching here proves the loop survived the panic and looped
+			// back. Return a far-future time so the second sleep parks the
+			// goroutine well beyond the test deadline.
+			close(secondIter)
+			return time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)
+		default:
+			return time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)
+		}
 	}
 
-	done := make(chan struct{})
-	go func() {
-		runJoinerReportSchedulerLoop(fake, "g", pastNow)
-		close(done)
-	}()
+	go runJoinerReportSchedulerLoop(fake, "g", now)
 
 	select {
-	case <-done:
-		// Goroutine exited — recover fired, loop unwound, no process crash.
+	case <-secondIter:
+		// Loop reached its second iteration after recovering the panic.
 	case <-time.After(2 * time.Second):
-		t.Fatalf("scheduler loop did not exit within 2s after panic — recover missing?")
+		t.Fatalf("scheduler loop did not reach a 2nd iteration within 2s — panic killed the loop instead of being recovered per-fire")
 	}
-	if !fake.called {
+	if fake.callCount() < 1 {
 		t.Errorf("fake session was never invoked — loop body did not run")
+	}
+}
+
+// TestRunJoinerReportSchedulerLoop_OrdinaryErrorContinues verifies a
+// non-panic report error (e.g. a Discord API error) is captured/logged but
+// does not stop the loop: the scheduler proceeds to the next fire without
+// an immediate in-cycle retry.
+func TestRunJoinerReportSchedulerLoop_OrdinaryErrorContinues(t *testing.T) {
+	fake := &fakeJoinerSession{guildMembersErr: errors.New("rate-limited")}
+
+	var nowMu sync.Mutex
+	nowCalls := 0
+	secondIter := make(chan struct{})
+	now := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		nowCalls++
+		switch nowCalls {
+		case 1:
+			return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		case 2:
+			close(secondIter)
+			return time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)
+		default:
+			return time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)
+		}
+	}
+
+	go runJoinerReportSchedulerLoop(fake, "g", now)
+
+	select {
+	case <-secondIter:
+		// Loop advanced to the next fire after the ordinary error.
+	case <-time.After(2 * time.Second):
+		t.Fatalf("scheduler loop did not reach a 2nd iteration within 2s after an ordinary error")
+	}
+	// One fire = one GuildMembers attempt: no immediate in-cycle retry.
+	if got := len(fake.pageCalls); got != 1 {
+		t.Errorf("expected exactly 1 GuildMembers call (no in-cycle retry), got %d", got)
 	}
 }


### PR DESCRIPTION
Closes #119.

Triage ratified **Option B**: a panic in one weekly report fire should be a failed run, not permanent scheduler shutdown until process restart.

## Changes
- `commands/star_citizen_joiners.go`: move `defer utils.RecoverPanic("star-citizen-joiner-report")` from the outer loop scope into a per-fire inner `func(){…}()` wrapping the `runJoinerReport` call + `CaptureError` handling. The outer `for` now survives a recovered panic and proceeds to the next weekly fire. Ordinary-error behavior (capture/log, no in-cycle retry, next Sunday is the retry) preserved exactly.
- `commands/star_citizen_joiners_test.go`: rework `TestRunJoinerReportSchedulerLoop_PanicIsRecovered` to prove survival **beyond** the first iteration; add `TestRunJoinerReportSchedulerLoop_OrdinaryErrorContinues`. Deterministic via injected `now func()` (far-past first call → immediate fire; far-future second → parks past test deadline). `-race`-safe.

## Test plan
- RED confirmed before fix (panic test failed under old outer-defer). `golangci-lint` clean, `go test ./...` green, floors held (no floor touched), `go test ./commands/ -race` ok, `go build` OK.

## Manual review gate
- N/A for a slash command (background scheduler change). Optionally verify a forced-panic fire in a dev run still schedules the next fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)