### PR TITLE
fix(commands): guard /awol On LOA column against unhealthy cache (#96)

### DIFF
--- a/commands/awol.go
+++ b/commands/awol.go
@@ -23,13 +23,22 @@ const (
 	awolThresholdDays = 8
 )
 
-// loaCacheReader is the minimal LOA-cache surface /awol (and /loa) consume.
-// Production wires *utils.LOACache (GlobalLOACache); tests substitute a fake
-// with canned entries so the handler stays deterministic without touching the
-// process-global singleton.
+// loaCacheUnavailableFooter is the warning appended to /awol output (#96) when
+// the LOA cache is unhealthy. Styled after loaUnavailableMessage; the On LOA
+// column is rendered "unknown" rather than a misleading "false" in this state.
+const loaCacheUnavailableFooter = "⚠️ LOA cache unavailable; On LOA column may be stale."
+
+// loaCacheReader is the minimal LOA-cache surface /awol consumes. Production
+// wires *utils.LOACache (GlobalLOACache); tests substitute a fake with canned
+// entries and a forced health verdict so the handler stays deterministic
+// without touching the process-global singleton. IsHealthy gates whether the
+// per-member On LOA column can be trusted (#96): when the cache is stale,
+// IsOnLOA/GetEntry silently return all-clear, so the column is rendered as
+// "unknown" rather than a misleading "false".
 type loaCacheReader interface {
 	IsOnLOA(username string) bool
 	GetEntry(username string) (utils.LOAEntry, bool)
+	IsHealthy(maxAge time.Duration) (bool, time.Time)
 }
 
 type AwolUser struct {
@@ -90,6 +99,23 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 		return
 	}
 
+	// #96: probe cache health once per invocation. When unhealthy, IsOnLOA
+	// returns false for everyone silently, so the On LOA column would lie. We do
+	// NOT abort — /awol's primary signal (lastForumPostDate) is independent — but
+	// render the column as "unknown" and warn. No Sentry capture: operational
+	// degradation, not an internal error (ADR 0001).
+	cacheHealthy, lastRefresh := cache.IsHealthy(loaCacheMaxAge)
+	if !cacheHealthy {
+		utils.Debug("AWOL served with unhealthy LOA cache",
+			"command", "Awol",
+			"username", i.Member.User.Username,
+			"discord_id", i.Member.User.ID,
+			"last_success", lastRefresh,
+			"served_at", now,
+			"staleness", now.Sub(lastRefresh),
+		)
+	}
+
 	roster, err := utils.GetRosterByFuzzyPositionSearch(ctx, position)
 	if err != nil {
 		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to fetch roster: %v", err))
@@ -142,21 +168,25 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 	}
 
 	loaCount := 0
-	for _, u := range awolUsers {
-		if u.OnLOA {
-			loaCount++
+	if cacheHealthy {
+		for _, u := range awolUsers {
+			if u.OnLOA {
+				loaCount++
+			}
 		}
 	}
 
 	var chunks []string
 	currentChunk := ""
 	for _, user := range awolUsers {
-		loaTag := ""
-		if user.OnLOA {
-			// NOTE: #96 — when the LOA cache is empty/unhealthy, every
-			// IsOnLOA returns false and this branch silently never fires,
-			// so the "On LOA" column reports incorrect (all-clear) status.
-			// Tracked separately; not in scope for #112.
+		// #96: only trust the cache lookup when it's healthy. When unhealthy,
+		// mark every row "On LOA: unknown" and suppress the [LOA] decoration so
+		// the column never silently reads all-clear.
+		var loaTag string
+		switch {
+		case !cacheHealthy:
+			loaTag = "On LOA: unknown — "
+		case user.OnLOA:
 			if entry, ok := cache.GetEntry(user.Username); ok && entry.ThreadID != 0 {
 				loaTag = fmt.Sprintf("**[[LOA]](https://7cav.us/threads/%d/)** ", entry.ThreadID)
 			} else {
@@ -182,14 +212,21 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 	utils.Info("Debug chunks info", "chunks_length", len(chunks), "max_embeds", maxEmbedsPerMsg)
 	if len(chunks) > maxEmbedsPerMsg {
 		utils.Info("⚠️ Too many AWOL users for embeds, falling back to file upload", "count", len(awolUsers))
-		sendAwolFile(r, i, awolUsers, position, forceFile, now)
+		sendAwolFile(r, i, awolUsers, position, forceFile, cacheHealthy, now)
 		utils.Info("✨ Done!", "command", "Awol")
 		return
 	} else if forceFile {
 		utils.Info("⚠️ Force file output enabled, falling back to embeds", "count", len(awolUsers))
-		sendAwolFile(r, i, awolUsers, position, forceFile, now)
+		sendAwolFile(r, i, awolUsers, position, forceFile, cacheHealthy, now)
 		utils.Info("✨ Done!", "command", "Awol")
 		return
+	}
+
+	// #96: when the cache is unhealthy the loaCount is meaningless, so report
+	// the warning instead of a concrete "(N on LOA)" tally.
+	footerText := fmt.Sprintf("Total AWOL: %d (%d on LOA)", len(awolUsers), loaCount)
+	if !cacheHealthy {
+		footerText = fmt.Sprintf("Total AWOL: %d — %s", len(awolUsers), loaCacheUnavailableFooter)
 	}
 
 	var embeds []*discordgo.MessageEmbed
@@ -199,7 +236,7 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 			Description: chunk,
 			Color:       0xfbcc29,
 			Footer: &discordgo.MessageEmbedFooter{
-				Text: fmt.Sprintf("Total AWOL: %d (%d on LOA)", len(awolUsers), loaCount),
+				Text: footerText,
 			},
 			Timestamp: now.Format(time.RFC3339),
 		}
@@ -217,15 +254,24 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 	utils.Info("✨ Done!", "command", "Awol")
 }
 
-func sendAwolFile(r utils.InteractionResponder, i *discordgo.InteractionCreate, awolUsers []AwolUser, position string, forceFile bool, now time.Time) {
+func sendAwolFile(r utils.InteractionResponder, i *discordgo.InteractionCreate, awolUsers []AwolUser, position string, forceFile, cacheHealthy bool, now time.Time) {
 	var content strings.Builder
 	_, _ = fmt.Fprintf(&content, "AWOL Report for %s\nGenerated: %s\n\n",
 		position,
 		now.Format("2006-01-02 15:04:05"))
+	if !cacheHealthy {
+		// #96: surface the cache-unavailable warning in the file too.
+		_, _ = fmt.Fprintf(&content, "%s\n\n", loaCacheUnavailableFooter)
+	}
 
 	for _, user := range awolUsers {
+		// #96: only trust IsOnLOA when the cache is healthy; otherwise the
+		// column is unknown, not all-clear.
 		loaTag := ""
-		if user.OnLOA {
+		switch {
+		case !cacheHealthy:
+			loaTag = " (On LOA: unknown)"
+		case user.OnLOA:
 			loaTag = " [LOA]"
 		}
 		_, _ = fmt.Fprintf(&content, "%s%s - %s\nMilpac: %s\n\n",

--- a/commands/awol_test.go
+++ b/commands/awol_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -54,8 +55,13 @@ func serveAwolRoster(t *testing.T, roster utils.LiteRosterResponse, rosterStatus
 // entries are keyed by lowercased username (matches the production cache's
 // case-folding); IsOnLOA returns true iff an entry exists, decoupling the test
 // from time.Now since the handler's "now" is already injected separately.
+// healthy/lastRefresh drive the IsHealthy staleness guard; the zero value is
+// unhealthy, so existing tests that want the original behavior should construct
+// via healthyCache.
 type fakeLOACache struct {
-	entries map[string]utils.LOAEntry
+	entries     map[string]utils.LOAEntry
+	healthy     bool
+	lastRefresh time.Time
 }
 
 func (f *fakeLOACache) GetEntry(username string) (utils.LOAEntry, bool) {
@@ -66,6 +72,16 @@ func (f *fakeLOACache) GetEntry(username string) (utils.LOAEntry, bool) {
 func (f *fakeLOACache) IsOnLOA(username string) bool {
 	_, ok := f.entries[strings.ToLower(username)]
 	return ok
+}
+
+func (f *fakeLOACache) IsHealthy(_ time.Duration) (bool, time.Time) {
+	return f.healthy, f.lastRefresh
+}
+
+// healthyCache builds a healthy fakeLOACache from the given entries (keyed by
+// lowercased username), with lastRefresh pinned at awolRefDate.
+func healthyCache(entries map[string]utils.LOAEntry) *fakeLOACache {
+	return &fakeLOACache{entries: entries, healthy: true, lastRefresh: awolRefDate}
 }
 
 func boolOption(name string, value bool) *discordgo.ApplicationCommandInteractionDataOption {
@@ -98,7 +114,7 @@ func TestRunAwol_SmallResultRendersEmbedChunks(t *testing.T) {
 	serveAwolRoster(t, roster, http.StatusOK)
 
 	f := &fakeResponder{}
-	cache := &fakeLOACache{}
+	cache := healthyCache(nil)
 	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
 
 	runAwol(f, cache, awolRefDate, i)
@@ -148,7 +164,7 @@ func TestRunAwol_LargeResultFallsBackToFile(t *testing.T) {
 	serveAwolRoster(t, roster, http.StatusOK)
 
 	f := &fakeResponder{}
-	cache := &fakeLOACache{}
+	cache := healthyCache(nil)
 	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
 
 	runAwol(f, cache, awolRefDate, i)
@@ -191,7 +207,7 @@ func TestRunAwol_ForceFileOutputWithSmallResult(t *testing.T) {
 	serveAwolRoster(t, roster, http.StatusOK)
 
 	f := &fakeResponder{}
-	cache := &fakeLOACache{}
+	cache := healthyCache(nil)
 	i := fakeAppCommandInteraction(
 		stringOption("position", "1-7"),
 		boolOption("force_file_output", true),
@@ -224,7 +240,7 @@ func TestRunAwol_EmptyRosterSurfacesFormatHint(t *testing.T) {
 	// simulates "already acknowledged" so its Edit fallback fires with the
 	// empty-roster format-hint message.
 	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
-	cache := &fakeLOACache{}
+	cache := healthyCache(nil)
 	i := fakeAppCommandInteraction(stringOption("position", "Q/Z/9-9"))
 
 	runAwol(f, cache, awolRefDate, i)
@@ -250,7 +266,7 @@ func TestRunAwol_RosterFetch500SurfacesError(t *testing.T) {
 	serveAwolRoster(t, utils.LiteRosterResponse{}, http.StatusInternalServerError)
 
 	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
-	cache := &fakeLOACache{}
+	cache := healthyCache(nil)
 	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
 
 	runAwol(f, cache, awolRefDate, i)
@@ -280,16 +296,14 @@ func TestRunAwol_OnLOAAnnotationRenders(t *testing.T) {
 	}
 	serveAwolRoster(t, roster, http.StatusOK)
 
-	cache := &fakeLOACache{
-		entries: map[string]utils.LOAEntry{
-			"trooper.a": {
-				Username:  "Trooper.A",
-				StartDate: mustParseAwolDate("2026-04-01 00:00:00"),
-				EndDate:   mustParseAwolDate("2026-06-01 00:00:00"),
-				ThreadID:  4242,
-			},
+	cache := healthyCache(map[string]utils.LOAEntry{
+		"trooper.a": {
+			Username:  "Trooper.A",
+			StartDate: mustParseAwolDate("2026-04-01 00:00:00"),
+			EndDate:   mustParseAwolDate("2026-06-01 00:00:00"),
+			ThreadID:  4242,
 		},
-	}
+	})
 	f := &fakeResponder{}
 	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
 
@@ -316,5 +330,115 @@ func TestRunAwol_OnLOAAnnotationRenders(t *testing.T) {
 			got = footer.Text
 		}
 		t.Fatalf("footer should report 1 on LOA; got %q", got)
+	}
+}
+
+// unhealthyCache builds an unhealthy fakeLOACache: entries may exist (and the
+// roster member may even have a "real" LOA) but the health probe reports stale,
+// so the handler must NOT trust IsOnLOA/GetEntry and must render "unknown".
+func unhealthyCache(entries map[string]utils.LOAEntry, lastRefresh time.Time) *fakeLOACache {
+	return &fakeLOACache{entries: entries, healthy: false, lastRefresh: lastRefresh}
+}
+
+func TestRunAwol_UnhealthyCacheRendersUnknownColumn(t *testing.T) {
+	// Two AWOL members. Trooper.A even has a (stale) cache entry with a thread,
+	// but because the cache is unhealthy the handler must treat On LOA as unknown
+	// for EVERY row: no [LOA]/[[LOA]] decoration, no loaCount, plus a footer
+	// warning line.
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+			"200": awolMember("Trooper.B", "200", "2026-04-01 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	cache := unhealthyCache(map[string]utils.LOAEntry{
+		"trooper.a": {
+			Username:  "Trooper.A",
+			StartDate: mustParseAwolDate("2026-04-01 00:00:00"),
+			EndDate:   mustParseAwolDate("2026-06-01 00:00:00"),
+			ThreadID:  4242,
+		},
+	}, awolRefDate.Add(-45*time.Minute))
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runAwol(f, cache, awolRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (placeholder + Edit), got %d: %+v", len(calls), calls)
+	}
+	edit := calls[1].Edit
+	if edit.Embeds == nil || len(*edit.Embeds) == 0 {
+		t.Fatalf("expected embeds even on unhealthy path; got Embeds=%v", edit.Embeds)
+	}
+	desc := (*edit.Embeds)[0].Description
+	// Members still listed.
+	for _, want := range []string{"Trooper.A", "Trooper.B"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("embed description missing %q.\nGot:\n%s", want, desc)
+		}
+	}
+	// No LOA decoration leaks through on the unhealthy path.
+	if strings.Contains(desc, "[LOA]") || strings.Contains(desc, "threads/4242") {
+		t.Fatalf("expected no LOA decoration on unhealthy path.\nGot:\n%s", desc)
+	}
+	// An "unknown" marker is present.
+	if !strings.Contains(desc, "On LOA: unknown") {
+		t.Fatalf("expected per-row 'On LOA: unknown' marker.\nGot:\n%s", desc)
+	}
+	footer := (*edit.Embeds)[0].Footer
+	if footer == nil {
+		t.Fatalf("expected footer on unhealthy path")
+	}
+	// loaCount aggregate must NOT report a concrete number.
+	if strings.Contains(footer.Text, "on LOA)") {
+		t.Fatalf("footer must not report a concrete loaCount on unhealthy path; got %q", footer.Text)
+	}
+	if !strings.Contains(footer.Text, "LOA cache unavailable") {
+		t.Fatalf("footer should carry cache-unavailable warning; got %q", footer.Text)
+	}
+}
+
+func TestRunAwol_UnhealthyCacheFileOutputCarriesWarning(t *testing.T) {
+	// Force the file path; the unhealthy cache must surface the warning and an
+	// unknown marker in the generated report rather than silent [LOA]/all-clear.
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	cache := unhealthyCache(map[string]utils.LOAEntry{
+		"trooper.a": {Username: "Trooper.A", ThreadID: 4242},
+	}, time.Time{})
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(
+		stringOption("position", "1-7"),
+		boolOption("force_file_output", true),
+	)
+
+	runAwol(f, cache, awolRefDate, i)
+
+	edit := f.Calls()[1].Edit
+	if len(edit.Files) != 1 {
+		t.Fatalf("expected 1 file attachment, got %d", len(edit.Files))
+	}
+	raw, err := io.ReadAll(edit.Files[0].Reader)
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	body := string(raw)
+	if strings.Contains(body, "[LOA]") {
+		t.Fatalf("file must not carry [LOA] tag on unhealthy path.\nGot:\n%s", body)
+	}
+	if !strings.Contains(body, "LOA cache unavailable") {
+		t.Fatalf("file should carry cache-unavailable warning.\nGot:\n%s", body)
+	}
+	if !strings.Contains(body, "unknown") {
+		t.Fatalf("file should mark On LOA unknown.\nGot:\n%s", body)
 	}
 }

--- a/commands/loa.go
+++ b/commands/loa.go
@@ -23,6 +23,11 @@ type loaCacheView interface {
 	IsHealthy(maxAge time.Duration) (bool, time.Time)
 }
 
+// loaCacheMaxAge is the staleness threshold for the LOA cache health probe,
+// shared by /loa and /awol. 2× the 15-min refresh interval: one missed refresh
+// is tolerated, two consecutive misses mark the cache unhealthy.
+const loaCacheMaxAge = 30 * time.Minute
+
 // loaUnavailableMessage formats the user-facing string shown when GlobalLOACache
 // is unhealthy. lastRefresh is the cache's last successful refresh (zero == never);
 // now is passed in so callers can read time.Now() once and tests stay deterministic.
@@ -83,7 +88,6 @@ func runLoa(r utils.InteractionResponder, cache loaCacheView, now time.Time, i *
 		return
 	}
 
-	const loaCacheMaxAge = 30 * time.Minute // 2× the 15-min refresh interval
 	healthy, lastRefresh := cache.IsHealthy(loaCacheMaxAge)
 	if !healthy {
 		msg := loaUnavailableMessage(lastRefresh, now)


### PR DESCRIPTION
Closes #96.

**Option A** (ratified): when the LOA cache is unhealthy, `/awol` no longer silently renders `On LOA: false` for everyone — it marks the column unknown and warns, while keeping the rest of the (cache-independent) AWOL listing intact.

## Changes
- `commands/awol.go`: check `utils.GlobalLOACache.IsHealthy(loaCacheMaxAge)` once at handler entry (reused for render + log). On unhealthy: render every row `On LOA: unknown`, suppress `[LOA]` thread-link decoration, drop the `loaCount` aggregate, append footer `⚠️ LOA cache unavailable; On LOA column may be stale.` (embed + file outputs). Emits a `utils.Debug` line (`command/username/discord_id/last_success/served_at/staleness`). **No new Sentry capture** (operational degradation per ADR 0001). Healthy path byte-identical to before.
- `commands/loa.go`: hoist `loaCacheMaxAge` to package-level — single source of truth shared with `/awol`.
- `commands/awol_test.go`: healthy-path tests pinned to a healthy fake; two new unhealthy-branch tests.

Tri-state approach: command-scope `cacheHealthy bool` (no `*bool`/struct plumbing); `AwolUser.OnLOA` interpreted only when healthy.

## Test plan
- `golangci-lint` clean, `go test ./...` green, floors held, `go test ./commands/ -race` ok, `go build` OK.

## Manual review gate
- Smoke test `/awol` on the test guild under an unhealthy cache (CI can't exercise the live gateway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)