### PR TITLE
test(commands): cover /s3aar Pattern B conversion (#105)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
 github.com/7cav/cavbot2/utils	73
-github.com/7cav/cavbot2/commands	50
+github.com/7cav/cavbot2/commands	60
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/commands/s3aar.go
+++ b/commands/s3aar.go
@@ -17,6 +17,10 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
+// bmBaseURL is the BattleMetrics API base. A package-level var (not a const) so
+// integration tests can point it at an httptest.Server. See s3aar_test.go.
+var bmBaseURL = "https://api.battlemetrics.com"
+
 type PlayerSession struct {
 	Name         string `json:"name"`
 	Playtime     int    `json:"playtime"`
@@ -144,7 +148,7 @@ func fetchBattleMetricsSessions(serverID string, start, stop time.Time, minAtten
 		return nil, fmt.Errorf("BM_TOKEN not set")
 	}
 
-	endpoint := fmt.Sprintf("https://api.battlemetrics.com/servers/%s/relationships/sessions", serverID)
+	endpoint := fmt.Sprintf("%s/servers/%s/relationships/sessions", bmBaseURL, serverID)
 	params := url.Values{}
 	params.Set("start", start.Format(time.RFC3339))
 	params.Set("stop", stop.Format(time.RFC3339))
@@ -299,22 +303,28 @@ func S3AAR() Command {
 				},
 			},
 		},
-		Handler: handleS3AARCommand,
+		Handler: handleS3aar,
 	}
 }
 
-func handleS3AARCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func handleS3aar(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	runS3aar(utils.NewSessionResponder(s), i)
+}
+
+func runS3aar(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
+	utils.Info("🚀 Starting S3 AAR", "command", "S3AAR", "username", i.Member.User.Username, "discord_id", i.Member.User.ID)
+
 	options := i.ApplicationCommandData().Options
 	optionMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(options))
 	for _, opt := range options {
 		optionMap[opt.Name] = opt
 	}
 
-	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
 	})
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("Failed to defer interaction: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("Failed to defer interaction: %v", err))
 		return
 	}
 
@@ -331,44 +341,40 @@ func handleS3AARCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	start, err := parseDateTime(startDate, startTime)
 	if err != nil {
-		_, sendErr := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		if sendErr := r.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 			Content: fmt.Sprintf("Invalid start date/time: %v", err),
-		})
-		if sendErr != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("Failed to send error message: %v", sendErr))
+		}); sendErr != nil {
+			utils.HandleError(r, i, fmt.Sprintf("Failed to send error message: %v", sendErr))
 		}
 		return
 	}
 
 	stop, err := parseDateTime(endDate, endTime)
 	if err != nil {
-		_, sendErr := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		if sendErr := r.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 			Content: fmt.Sprintf("Invalid end date/time: %v", err),
-		})
-		if sendErr != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("Failed to send error message: %v", sendErr))
+		}); sendErr != nil {
+			utils.HandleError(r, i, fmt.Sprintf("Failed to send error message: %v", sendErr))
 		}
 		return
 	}
 
 	serverID, err := getServerID(server)
 	if err != nil {
-		_, sendErr := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		if sendErr := r.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 			Content: fmt.Sprintf("Invalid server selection: %v", err),
-		})
-		if sendErr != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("Failed to send error message: %v", sendErr))
+		}); sendErr != nil {
+			utils.HandleError(r, i, fmt.Sprintf("Failed to send error message: %v", sendErr))
 		}
 		return
 	}
 
 	sessions, err := fetchBattleMetricsSessions(serverID, start, stop, minAttendance)
 	if err != nil {
-		_, sendErr := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		if sendErr := r.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 			Content: fmt.Sprintf("Failed to fetch BattleMetrics data: %v", err),
-		})
-		if sendErr != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("Failed to send error message: %v", sendErr))
+		}); sendErr != nil {
+			utils.HandleError(r, i, fmt.Sprintf("Failed to send error message: %v", sendErr))
 		}
 		return
 	}
@@ -391,11 +397,11 @@ func handleS3AARCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return rankI < rankJ
 	})
 
-	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+	err = r.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 		Embeds: []*discordgo.MessageEmbed{embed1},
 	})
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("Failed to send embeds: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("Failed to send embeds: %v", err))
 		return
 	}
 
@@ -414,7 +420,7 @@ func handleS3AARCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	}
 	forumText := strings.Join(forumLines, "\n")
 
-	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+	err = r.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 		Content: "AAR Roster (Copy Text to Forum Post)",
 		Files: []*discordgo.File{
 			{
@@ -425,22 +431,21 @@ func handleS3AARCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		},
 	})
 	if err != nil {
-		utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("Failed to send AAR roster file: %v", err))
+		utils.HandleError(r, i, fmt.Sprintf("Failed to send AAR roster file: %v", err))
 	}
 
 	if debug == "Yes" {
 		jsonData, err := json.MarshalIndent(sessions, "", "  ")
 		if err != nil {
-			_, sendErr := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+			if sendErr := r.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 				Content: fmt.Sprintf("Failed to format session data: %v", err),
-			})
-			if sendErr != nil {
-				utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("❌ Failed to send error message: %v", sendErr))
+			}); sendErr != nil {
+				utils.HandleError(r, i, fmt.Sprintf("❌ Failed to send error message: %v", sendErr))
 			}
 			return
 		}
 
-		_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		err = r.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 			Files: []*discordgo.File{
 				{
 					Name:        "attendance.json",
@@ -450,7 +455,9 @@ func handleS3AARCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			},
 		})
 		if err != nil {
-			utils.HandleError(utils.NewSessionResponder(s), i, fmt.Sprintf("Failed to send JSON file: %v", err))
+			utils.HandleError(r, i, fmt.Sprintf("Failed to send JSON file: %v", err))
 		}
 	}
+
+	utils.Info("✨ Done!", "command", "S3AAR")
 }

--- a/commands/s3aar_test.go
+++ b/commands/s3aar_test.go
@@ -1,0 +1,244 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+// bmSession is one BattleMetrics session record as the fake API serializes it.
+// Fields mirror the subset s3aar.go decodes (BMResponse).
+type bmSession struct {
+	Name  string
+	Start time.Time
+	Stop  time.Time
+}
+
+// serveBattleMetrics stands up a fake BattleMetrics sessions API returning the
+// given sessions, and a fake milpacs API that 404s every enrichment lookup so
+// enrichPlayer fails deterministically (its error is intentionally ignored in
+// s3aar.go, leaving CavName/Roster empty — no live network, no flake). It swaps
+// both bmBaseURL and utils apiBaseURL via t.Cleanup-registered restorers.
+func serveBattleMetrics(t *testing.T, sessions []bmSession) {
+	t.Helper()
+	t.Setenv("BM_TOKEN", "test-token")
+
+	payload := map[string]any{"data": make([]map[string]any, 0, len(sessions))}
+	for _, s := range sessions {
+		payload["data"] = append(payload["data"].([]map[string]any), map[string]any{
+			"attributes": map[string]any{
+				"start": s.Start,
+				"stop":  s.Stop,
+				"name":  s.Name,
+			},
+		})
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("serveBattleMetrics marshal: %v", err)
+	}
+
+	bmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/relationships/sessions") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(bmSrv.Close)
+
+	prevBM := bmBaseURL
+	bmBaseURL = bmSrv.URL
+	t.Cleanup(func() { bmBaseURL = prevBM })
+
+	// All milpacs enrichment lookups 404 → enrichPlayer returns an error that
+	// s3aar.go discards, so sessions still build with empty enrichment fields.
+	milpacSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(milpacSrv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(milpacSrv.URL))
+}
+
+// serveBattleMetricsError stands up a BattleMetrics API that returns a non-200,
+// driving the upstream-error path in fetchBattleMetricsSessions.
+func serveBattleMetricsError(t *testing.T, status int) {
+	t.Helper()
+	t.Setenv("BM_TOKEN", "test-token")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+	prevBM := bmBaseURL
+	bmBaseURL = srv.URL
+	t.Cleanup(func() { bmBaseURL = prevBM })
+}
+
+// s3aarOptions builds the required /s3aar option set, with an optional debug
+// value appended when non-empty.
+func s3aarOptions(server, startDate, endDate, startTime, endTime string, minAttendance int, debug string) *discordgo.InteractionCreate {
+	opts := []*discordgo.ApplicationCommandInteractionDataOption{
+		stringOption("game", "Arma"),
+		stringOption("server", server),
+		stringOption("start_date", startDate),
+		stringOption("end_date", endDate),
+		stringOption("start_time", startTime),
+		stringOption("end_time", endTime),
+		{Name: "minimum_attendance", Type: discordgo.ApplicationCommandOptionInteger, Value: float64(minAttendance)},
+	}
+	if debug != "" {
+		opts = append(opts, stringOption("debug", debug))
+	}
+	return fakeAppCommandInteraction(opts...)
+}
+
+// followups returns every recorded Followup call in order.
+func followups(calls []recordedCall) []recordedCall {
+	var out []recordedCall
+	for _, c := range calls {
+		if c.Method == "Followup" {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func TestRunS3aar_SuccessEmbedOutput(t *testing.T) {
+	start := time.Date(2025, 11, 10, 18, 0, 0, 0, time.UTC)
+	stop := start.Add(2 * time.Hour)
+	serveBattleMetrics(t, []bmSession{
+		{Name: "ABC.Smith.J", Start: start, Stop: stop},
+	})
+
+	r := &fakeResponder{}
+	i := s3aarOptions("Tac1", "10NOV25", "10NOV25", "1800", "2000", 30, "")
+	runS3aar(r, i)
+
+	calls := r.Calls()
+	// Defer must be the first call.
+	if len(calls) == 0 || calls[0].Method != "Respond" ||
+		calls[0].Response.Type != discordgo.InteractionResponseDeferredChannelMessageWithSource {
+		t.Fatalf("expected deferred Respond first; got %+v", calls)
+	}
+	fups := followups(calls)
+	if len(fups) < 2 {
+		t.Fatalf("expected at least embed + file followups; got %d", len(fups))
+	}
+	// First followup carries the attendance embed.
+	if len(fups[0].Params.Embeds) == 0 {
+		t.Fatalf("first followup must carry an embed; got %+v", fups[0].Params)
+	}
+	if !strings.Contains(fups[0].Params.Embeds[0].Description, "Smith.J") {
+		t.Fatalf("embed should list player; got %q", fups[0].Params.Embeds[0].Description)
+	}
+}
+
+func TestRunS3aar_SuccessFileOutput(t *testing.T) {
+	start := time.Date(2025, 11, 10, 18, 0, 0, 0, time.UTC)
+	stop := start.Add(3 * time.Hour)
+	// Many distinct players → large attendance result; the AAR roster file
+	// followup is always emitted regardless.
+	var sessions []bmSession
+	for n := 0; n < 60; n++ {
+		sessions = append(sessions, bmSession{
+			Name:  fmt.Sprintf("ABC.Player%02d.X", n),
+			Start: start,
+			Stop:  stop,
+		})
+	}
+	serveBattleMetrics(t, sessions)
+
+	r := &fakeResponder{}
+	i := s3aarOptions("Tac2", "10NOV25", "10NOV25", "1800", "2100", 30, "")
+	runS3aar(r, i)
+
+	fups := followups(r.Calls())
+	var fileFup *recordedCall
+	for idx := range fups {
+		for _, f := range fups[idx].Params.Files {
+			if f.Name == "aar_roster.txt" {
+				fileFup = &fups[idx]
+			}
+		}
+	}
+	if fileFup == nil {
+		t.Fatalf("expected an aar_roster.txt file followup; got %+v", fups)
+	}
+	if fileFup.Params.Content != "AAR Roster (Copy Text to Forum Post)" {
+		t.Fatalf("unexpected AAR file content prefix: %q", fileFup.Params.Content)
+	}
+}
+
+func TestRunS3aar_DebugJSONOutput(t *testing.T) {
+	start := time.Date(2025, 11, 10, 18, 0, 0, 0, time.UTC)
+	stop := start.Add(2 * time.Hour)
+	serveBattleMetrics(t, []bmSession{
+		{Name: "ABC.Jones.K", Start: start, Stop: stop},
+	})
+
+	r := &fakeResponder{}
+	i := s3aarOptions("TS1", "10NOV25", "10NOV25", "1800", "2000", 30, "Yes")
+	runS3aar(r, i)
+
+	fups := followups(r.Calls())
+	var jsonFup *recordedCall
+	for idx := range fups {
+		for _, f := range fups[idx].Params.Files {
+			if f.Name == "attendance.json" {
+				jsonFup = &fups[idx]
+			}
+		}
+	}
+	if jsonFup == nil {
+		t.Fatalf("debug=Yes must emit attendance.json followup; got %+v", fups)
+	}
+	// The JSON file must contain decodable PlayerSession data.
+	var f *discordgo.File
+	for _, file := range jsonFup.Params.Files {
+		if file.Name == "attendance.json" {
+			f = file
+		}
+	}
+	raw, err := io.ReadAll(f.Reader)
+	if err != nil {
+		t.Fatalf("read json file: %v", err)
+	}
+	var decoded []PlayerSession
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("attendance.json not valid PlayerSession JSON: %v\n%s", err, raw)
+	}
+	if len(decoded) != 1 || decoded[0].Name != "ABC.Jones.K" {
+		t.Fatalf("unexpected debug payload: %+v", decoded)
+	}
+}
+
+func TestRunS3aar_BattleMetricsUpstreamError(t *testing.T) {
+	serveBattleMetricsError(t, http.StatusInternalServerError)
+
+	r := &fakeResponder{}
+	i := s3aarOptions("Tac1", "10NOV25", "10NOV25", "1800", "2000", 30, "")
+	runS3aar(r, i)
+
+	calls := r.Calls()
+	// Defer succeeds, then the upstream failure is reported via a followup.
+	fups := followups(calls)
+	if len(fups) != 1 {
+		t.Fatalf("upstream error must produce exactly one (error) followup; got %d: %+v", len(fups), fups)
+	}
+	if !strings.Contains(fups[0].Params.Content, "Failed to fetch BattleMetrics data") {
+		t.Fatalf("unexpected upstream-error content: %q", fups[0].Params.Content)
+	}
+	// No embed/file followup on the error path.
+	if len(fups[0].Params.Embeds) != 0 || len(fups[0].Params.Files) != 0 {
+		t.Fatalf("error followup must be plain content, got %+v", fups[0].Params)
+	}
+}


### PR DESCRIPTION
Closes #105.

Converts `/s3aar` to the `handleX → runX(responder, i)` harness (Pattern B — defer + multi-followup, the heaviest `FollowupMessageCreate` user) and adds integration coverage.

## Changes
- `commands/s3aar.go`: extract `var bmBaseURL = "https://api.battlemetrics.com"` (var, swappable); `handleS3aar → runS3aar(r, i)` routing every Respond/Followup through `utils.InteractionResponder`; add `🚀 Starting`/`✨ Done!` logs. Output (deferred ack → embed followup → `aar_roster.txt` file followup → optional `attendance.json` debug followup) byte-for-byte preserved; registration unchanged.
- `commands/s3aar_test.go` (new): 4 httptest-driven tests — embed output, file output (60-player result), `debug=Yes` JSON, BattleMetrics upstream error. Asserts ordered Respond/Followup sequence via `fakeResponder`; milpac enrichment pointed at a 404 server so tests stay fully offline.
- `.github/scripts/check-coverage-floors.sh`: commands floor 50 → 60 (measured 60.7%).

## Test plan
- `golangci-lint` clean, `go test ./...` green (commands 60.7% ≥ 60), `go test ./commands/ -race` clean, `go build` OK.

## Manual review gate
- Smoke test `/s3aar` on the test guild — embed, file, and `debug=true` variants (live gateway not exercisable in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)