### PR TITLE
test(utils): cover HandleValidateBranchName (#108)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 # heredoc, read returns 1 at EOF. Without `|| true`, `set -e` would kill the
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
-github.com/7cav/cavbot2/utils	73
+github.com/7cav/cavbot2/utils	77
 github.com/7cav/cavbot2/commands	60
 EOF
 

--- a/utils/handlers_test.go
+++ b/utils/handlers_test.go
@@ -2,10 +2,56 @@ package utils
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
 )
+
+func TestHandleValidateBranchName(t *testing.T) {
+	// Cases are written to the ACTUAL behavior of the current regex
+	// `^[a-zA-Z0-9][a-zA-Z0-9._-]*$` plus the explicit length and leading-dot
+	// guards in HandleValidateBranchName. The regex does NOT reject git-forbidden
+	// patterns like a `..` sequence or a `.lock` suffix mid/end of string, so
+	// those "look-forbidden" names are accepted here — assert that real behavior,
+	// not git's rules.
+	tests := []struct {
+		name    string
+		branch  string
+		wantErr bool
+	}{
+		{"valid simple", "feature", false},
+		{"slash rejected by regex", "feat/issue-108", true},
+		{"valid dots hyphens underscores", "v1.2.3-rc_1", false},
+		{"valid single alphanumeric", "a", false},
+		{"valid leading digit", "9lives", false},
+		{"empty input", "", true},
+		{"too long 256 chars", strings.Repeat("a", 256), true},
+		{"max length 255 chars ok", strings.Repeat("a", 255), false},
+		{"leading dot", ".hidden", true},
+		{"leading hyphen rejected by regex", "-branch", true},
+		{"leading underscore rejected by regex", "_branch", true},
+		{"invalid slash character", "feature/foo", true},
+		{"invalid space character", "my branch", true},
+		{"leading whitespace", " branch", true},
+		{"trailing whitespace", "branch ", true},
+		{"invalid at sign", "br@nch", true},
+		{"double dot accepted by regex", "foo..bar", false},
+		{"dot-lock suffix accepted by regex", "release.lock", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := HandleValidateBranchName(tc.branch)
+			if tc.wantErr && err == nil {
+				t.Fatalf("HandleValidateBranchName(%q) = nil, want error", tc.branch)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("HandleValidateBranchName(%q) = %v, want nil", tc.branch, err)
+			}
+		})
+	}
+}
 
 func TestHandleError_AppCommand_RespondSucceeds(t *testing.T) {
 	f := &fakeResponder{}


### PR DESCRIPTION
Closes #108.

Table-driven tests for `HandleValidateBranchName` (`utils/handlers.go`), written to the function's **actual** regex behavior (not git's forbidden-name rules).

## Changes
- `utils/handlers_test.go`: 18-case `TestHandleValidateBranchName`. Documents real behavior of `^[a-zA-Z0-9][a-zA-Z0-9._-]*$`:
  - **Accepted** (function does NOT enforce git rules): `foo..bar` (double dot), `release.lock` (.lock suffix), 255-char name.
  - **Rejected**: slashes (`feat/issue-108`), spaces, leading/trailing whitespace, `@`, leading `.`/`-`/`_`, empty, 256-char.
- `.github/scripts/check-coverage-floors.sh`: utils floor 73 → 77 (measured 77.1%).

No function/regex changes.

## Test plan
- `golangci-lint` clean, `go test ./...` green (utils 77.1% ≥ 77), `go build` OK.

## Manual review gate
- None (pure-function tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)