### PR TITLE
test(commands): cover /milpac Pattern A conversion (#104)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
 github.com/7cav/cavbot2/utils	56
-github.com/7cav/cavbot2/commands	41
+github.com/7cav/cavbot2/commands	50
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/commands/milpac.go
+++ b/commands/milpac.go
@@ -43,14 +43,25 @@ func Milpac() Command {
 }
 
 func handleMilpacCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	runMilpac(utils.NewSessionResponder(s), i)
+}
+
+// runMilpac is the Pattern A core: it takes a utils.InteractionResponder so
+// tests can substitute the discordgo session, and runs synchronously. The
+// previous goroutine'd processMilpacRequest was made inline — the interaction
+// dispatcher already wraps handlers in utils.RecoverPanic (see main.go), so the
+// background-goroutine boundary (and its own RecoverPanic) is no longer needed.
+func runMilpac(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
+	utils.Info("🚀 Starting Milpac", "command", "Milpac", "username", i.Member.User.Username, "discord_id", i.Member.User.ID)
+
+	err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: "Fetching Milpac data...",
 		},
 	})
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to respond to interaction: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to respond to interaction: %v", err))
 		return
 	}
 
@@ -60,25 +71,21 @@ func handleMilpacCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		optionMap[opt.Name] = opt
 	}
 
-	utils.Info("Milpac requested", "command", "Milpac", "username", i.Member.User.Username, "discord_id", i.Member.User.ID)
-	user := optionMap["user"].UserValue(s)
+	// UserValue(nil) resolves the option to a *User carrying just the ID — which
+	// is all this command consumes. Passing nil avoids needing a live session.
+	user := optionMap["user"].UserValue(nil)
 
-	go processMilpacRequest(s, i, user)
-}
-
-func processMilpacRequest(s *discordgo.Session, i *discordgo.InteractionCreate, user *discordgo.User) {
-	defer utils.RecoverPanic("milpac-bg")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	milpac, err := utils.GetMilpacByDiscordID(ctx, user.ID)
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to fetch milpac: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to fetch milpac: %v", err))
 		return
 	}
 	joinDate, err := time.Parse("2006-01-02", milpac.JoinDate)
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to parse join date: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to parse join date: %v", err))
 		return
 	}
 	formatJoinDate := joinDate.Format("02Jan2006")
@@ -88,7 +95,7 @@ func processMilpacRequest(s *discordgo.Session, i *discordgo.InteractionCreate, 
 		var err error
 		promotionDate, err = time.Parse("2006-01-02", milpac.PromotionDate)
 		if err != nil || promotionDate.IsZero() {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to parse promotion date: %v", err))
+			utils.HandleError(r, i, fmt.Sprintf("❌ Failed to parse promotion date: %v", err))
 			return
 		}
 	} else {
@@ -107,7 +114,7 @@ func processMilpacRequest(s *discordgo.Session, i *discordgo.InteractionCreate, 
 			utils.Debug("📋 Processing record", "type", record.RecordType, "date", record.RecordDate)
 			recordDate, err := time.Parse("2006-01-02", record.RecordDate)
 			if err != nil {
-				utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to parse record date: %v", err))
+				utils.HandleError(r, i, fmt.Sprintf("❌ Failed to parse record date: %v", err))
 				return
 			}
 			if strings.Contains(record.RecordDetails, "Retired") || strings.Contains(record.RecordDetails, "ELOA") ||
@@ -189,7 +196,7 @@ func processMilpacRequest(s *discordgo.Session, i *discordgo.InteractionCreate, 
 	}
 	matches := regexp.MustCompile(`/\d+/(\d+)\.jpg`).FindStringSubmatch(milpac.UniformUrl)
 	if len(matches) < 2 {
-		utils.HandleError(utils.NewSessionResponder(s), i, "❌ Failed to parse uniform URL")
+		utils.HandleError(r, i, "❌ Failed to parse uniform URL")
 		return
 	}
 	id := matches[1]
@@ -209,12 +216,12 @@ func processMilpacRequest(s *discordgo.Session, i *discordgo.InteractionCreate, 
 	}
 	utils.Info("Returning Milpac", "command", "Milpac", "milpac_name", embed.Title, "username", i.Member.User.Username, "discord_id", i.Member.User.ID)
 	emptyContent := ""
-	_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+	err = r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 		Content: &emptyContent,
 		Embeds:  &[]*discordgo.MessageEmbed{embed},
 	})
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to edit response with embed: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response with embed: %v", err))
 	}
 	utils.Info("✨ Done!", "command", "Milpac")
 }

--- a/commands/milpac_test.go
+++ b/commands/milpac_test.go
@@ -1,0 +1,241 @@
+package commands
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+// userOption builds a User-typed slash-command option. The Value of a User
+// option is the Discord ID string; UserValue(nil) resolves it to a
+// *discordgo.User carrying just that ID — which is all runMilpac consumes.
+func userOption(name, discordID string) *discordgo.ApplicationCommandInteractionDataOption {
+	return &discordgo.ApplicationCommandInteractionDataOption{
+		Name:  name,
+		Type:  discordgo.ApplicationCommandOptionUser,
+		Value: discordID,
+	}
+}
+
+// serveMilpacByDiscordID stands up an httptest.Server that returns the marshaled
+// profile for any /milpac/discord/<id> request (the path GetMilpacByDiscordID
+// hits), 404 otherwise. It redirects makeAPIRequest at the server via
+// SetAPIBaseURLForTest and registers cleanups.
+func serveMilpacByDiscordID(t *testing.T, profile utils.ProfileResponse) {
+	t.Helper()
+	body, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatalf("serveMilpacByDiscordID marshal: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/milpac/discord/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+}
+
+// serveMilpacStatus stands up a server that always replies with the given
+// status (and no body) for the discord-ID endpoint, to exercise upstream-error
+// paths.
+func serveMilpacStatus(t *testing.T, status int) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+}
+
+// milpacProfileWithSecondaries is a complete ProfileResponse exercising the
+// "has secondary positions" embed branch. Dates are fixed so the embed renders
+// deterministically; the uniform URL matches the /\d+/(\d+)\.jpg regex (id 456).
+func milpacProfileWithSecondaries() utils.ProfileResponse {
+	return utils.ProfileResponse{
+		User:          utils.User{UserID: "42", Username: "Test.Trooper"},
+		Gamertag:      "TestGamer",
+		Rank:          utils.Rank{RankShort: "SPC", RankFull: "Specialist", RankImageUrl: "https://example.com/rank.png"},
+		RealName:      "Test Trooper",
+		UniformUrl:    "https://7cav.us/data/roster_uniforms/0/456.jpg",
+		Roster:        "ROSTER_TYPE_COMBAT",
+		Primary:       utils.Position{PositionTitle: "Trooper 3/2/A/1-7"},
+		Secondary:     []utils.Position{{PositionTitle: "S6 Operations Staff IT"}},
+		JoinDate:      "2023-01-15",
+		PromotionDate: "2024-02-20",
+		DiscordID:     "111",
+		Records: []utils.Record{
+			{RecordType: "RECORD_TYPE_ASSIGNMENT", RecordDate: "2023-01-15", RecordDetails: "Enlisted into the 7th Cavalry"},
+		},
+	}
+}
+
+func TestRunMilpac_SuccessByDiscordID(t *testing.T) {
+	profile := milpacProfileWithSecondaries()
+	serveMilpacByDiscordID(t, profile)
+
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(userOption("user", "111"))
+
+	runMilpac(f, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (placeholder Respond + final Edit), got %d: %+v", len(calls), calls)
+	}
+	if calls[0].Method != "Respond" {
+		t.Fatalf("calls[0]: expected Respond, got %q", calls[0].Method)
+	}
+	if !strings.Contains(calls[0].Response.Data.Content, "Fetching Milpac data") {
+		t.Fatalf("calls[0]: expected placeholder content, got %q", calls[0].Response.Data.Content)
+	}
+	if calls[1].Method != "Edit" {
+		t.Fatalf("calls[1]: expected Edit, got %q", calls[1].Method)
+	}
+	if calls[1].Edit.Embeds == nil || len(*calls[1].Edit.Embeds) != 1 {
+		t.Fatalf("calls[1]: expected exactly one embed, got %+v", calls[1].Edit.Embeds)
+	}
+	embed := (*calls[1].Edit.Embeds)[0]
+	if !strings.Contains(embed.Title, "Specialist Test Trooper") {
+		t.Fatalf("embed title = %q, want it to contain rank+name", embed.Title)
+	}
+	if embed.URL != "https://7cav.us/rosters/profile/456" {
+		t.Fatalf("embed URL = %q, want milpac profile URL with id 456", embed.URL)
+	}
+	// Secondary-positions branch renders a Gamertag field; assert it's present.
+	var sawGamertag, sawSecondary bool
+	for _, fld := range embed.Fields {
+		switch fld.Name {
+		case "Gamertag":
+			sawGamertag = true
+		case "Secondary Positions":
+			sawSecondary = true
+		}
+	}
+	if !sawGamertag || !sawSecondary {
+		t.Fatalf("expected Gamertag and Secondary Positions fields; sawGamertag=%v sawSecondary=%v", sawGamertag, sawSecondary)
+	}
+}
+
+func TestRunMilpac_SuccessNoSecondaries(t *testing.T) {
+	profile := milpacProfileWithSecondaries()
+	profile.Secondary = nil // exercise the no-secondaries embed branch
+	serveMilpacByDiscordID(t, profile)
+
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(userOption("user", "111"))
+
+	runMilpac(f, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %+v", len(calls), calls)
+	}
+	embed := (*calls[1].Edit.Embeds)[0]
+	for _, fld := range embed.Fields {
+		if fld.Name == "Gamertag" || fld.Name == "Secondary Positions" {
+			t.Fatalf("no-secondaries branch should omit %q field", fld.Name)
+		}
+	}
+}
+
+func TestRunMilpac_NotFound_FallsThroughHandleError(t *testing.T) {
+	serveMilpacStatus(t, http.StatusNotFound)
+
+	// Placeholder Respond succeeds; HandleError's Respond hits "already
+	// acknowledged" (simulated) and falls back to Edit.
+	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
+	i := fakeAppCommandInteraction(userOption("user", "404"))
+
+	runMilpac(f, i)
+
+	calls := f.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls (placeholder + HandleError Respond + Edit fallback), got %d: %+v", len(calls), calls)
+	}
+	if calls[2].Method != "Edit" {
+		t.Fatalf("calls[2]: expected Edit (HandleError fallback), got %q", calls[2].Method)
+	}
+	if calls[2].Edit.Content == nil || !strings.Contains(*calls[2].Edit.Content, "no milpac found") {
+		got := "<nil>"
+		if calls[2].Edit.Content != nil {
+			got = *calls[2].Edit.Content
+		}
+		t.Fatalf("calls[2]: expected 'no milpac found' in error, got %q", got)
+	}
+}
+
+func TestRunMilpac_UpstreamError_FallsThroughHandleError(t *testing.T) {
+	serveMilpacStatus(t, http.StatusInternalServerError)
+
+	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
+	i := fakeAppCommandInteraction(userOption("user", "500"))
+
+	runMilpac(f, i)
+
+	calls := f.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls, got %d: %+v", len(calls), calls)
+	}
+	if calls[2].Edit.Content == nil || !strings.Contains(*calls[2].Edit.Content, "milpac API returned 500") {
+		got := "<nil>"
+		if calls[2].Edit.Content != nil {
+			got = *calls[2].Edit.Content
+		}
+		t.Fatalf("calls[2]: expected '500' surfaced in user-visible error, got %q", got)
+	}
+}
+
+func TestRunMilpac_BadJoinDate_FallsThroughHandleError(t *testing.T) {
+	profile := milpacProfileWithSecondaries()
+	profile.JoinDate = "not-a-date"
+	serveMilpacByDiscordID(t, profile)
+
+	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
+	i := fakeAppCommandInteraction(userOption("user", "111"))
+
+	runMilpac(f, i)
+
+	calls := f.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls, got %d: %+v", len(calls), calls)
+	}
+	if calls[2].Edit.Content == nil || !strings.Contains(*calls[2].Edit.Content, "Failed to parse join date") {
+		got := "<nil>"
+		if calls[2].Edit.Content != nil {
+			got = *calls[2].Edit.Content
+		}
+		t.Fatalf("calls[2]: expected 'Failed to parse join date', got %q", got)
+	}
+}
+
+func TestRunMilpac_BadUniformURL_FallsThroughHandleError(t *testing.T) {
+	profile := milpacProfileWithSecondaries()
+	profile.UniformUrl = "garbage"
+	serveMilpacByDiscordID(t, profile)
+
+	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
+	i := fakeAppCommandInteraction(userOption("user", "111"))
+
+	runMilpac(f, i)
+
+	calls := f.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls, got %d: %+v", len(calls), calls)
+	}
+	if calls[2].Edit.Content == nil || !strings.Contains(*calls[2].Edit.Content, "uniform URL") {
+		got := "<nil>"
+		if calls[2].Edit.Content != nil {
+			got = *calls[2].Edit.Content
+		}
+		t.Fatalf("calls[2]: expected 'uniform URL' error, got %q", got)
+	}
+}


### PR DESCRIPTION
Closes 7Cav/cavbot2#104.

Converts `/milpac` to the `handleX → runX(responder, i)` harness (Pattern A) and adds integration coverage.

## Changes

* `commands/milpac.go`: `handleMilpacCommand → runMilpac(utils.NewSessionResponder(s), i)`. The former `go processMilpacRequest(...)` goroutine is **inlined** into the synchronous `runMilpac` — its standalone `RecoverPanic("milpac-bg")` is dropped because `main.go`'s dispatcher `defer utils.RecoverPanic("interaction-handler")` now covers it (matches afsm/awol/gamertag shape). Registration + user-facing behavior unchanged.
* `commands/milpac_test.go` (new): fake-transport + `fakeResponder`/`fakeAppCommandInteraction` tests — success-by-Discord-ID (with/without secondary positions), milpac-not-found (404), upstream API error (500), bad-join-date and bad-uniform-URL paths.
* `.github/scripts/check-coverage-floors.sh`: commands floor 41 → 50 (measured 50.5%).

## Test plan

* `golangci-lint` clean, `go test ./...` green (commands 50.5% ≥ 50), `go test ./commands/ -race` clean, `go build` OK.

## Manual review gate

* Smoke test `/milpac` (by Discord ID and by forum username) on the test guild — live gateway not exercisable in CI.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)