### PR TITLE
test(commands): cover /warden Pattern C conversion (#106)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
 github.com/7cav/cavbot2/utils	77
-github.com/7cav/cavbot2/commands	60
+github.com/7cav/cavbot2/commands	75
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/commands/guild_manager.go
+++ b/commands/guild_manager.go
@@ -1,0 +1,77 @@
+package commands
+
+import "github.com/bwmarrin/discordgo"
+
+// GuildManager is the subset of *discordgo.Session that /warden uses to read
+// and mutate guild roles, members, and channel permission overwrites. Command
+// code depends on this interface so tests can substitute a fake that records
+// calls and injects per-call errors without touching the live Discord gateway.
+//
+// Following the InteractionResponder precedent (utils/discord_responder.go),
+// the production wrapper is a thin pass-through; the variadic
+// discordgo.RequestOption arguments are dropped because no /warden call site
+// uses them.
+type GuildManager interface {
+	GuildRoles(guildID string) ([]*discordgo.Role, error)
+	GuildRoleCreate(guildID string, data *discordgo.RoleParams) (*discordgo.Role, error)
+	GuildRoleEdit(guildID, roleID string, data *discordgo.RoleParams) (*discordgo.Role, error)
+	GuildRoleDelete(guildID, roleID string) error
+	GuildChannels(guildID string) ([]*discordgo.Channel, error)
+	ChannelPermissionSet(channelID, targetID string, targetType discordgo.PermissionOverwriteType, allow, deny int64) error
+	GuildMember(guildID, userID string) (*discordgo.Member, error)
+	GuildMembersSearch(guildID, query string, limit int) ([]*discordgo.Member, error)
+	GuildMemberRoleAdd(guildID, userID, roleID string) error
+	GuildMemberRoleRemove(guildID, userID, roleID string) error
+}
+
+// sessionGuildManager adapts *discordgo.Session to GuildManager. Each method is
+// a one-line pass-through; keeping it trivial means the (hard-to-unit-test)
+// wrapper adds negligible uncovered surface to the package.
+type sessionGuildManager struct {
+	s *discordgo.Session
+}
+
+// NewSessionGuildManager wraps a real Discord session for production use.
+func NewSessionGuildManager(s *discordgo.Session) GuildManager {
+	return &sessionGuildManager{s: s}
+}
+
+func (g *sessionGuildManager) GuildRoles(guildID string) ([]*discordgo.Role, error) {
+	return g.s.GuildRoles(guildID)
+}
+
+func (g *sessionGuildManager) GuildRoleCreate(guildID string, data *discordgo.RoleParams) (*discordgo.Role, error) {
+	return g.s.GuildRoleCreate(guildID, data)
+}
+
+func (g *sessionGuildManager) GuildRoleEdit(guildID, roleID string, data *discordgo.RoleParams) (*discordgo.Role, error) {
+	return g.s.GuildRoleEdit(guildID, roleID, data)
+}
+
+func (g *sessionGuildManager) GuildRoleDelete(guildID, roleID string) error {
+	return g.s.GuildRoleDelete(guildID, roleID)
+}
+
+func (g *sessionGuildManager) GuildChannels(guildID string) ([]*discordgo.Channel, error) {
+	return g.s.GuildChannels(guildID)
+}
+
+func (g *sessionGuildManager) ChannelPermissionSet(channelID, targetID string, targetType discordgo.PermissionOverwriteType, allow, deny int64) error {
+	return g.s.ChannelPermissionSet(channelID, targetID, targetType, allow, deny)
+}
+
+func (g *sessionGuildManager) GuildMember(guildID, userID string) (*discordgo.Member, error) {
+	return g.s.GuildMember(guildID, userID)
+}
+
+func (g *sessionGuildManager) GuildMembersSearch(guildID, query string, limit int) ([]*discordgo.Member, error) {
+	return g.s.GuildMembersSearch(guildID, query, limit)
+}
+
+func (g *sessionGuildManager) GuildMemberRoleAdd(guildID, userID, roleID string) error {
+	return g.s.GuildMemberRoleAdd(guildID, userID, roleID)
+}
+
+func (g *sessionGuildManager) GuildMemberRoleRemove(guildID, userID, roleID string) error {
+	return g.s.GuildMemberRoleRemove(guildID, userID, roleID)
+}

--- a/commands/warden.go
+++ b/commands/warden.go
@@ -15,655 +15,686 @@ import (
 
 const wardenRoleBaseName = "Verified Warden"
 
-var (
-    wardenRoleScopes  = []string{"internal", "external", "both"}
-    wardenSubcommands = []string{
-        "add",
-        "remove",
-        "bulkadd",
-        "purge",
-    }
+// wardenOverwriteDelay throttles successive channel-permission writes during a
+// purge to stay under Discord's rate limit. A package var (not a const) so
+// tests can zero it out and avoid sleeping. See warden_test.go.
+var wardenOverwriteDelay = 200 * time.Millisecond
 
-    wardenTitleCaser = cases.Title(language.Und, cases.NoLower)
+var (
+	wardenRoleScopes  = []string{"internal", "external", "both"}
+	wardenSubcommands = []string{
+		"add",
+		"remove",
+		"bulkadd",
+		"purge",
+	}
+
+	wardenTitleCaser = cases.Title(language.Und, cases.NoLower)
 )
 
 func Warden() Command {
-    return Command{
-        Definition: &discordgo.ApplicationCommand{
-            Name:        "warden",
-            Description: "Warden role management",
-            Options: []*discordgo.ApplicationCommandOption{
-                {
-                    Type:        discordgo.ApplicationCommandOptionString,
-                    Name:        "command",
-                    Description: "Choose between " + strings.Join(wardenSubcommands, ", "),
-                    Required:    true,
-                    Choices:     stringChoices(wardenSubcommands),
-                },
-                {
-                    Type:        discordgo.ApplicationCommandOptionString,
-                    Name:        "flag",
-                    Description: "Internal/external scope, or both",
-                    Required:    true,
-                    Choices:     stringChoices(wardenRoleScopes),
-                },
-                {
-                    Type:        discordgo.ApplicationCommandOptionString,
-                    Name:        "discordname",
-                    Description: "Mention/ID/partial name; for bulkadd use comma-separated list; optional for purge",
-                    Required:    false,
-                },
-            },
-        },
-        Handler: handleWarden,
-    }
+	return Command{
+		Definition: &discordgo.ApplicationCommand{
+			Name:        "warden",
+			Description: "Warden role management",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "command",
+					Description: "Choose between " + strings.Join(wardenSubcommands, ", "),
+					Required:    true,
+					Choices:     stringChoices(wardenSubcommands),
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "flag",
+					Description: "Internal/external scope, or both",
+					Required:    true,
+					Choices:     stringChoices(wardenRoleScopes),
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "discordname",
+					Description: "Mention/ID/partial name; for bulkadd use comma-separated list; optional for purge",
+					Required:    false,
+				},
+			},
+		},
+		Handler: handleWarden,
+	}
 }
 
 func handleWarden(
-    session *discordgo.Session,
-    interaction *discordgo.InteractionCreate,
+	session *discordgo.Session,
+	interaction *discordgo.InteractionCreate,
 ) {
-    commandData := interaction.ApplicationCommandData()
-
-    subcommand, ok := getOptionString(commandData, "command")
-    if !ok || !slices.Contains(wardenSubcommands, subcommand) {
-        utils.HandleError(
-            utils.NewSessionResponder(session),
-            interaction,
-            "❌ Invalid warden command; must be "+strings.Join(wardenSubcommands, ", "),
-        )
-        return
-    }
-
-    roleScope, ok := getOptionString(commandData, "flag")
-    if !ok || !slices.Contains(wardenRoleScopes, roleScope) {
-        utils.HandleError(
-            utils.NewSessionResponder(session),
-            interaction,
-            "❌ Missing or invalid flag argument; must be 'internal', 'external', or 'both'",
-        )
-        return
-    }
-
-    guildID := interaction.GuildID
-    if guildID == "" {
-        utils.HandleError(utils.NewSessionResponder(session), interaction, "❌ This command can only be used in a server (guild).")
-        return
-    }
-
-    query, _ := getOptionString(
-        commandData,
-        "discordname",
-    )
-
-    query = strings.TrimSpace(query)
-
-    if subcommand != "purge" && query == "" {
-        utils.HandleError(utils.NewSessionResponder(session), interaction, "❌ Missing discordname argument for this command")
-        return
-    }
-
-    utils.Debug("Warden command invoked", "command", subcommand, "query", query, "flag", roleScope)
-
-    switch subcommand {
-    case "add":
-        handleWardenAdd(session, interaction, guildID, query, roleScope)
-    case "remove":
-        handleWardenRemove(session, interaction, guildID, query, roleScope)
-    case "bulkadd":
-        handleWardenBulkAdd(session, interaction, guildID, query, roleScope)
-    case "purge":
-        handleWardenPurge(session, interaction, guildID, roleScope)
-    default:
-        utils.HandleError(utils.NewSessionResponder(session), interaction, "❌ Unknown subcommand")
-    }
+	runWarden(utils.NewSessionResponder(session), NewSessionGuildManager(session), interaction)
 }
 
-func handleWardenAdd(session *discordgo.Session, interaction *discordgo.InteractionCreate, guildID, query, roleScope string) {
-    if err := deferEphemeral(session, interaction); err != nil {
-        utils.HandleError(utils.NewSessionResponder(session), interaction, fmt.Sprintf("❌ Failed to acknowledge: %v", err))
-        return
-    }
+func runWarden(
+	r utils.InteractionResponder,
+	gm GuildManager,
+	interaction *discordgo.InteractionCreate,
+) {
+	utils.Info("🚀 Starting Warden", "command", "Warden", "username", interaction.Member.User.Username, "discord_id", interaction.Member.User.ID)
 
-    member, err := findGuildMember(session, guildID, query)
-    if err != nil {
-        editEphemeral(session, interaction, err.Error())
-        return
-    }
+	commandData := interaction.ApplicationCommandData()
 
-    roleIDs, roleNames, err := resolveWardenRoleIDs(session, guildID, roleScope)
-    if err != nil {
-        editEphemeral(session, interaction, err.Error())
-        return
-    }
+	subcommand, ok := getOptionString(commandData, "command")
+	if !ok || !slices.Contains(wardenSubcommands, subcommand) {
+		utils.HandleError(
+			r,
+			interaction,
+			"❌ Invalid warden command; must be "+strings.Join(wardenSubcommands, ", "),
+		)
+		return
+	}
 
-    for index, roleID := range roleIDs {
-        roleName := roleNames[index]
-        if err := session.GuildMemberRoleAdd(guildID, member.User.ID, roleID); err != nil {
-            utils.CaptureError("Failed to add warden role", err, "user", member.User.ID, "role", roleName)
-            editEphemeral(
-                session,
-                interaction,
-                fmt.Sprintf(
-                    "❌ Failed to add '%s' role to %s: %v",
-                    roleName,
-                    formatUser(member),
-                    err,
-                ),
-            )
-            return
-        }
-    }
+	roleScope, ok := getOptionString(commandData, "flag")
+	if !ok || !slices.Contains(wardenRoleScopes, roleScope) {
+		utils.HandleError(
+			r,
+			interaction,
+			"❌ Missing or invalid flag argument; must be 'internal', 'external', or 'both'",
+		)
+		return
+	}
 
-    utils.Info("Warden role(s) added", "user", member.User.ID, "roles", strings.Join(roleNames, ", "))
-    editEphemeral(
-        session,
-        interaction,
-        fmt.Sprintf(
-            "✅ Added warden role(s) (%s) to %s",
-            strings.Join(roleNames, ", "),
-            formatUser(member),
-        ),
-    )
+	guildID := interaction.GuildID
+	if guildID == "" {
+		utils.HandleError(r, interaction, "❌ This command can only be used in a server (guild).")
+		return
+	}
+
+	query, _ := getOptionString(
+		commandData,
+		"discordname",
+	)
+
+	query = strings.TrimSpace(query)
+
+	if subcommand != "purge" && query == "" {
+		utils.HandleError(r, interaction, "❌ Missing discordname argument for this command")
+		return
+	}
+
+	utils.Debug("Warden command invoked", "command", subcommand, "query", query, "flag", roleScope)
+
+	switch subcommand {
+	case "add":
+		handleWardenAdd(r, gm, interaction, guildID, query, roleScope)
+	case "remove":
+		handleWardenRemove(r, gm, interaction, guildID, query, roleScope)
+	case "bulkadd":
+		handleWardenBulkAdd(r, gm, interaction, guildID, query, roleScope)
+	case "purge":
+		handleWardenPurge(r, gm, interaction, guildID, roleScope)
+	default:
+		utils.HandleError(r, interaction, "❌ Unknown subcommand")
+	}
+
+	utils.Info("✨ Done!", "command", "Warden")
+}
+
+func handleWardenAdd(r utils.InteractionResponder, gm GuildManager, interaction *discordgo.InteractionCreate, guildID, query, roleScope string) {
+	if err := deferEphemeral(r, interaction); err != nil {
+		utils.HandleError(r, interaction, fmt.Sprintf("❌ Failed to acknowledge: %v", err))
+		return
+	}
+
+	member, err := findGuildMember(gm, guildID, query)
+	if err != nil {
+		editEphemeral(r, interaction, err.Error())
+		return
+	}
+
+	roleIDs, roleNames, err := resolveWardenRoleIDs(gm, guildID, roleScope)
+	if err != nil {
+		editEphemeral(r, interaction, err.Error())
+		return
+	}
+
+	for index, roleID := range roleIDs {
+		roleName := roleNames[index]
+		if err := gm.GuildMemberRoleAdd(guildID, member.User.ID, roleID); err != nil {
+			utils.CaptureError("Failed to add warden role", err, "user", member.User.ID, "role", roleName)
+			editEphemeral(
+				r,
+				interaction,
+				fmt.Sprintf(
+					"❌ Failed to add '%s' role to %s: %v",
+					roleName,
+					formatUser(member),
+					err,
+				),
+			)
+			return
+		}
+	}
+
+	utils.Info("Warden role(s) added", "user", member.User.ID, "roles", strings.Join(roleNames, ", "))
+	editEphemeral(
+		r,
+		interaction,
+		fmt.Sprintf(
+			"✅ Added warden role(s) (%s) to %s",
+			strings.Join(roleNames, ", "),
+			formatUser(member),
+		),
+	)
 }
 
 func handleWardenRemove(
-    session *discordgo.Session,
-    interaction *discordgo.InteractionCreate,
-    guildID string,
-    query string,
-    roleScope string,
+	r utils.InteractionResponder,
+	gm GuildManager,
+	interaction *discordgo.InteractionCreate,
+	guildID string,
+	query string,
+	roleScope string,
 ) {
-    if err := deferEphemeral(session, interaction); err != nil {
-        utils.HandleError(utils.NewSessionResponder(session), interaction, fmt.Sprintf("❌ Failed to acknowledge: %v", err))
-        return
-    }
+	if err := deferEphemeral(r, interaction); err != nil {
+		utils.HandleError(r, interaction, fmt.Sprintf("❌ Failed to acknowledge: %v", err))
+		return
+	}
 
-    member, err := findGuildMember(session, guildID, query)
-    if err != nil {
-        editEphemeral(session, interaction, err.Error())
-        return
-    }
+	member, err := findGuildMember(gm, guildID, query)
+	if err != nil {
+		editEphemeral(r, interaction, err.Error())
+		return
+	}
 
-    roleIDs, roleNames, err := resolveWardenRoleIDs(session, guildID, roleScope)
-    if err != nil {
-        editEphemeral(session, interaction, err.Error())
-        return
-    }
+	roleIDs, roleNames, err := resolveWardenRoleIDs(gm, guildID, roleScope)
+	if err != nil {
+		editEphemeral(r, interaction, err.Error())
+		return
+	}
 
-    for index, roleID := range roleIDs {
-        roleName := roleNames[index]
-        if err := session.GuildMemberRoleRemove(guildID, member.User.ID, roleID); err != nil {
-            utils.CaptureError("Failed to remove warden role", err, "user", member.User.ID, "role", roleName)
-            editEphemeral(session, interaction, fmt.Sprintf("❌ Failed to remove '%s' role from %s: %v", roleName, formatUser(member), err))
-            return
-        }
-    }
+	for index, roleID := range roleIDs {
+		roleName := roleNames[index]
+		if err := gm.GuildMemberRoleRemove(guildID, member.User.ID, roleID); err != nil {
+			utils.CaptureError("Failed to remove warden role", err, "user", member.User.ID, "role", roleName)
+			editEphemeral(r, interaction, fmt.Sprintf("❌ Failed to remove '%s' role from %s: %v", roleName, formatUser(member), err))
+			return
+		}
+	}
 
-    utils.Info("Warden role(s) removed", "user", member.User.ID, "roles", strings.Join(roleNames, ", "))
-    editEphemeral(session, interaction, fmt.Sprintf("✅ Removed warden role(s) (%s) from %s", strings.Join(roleNames, ", "), formatUser(member)))
+	utils.Info("Warden role(s) removed", "user", member.User.ID, "roles", strings.Join(roleNames, ", "))
+	editEphemeral(r, interaction, fmt.Sprintf("✅ Removed warden role(s) (%s) from %s", strings.Join(roleNames, ", "), formatUser(member)))
 }
 
 func handleWardenBulkAdd(
-    session *discordgo.Session,
-    interaction *discordgo.InteractionCreate,
-    guildID string,
-    query string,
-    roleScope string,
+	r utils.InteractionResponder,
+	gm GuildManager,
+	interaction *discordgo.InteractionCreate,
+	guildID string,
+	query string,
+	roleScope string,
 ) {
-    if err := deferEphemeral(session, interaction); err != nil {
-        utils.HandleError(utils.NewSessionResponder(session), interaction, fmt.Sprintf("❌ Failed to acknowledge bulk add: %v", err))
-        return
-    }
+	if err := deferEphemeral(r, interaction); err != nil {
+		utils.HandleError(r, interaction, fmt.Sprintf("❌ Failed to acknowledge bulk add: %v", err))
+		return
+	}
 
-    roleIDs, roleNames, err := resolveWardenRoleIDs(session, guildID, roleScope)
-    if err != nil {
-        editEphemeral(session, interaction, err.Error())
-        return
-    }
+	roleIDs, roleNames, err := resolveWardenRoleIDs(gm, guildID, roleScope)
+	if err != nil {
+		editEphemeral(r, interaction, err.Error())
+		return
+	}
 
-    requestedQueries := splitCommaSeparated(query)
-    if len(requestedQueries) == 0 {
-        editEphemeral(session, interaction, "⚠️ Nothing to do.")
-        return
-    }
+	requestedQueries := splitCommaSeparated(query)
+	if len(requestedQueries) == 0 {
+		editEphemeral(r, interaction, "⚠️ Nothing to do.")
+		return
+	}
 
-    var addedMembers []*discordgo.Member
-    var failures []string
-    for _, singleQuery := range requestedQueries {
-        member, memberErr := findGuildMember(session, guildID, singleQuery)
-        if memberErr != nil {
-            failures = append(failures, memberErr.Error())
-            continue
-        }
+	var addedMembers []*discordgo.Member
+	var failures []string
+	for _, singleQuery := range requestedQueries {
+		member, memberErr := findGuildMember(gm, guildID, singleQuery)
+		if memberErr != nil {
+			failures = append(failures, memberErr.Error())
+			continue
+		}
 
-        allOK := true
-        for index, roleID := range roleIDs {
-            roleName := roleNames[index]
-            if err := session.GuildMemberRoleAdd(guildID, member.User.ID, roleID); err != nil {
-                utils.CaptureError("Failed to add warden role in bulk", err, "user", member.User.ID, "role", roleName)
-                failures = append(failures, fmt.Sprintf("❌ Failed to add '%s' role to %s: %v", roleName, formatUser(member), err))
-                allOK = false
-            }
-        }
-        if allOK {
-            addedMembers = append(addedMembers, member)
-        }
-    }
+		allOK := true
+		for index, roleID := range roleIDs {
+			roleName := roleNames[index]
+			if err := gm.GuildMemberRoleAdd(guildID, member.User.ID, roleID); err != nil {
+				utils.CaptureError("Failed to add warden role in bulk", err, "user", member.User.ID, "role", roleName)
+				failures = append(failures, fmt.Sprintf("❌ Failed to add '%s' role to %s: %v", roleName, formatUser(member), err))
+				allOK = false
+			}
+		}
+		if allOK {
+			addedMembers = append(addedMembers, member)
+		}
+	}
 
-    content := buildBulkAddSummary(len(addedMembers), failures)
-    var embed *discordgo.MessageEmbed
-    if len(addedMembers) > 0 {
-        embed = buildAddedMembersEmbed(addedMembers)
-    }
-    editEphemeralWithEmbed(session, interaction, content, embed)
+	content := buildBulkAddSummary(len(addedMembers), failures)
+	var embed *discordgo.MessageEmbed
+	if len(addedMembers) > 0 {
+		embed = buildAddedMembersEmbed(addedMembers)
+	}
+	editEphemeralWithEmbed(r, interaction, content, embed)
 }
 
 func handleWardenPurge(
-    session *discordgo.Session,
-    interaction *discordgo.InteractionCreate,
-    guildID string,
-    roleScope string,
+	r utils.InteractionResponder,
+	gm GuildManager,
+	interaction *discordgo.InteractionCreate,
+	guildID string,
+	roleScope string,
 ) {
-    if err := deferEphemeral(session, interaction); err != nil {
-        utils.HandleError(utils.NewSessionResponder(session), interaction, fmt.Sprintf("❌ Failed to acknowledge purge: %v", err))
-        return
-    }
+	if err := deferEphemeral(r, interaction); err != nil {
+		utils.HandleError(r, interaction, fmt.Sprintf("❌ Failed to acknowledge purge: %v", err))
+		return
+	}
 
-    go func() {
-    defer utils.RecoverPanic("warden-purge")
-    roleIDsToRecreate, roleNamesToRecreate, err := resolveWardenRoleIDs(session, guildID, roleScope)
-        if err != nil {
-            editEphemeral(session, interaction, err.Error())
-            return
-        }
+	go func() {
+		defer utils.RecoverPanic("warden-purge")
+		runWardenPurge(r, gm, interaction, guildID, roleScope)
+	}()
+}
 
-        if len(roleIDsToRecreate) == 0 {
-            editEphemeral(session, interaction, "❌ No roles resolved for purge scope.")
-            return
-        }
+// runWardenPurge performs the role-recreation purge. Extracted from the inline
+// goroutine in handleWardenPurge so it is directly callable from tests with a
+// fake GuildManager/responder; the caller (handleWardenPurge) owns the
+// goroutine + panic recovery and the deferred-ephemeral acknowledge.
+func runWardenPurge(
+	r utils.InteractionResponder,
+	gm GuildManager,
+	interaction *discordgo.InteractionCreate,
+	guildID string,
+	roleScope string,
+) {
+	roleIDsToRecreate, roleNamesToRecreate, err := resolveWardenRoleIDs(gm, guildID, roleScope)
+	if err != nil {
+		editEphemeral(r, interaction, err.Error())
+		return
+	}
 
-        guildChannels, err := session.GuildChannels(guildID)
-        if err != nil {
-            editEphemeral(session, interaction, fmt.Sprintf("❌ Failed to retrieve guild channels: %v", err))
-            return
-        }
+	if len(roleIDsToRecreate) == 0 {
+		editEphemeral(r, interaction, "❌ No roles resolved for purge scope.")
+		return
+	}
 
-        var summaryLines []string
+	guildChannels, err := gm.GuildChannels(guildID)
+	if err != nil {
+		editEphemeral(r, interaction, fmt.Sprintf("❌ Failed to retrieve guild channels: %v", err))
+		return
+	}
 
-        for index, roleIDToRecreate := range roleIDsToRecreate {
-            roleName := roleNamesToRecreate[index]
+	var summaryLines []string
 
-            newRoleID, reappliedOverwriteCount, recreateErr := recreateRoleWithChannelOverwrites(
-                session,
-                guildID,
-                roleIDToRecreate,
-                guildChannels,
-            )
+	for index, roleIDToRecreate := range roleIDsToRecreate {
+		roleName := roleNamesToRecreate[index]
 
-            if recreateErr != nil {
-                utils.CaptureError(
-                    "Warden purge role recreation failed",
-                    recreateErr,
-                    "guild", guildID,
-                    "roleName", roleName,
-                    "roleID", roleIDToRecreate,
-                )
+		newRoleID, reappliedOverwriteCount, recreateErr := recreateRoleWithChannelOverwrites(
+			gm,
+			guildID,
+			roleIDToRecreate,
+			guildChannels,
+		)
 
-                summaryLines = append(summaryLines, fmt.Sprintf("❌ Failed to recreate '%s': %v", roleName, recreateErr))
-                continue
-            }
+		if recreateErr != nil {
+			utils.CaptureError(
+				"Warden purge role recreation failed",
+				recreateErr,
+				"guild", guildID,
+				"roleName", roleName,
+				"roleID", roleIDToRecreate,
+			)
 
-            summaryLines = append(
-                summaryLines,
-                fmt.Sprintf(
-                    "✅ Recreated '%s' (old: `%s`, new: `%s`), re-applied %d overwrite(s).",
-                    roleName,
-                    roleIDToRecreate,
-                    newRoleID,
-                    reappliedOverwriteCount,
-                ),
-            )
-        }
+			summaryLines = append(summaryLines, fmt.Sprintf("❌ Failed to recreate '%s': %v", roleName, recreateErr))
+			continue
+		}
 
-        editEphemeral(session, interaction, joinOrFallback(summaryLines, "✅ Purge complete."))
-    }()
+		summaryLines = append(
+			summaryLines,
+			fmt.Sprintf(
+				"✅ Recreated '%s' (old: `%s`, new: `%s`), re-applied %d overwrite(s).",
+				roleName,
+				roleIDToRecreate,
+				newRoleID,
+				reappliedOverwriteCount,
+			),
+		)
+	}
+
+	editEphemeral(r, interaction, joinOrFallback(summaryLines, "✅ Purge complete."))
 }
 
 func recreateRoleWithChannelOverwrites(
-    session *discordgo.Session,
-    guildID string,
-    oldRoleID string,
-    guildChannels []*discordgo.Channel,
+	gm GuildManager,
+	guildID string,
+	oldRoleID string,
+	guildChannels []*discordgo.Channel,
 ) (string, int, error) {
-    oldRole, err := fetchGuildRoleByID(session, guildID, oldRoleID)
-    if err != nil {
-        return "", 0, fmt.Errorf("fetch role: %w", err)
-    }
+	oldRole, err := fetchGuildRoleByID(gm, guildID, oldRoleID)
+	if err != nil {
+		return "", 0, fmt.Errorf("fetch role: %w", err)
+	}
 
-    channelOverwritesByChannelID := collectRoleOverwritesByChannelID(oldRoleID, guildChannels)
+	channelOverwritesByChannelID := collectRoleOverwritesByChannelID(oldRoleID, guildChannels)
 
-    newRole, err := session.GuildRoleCreate(guildID, &discordgo.RoleParams{
-        Name:        oldRole.Name,
-        Color:       &oldRole.Color,
-        Hoist:       &oldRole.Hoist,
-        Mentionable: &oldRole.Mentionable,
-        Permissions: &oldRole.Permissions,
-    })
+	newRole, err := gm.GuildRoleCreate(guildID, &discordgo.RoleParams{
+		Name:        oldRole.Name,
+		Color:       &oldRole.Color,
+		Hoist:       &oldRole.Hoist,
+		Mentionable: &oldRole.Mentionable,
+		Permissions: &oldRole.Permissions,
+	})
 
-    if err != nil {
-        return "", 0, fmt.Errorf("create role: %w", err)
-    }
+	if err != nil {
+		return "", 0, fmt.Errorf("create role: %w", err)
+	}
 
-    if err := applyRoleProperties(session, guildID, newRole.ID, oldRole); err != nil {
-        return "", 0, fmt.Errorf("apply role properties: %w", err)
-    }
+	if err := applyRoleProperties(gm, guildID, newRole.ID, oldRole); err != nil {
+		return "", 0, fmt.Errorf("apply role properties: %w", err)
+	}
 
-    reappliedOverwriteCount, err := reapplyRoleOverwrites(
-        session,
-        newRole.ID,
-        channelOverwritesByChannelID,
-    )
+	reappliedOverwriteCount, err := reapplyRoleOverwrites(
+		gm,
+		newRole.ID,
+		channelOverwritesByChannelID,
+	)
 
-    if err != nil {
-        return "", reappliedOverwriteCount, fmt.Errorf("reapply overwrites: %w", err)
-    }
+	if err != nil {
+		return "", reappliedOverwriteCount, fmt.Errorf("reapply overwrites: %w", err)
+	}
 
-    if err := session.GuildRoleDelete(guildID, oldRoleID); err != nil {
-        return newRole.ID, reappliedOverwriteCount, fmt.Errorf("delete old role: %w", err)
-    }
+	if err := gm.GuildRoleDelete(guildID, oldRoleID); err != nil {
+		return newRole.ID, reappliedOverwriteCount, fmt.Errorf("delete old role: %w", err)
+	}
 
-    return newRole.ID, reappliedOverwriteCount, nil
+	return newRole.ID, reappliedOverwriteCount, nil
 }
 
-func fetchGuildRoleByID(session *discordgo.Session, guildID, roleID string) (*discordgo.Role, error) {
-    guildRoles, err := session.GuildRoles(guildID)
+func fetchGuildRoleByID(gm GuildManager, guildID, roleID string) (*discordgo.Role, error) {
+	guildRoles, err := gm.GuildRoles(guildID)
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    for _, role := range guildRoles {
-        if role.ID == roleID {
-            return role, nil
-        }
-    }
+	for _, role := range guildRoles {
+		if role.ID == roleID {
+			return role, nil
+		}
+	}
 
-    return nil, fmt.Errorf("role id %s not found", roleID)
+	return nil, fmt.Errorf("role id %s not found", roleID)
 }
 
 func collectRoleOverwritesByChannelID(
-    roleID string,
-    guildChannels []*discordgo.Channel,
+	roleID string,
+	guildChannels []*discordgo.Channel,
 ) map[string]*discordgo.PermissionOverwrite {
-    channelOverwritesByChannelID := make(map[string]*discordgo.PermissionOverwrite, 32)
+	channelOverwritesByChannelID := make(map[string]*discordgo.PermissionOverwrite, 32)
 
-    for _, channel := range guildChannels {
-        for _, overwrite := range channel.PermissionOverwrites {
-            if overwrite.Type != discordgo.PermissionOverwriteTypeRole {
-                continue
-            }
-            if overwrite.ID != roleID {
-                continue
-            }
+	for _, channel := range guildChannels {
+		for _, overwrite := range channel.PermissionOverwrites {
+			if overwrite.Type != discordgo.PermissionOverwriteTypeRole {
+				continue
+			}
+			if overwrite.ID != roleID {
+				continue
+			}
 
-            overwriteCopy := *overwrite
-            channelOverwritesByChannelID[channel.ID] = &overwriteCopy
-        }
-    }
+			overwriteCopy := *overwrite
+			channelOverwritesByChannelID[channel.ID] = &overwriteCopy
+		}
+	}
 
-    return channelOverwritesByChannelID
+	return channelOverwritesByChannelID
 }
 
 func applyRoleProperties(
-    session *discordgo.Session,
-    guildID string,
-    roleID string,
-    sourceRole *discordgo.Role,
+	gm GuildManager,
+	guildID string,
+	roleID string,
+	sourceRole *discordgo.Role,
 ) error {
-    _, err := session.GuildRoleEdit(guildID, roleID, &discordgo.RoleParams{
-        Name:        sourceRole.Name,
-        Color:       &sourceRole.Color,
-        Hoist:       &sourceRole.Hoist,
-        Mentionable: &sourceRole.Mentionable,
-        Permissions: &sourceRole.Permissions,
-    })
-    return err
+	_, err := gm.GuildRoleEdit(guildID, roleID, &discordgo.RoleParams{
+		Name:        sourceRole.Name,
+		Color:       &sourceRole.Color,
+		Hoist:       &sourceRole.Hoist,
+		Mentionable: &sourceRole.Mentionable,
+		Permissions: &sourceRole.Permissions,
+	})
+	return err
 }
 
 func reapplyRoleOverwrites(
-    session *discordgo.Session,
-    newRoleID string,
-    channelOverwritesByChannelID map[string]*discordgo.PermissionOverwrite,
+	gm GuildManager,
+	newRoleID string,
+	channelOverwritesByChannelID map[string]*discordgo.PermissionOverwrite,
 ) (int, error) {
-    reappliedCount := 0
+	reappliedCount := 0
 
-    // Stable order (maps iterate randomly)
-    channelIDs := make([]string, 0, len(channelOverwritesByChannelID))
-    for channelID := range channelOverwritesByChannelID {
-        channelIDs = append(channelIDs, channelID)
-    }
-    slices.Sort(channelIDs)
+	// Stable order (maps iterate randomly)
+	channelIDs := make([]string, 0, len(channelOverwritesByChannelID))
+	for channelID := range channelOverwritesByChannelID {
+		channelIDs = append(channelIDs, channelID)
+	}
+	slices.Sort(channelIDs)
 
-    for _, channelID := range channelIDs {
-        overwrite := channelOverwritesByChannelID[channelID]
+	for _, channelID := range channelIDs {
+		overwrite := channelOverwritesByChannelID[channelID]
 
-        if err := session.ChannelPermissionSet(
-            channelID,
-            newRoleID,
-            discordgo.PermissionOverwriteTypeRole,
-            overwrite.Allow,
-            overwrite.Deny,
-        ); err != nil {
-            return reappliedCount, fmt.Errorf("channel %s: %w", channelID, err)
-        }
+		if err := gm.ChannelPermissionSet(
+			channelID,
+			newRoleID,
+			discordgo.PermissionOverwriteTypeRole,
+			overwrite.Allow,
+			overwrite.Deny,
+		); err != nil {
+			return reappliedCount, fmt.Errorf("channel %s: %w", channelID, err)
+		}
 
-        reappliedCount++
-        time.Sleep(200 * time.Millisecond)
-    }
+		reappliedCount++
+		time.Sleep(wardenOverwriteDelay)
+	}
 
-    return reappliedCount, nil
+	return reappliedCount, nil
 }
 
-
 func resolveWardenRoleNames(roleScope string) []string {
-    switch roleScope {
-    case "both":
-        return []string{
-            wardenRoleBaseName + " Internal",
-            wardenRoleBaseName + " External",
-        }
-    case "internal", "external":
-        return []string{
-            wardenRoleBaseName + " " + wardenTitleCaser.String(roleScope),
-        }
-    default:
-        return []string{
-            wardenRoleBaseName + " " + wardenTitleCaser.String(roleScope),
-        }
-    }
+	switch roleScope {
+	case "both":
+		return []string{
+			wardenRoleBaseName + " Internal",
+			wardenRoleBaseName + " External",
+		}
+	case "internal", "external":
+		return []string{
+			wardenRoleBaseName + " " + wardenTitleCaser.String(roleScope),
+		}
+	default:
+		return []string{
+			wardenRoleBaseName + " " + wardenTitleCaser.String(roleScope),
+		}
+	}
 }
 
 func resolveWardenRoleIDs(
-    session *discordgo.Session,
-    guildID string,
-    roleScope string,
+	gm GuildManager,
+	guildID string,
+	roleScope string,
 ) (roleIDs []string, roleNames []string, err error) {
-    roleNames = resolveWardenRoleNames(roleScope)
-    roleIDs = make([]string, 0, len(roleNames))
+	roleNames = resolveWardenRoleNames(roleScope)
+	roleIDs = make([]string, 0, len(roleNames))
 
-    for _, roleName := range roleNames {
-        roleID, findErr := findGuildRoleIDByName(session, guildID, roleName)
-        if findErr != nil {
-            return nil, nil, fmt.Errorf("❌ Failed to retrieve guild roles: %v", findErr)
-        }
-        if roleID == "" {
-            return nil, nil, fmt.Errorf("❌ '%s' role not found in guild", roleName)
-        }
-        roleIDs = append(roleIDs, roleID)
-    }
+	for _, roleName := range roleNames {
+		roleID, findErr := findGuildRoleIDByName(gm, guildID, roleName)
+		if findErr != nil {
+			return nil, nil, fmt.Errorf("❌ Failed to retrieve guild roles: %v", findErr)
+		}
+		if roleID == "" {
+			return nil, nil, fmt.Errorf("❌ '%s' role not found in guild", roleName)
+		}
+		roleIDs = append(roleIDs, roleID)
+	}
 
-    return roleIDs, roleNames, nil
+	return roleIDs, roleNames, nil
 }
 
 func getOptionString(
-    commandData discordgo.ApplicationCommandInteractionData,
-    optionName string,
+	commandData discordgo.ApplicationCommandInteractionData,
+	optionName string,
 ) (string, bool) {
-    for _, option := range commandData.Options {
-        if option != nil && option.Name == optionName {
-            return option.StringValue(), true
-        }
-    }
-    return "", false
+	for _, option := range commandData.Options {
+		if option != nil && option.Name == optionName {
+			return option.StringValue(), true
+		}
+	}
+	return "", false
 }
 
 func stringChoices(values []string) []*discordgo.ApplicationCommandOptionChoice {
-    choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(values))
-    for _, value := range values {
-        choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
-            Name:  value,
-            Value: value,
-        })
-    }
-    return choices
+	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(values))
+	for _, value := range values {
+		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
+			Name:  value,
+			Value: value,
+		})
+	}
+	return choices
 }
 
-func deferEphemeral(session *discordgo.Session, interaction *discordgo.InteractionCreate) error {
-    return session.InteractionRespond(interaction.Interaction, &discordgo.InteractionResponse{
-        Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
-        Data: &discordgo.InteractionResponseData{
-            Flags: discordgo.MessageFlagsEphemeral,
-        },
-    })
+func deferEphemeral(r utils.InteractionResponder, interaction *discordgo.InteractionCreate) error {
+	return r.InteractionRespond(interaction.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Flags: discordgo.MessageFlagsEphemeral,
+		},
+	})
 }
 
-func editEphemeral(session *discordgo.Session, interaction *discordgo.InteractionCreate, content string) {
-    _, err := session.InteractionResponseEdit(interaction.Interaction, &discordgo.WebhookEdit{
-        Content: &content,
-    })
-    if err != nil {
-        utils.HandleError(utils.NewSessionResponder(session), interaction, fmt.Sprintf("❌ Failed to edit response: %v", err))
-    }
+func editEphemeral(r utils.InteractionResponder, interaction *discordgo.InteractionCreate, content string) {
+	if err := r.InteractionResponseEdit(interaction.Interaction, &discordgo.WebhookEdit{
+		Content: &content,
+	}); err != nil {
+		utils.HandleError(r, interaction, fmt.Sprintf("❌ Failed to edit response: %v", err))
+	}
 }
 
-func editEphemeralWithEmbed(session *discordgo.Session, interaction *discordgo.InteractionCreate, content string, embed *discordgo.MessageEmbed) {
-    edit := &discordgo.WebhookEdit{Content: &content}
-    if embed != nil {
-        edit.Embeds = &[]*discordgo.MessageEmbed{embed}
-    }
-    _, err := session.InteractionResponseEdit(interaction.Interaction, edit)
-    if err != nil {
-        utils.HandleError(utils.NewSessionResponder(session), interaction, fmt.Sprintf("❌ Failed to edit response: %v", err))
-    }
+func editEphemeralWithEmbed(r utils.InteractionResponder, interaction *discordgo.InteractionCreate, content string, embed *discordgo.MessageEmbed) {
+	edit := &discordgo.WebhookEdit{Content: &content}
+	if embed != nil {
+		edit.Embeds = &[]*discordgo.MessageEmbed{embed}
+	}
+	if err := r.InteractionResponseEdit(interaction.Interaction, edit); err != nil {
+		utils.HandleError(r, interaction, fmt.Sprintf("❌ Failed to edit response: %v", err))
+	}
 }
 
 func buildAddedMembersEmbed(members []*discordgo.Member) *discordgo.MessageEmbed {
-    const maxDescLen = 4096
-    var sb strings.Builder
-    for _, m := range members {
-        line := fmt.Sprintf("<@%s>\n", m.User.ID)
-        if sb.Len()+len(line) > maxDescLen {
-            _, _ = fmt.Fprintf(&sb, "... and %d more.", len(members)-strings.Count(sb.String(), "\n"))
-            break
-        }
-        sb.WriteString(line)
-    }
-    return &discordgo.MessageEmbed{
-        Title:       fmt.Sprintf("Added %d user(s)", len(members)),
-        Description: strings.TrimRight(sb.String(), "\n"),
-        Color:       0xfbcc29, // Cav Yellow
-    }
+	const maxDescLen = 4096
+	var sb strings.Builder
+	for _, m := range members {
+		line := fmt.Sprintf("<@%s>\n", m.User.ID)
+		if sb.Len()+len(line) > maxDescLen {
+			_, _ = fmt.Fprintf(&sb, "... and %d more.", len(members)-strings.Count(sb.String(), "\n"))
+			break
+		}
+		sb.WriteString(line)
+	}
+	return &discordgo.MessageEmbed{
+		Title:       fmt.Sprintf("Added %d user(s)", len(members)),
+		Description: strings.TrimRight(sb.String(), "\n"),
+		Color:       0xfbcc29, // Cav Yellow
+	}
 }
 
 func formatUser(member *discordgo.Member) string {
-    if member == nil || member.User == nil {
-        return "<unknown>"
-    }
+	if member == nil || member.User == nil {
+		return "<unknown>"
+	}
 
-    if member.User.Discriminator != "" && member.User.Discriminator != "0" {
-        return fmt.Sprintf("%s#%s", member.User.Username, member.User.Discriminator)
-    }
+	if member.User.Discriminator != "" && member.User.Discriminator != "0" {
+		return fmt.Sprintf("%s#%s", member.User.Username, member.User.Discriminator)
+	}
 
-    return member.User.Username
+	return member.User.Username
 }
 
-func findGuildMember(session *discordgo.Session, guildID, query string) (*discordgo.Member, error) {
-    trimmedQuery := strings.TrimSpace(query)
-    if trimmedQuery == "" {
-        return nil, fmt.Errorf("❌ Empty query")
-    }
+func findGuildMember(gm GuildManager, guildID, query string) (*discordgo.Member, error) {
+	trimmedQuery := strings.TrimSpace(query)
+	if trimmedQuery == "" {
+		return nil, fmt.Errorf("❌ Empty query")
+	}
 
-    // Mentions: <@123>, <@!123>
-    if strings.HasPrefix(trimmedQuery, "<@") && strings.HasSuffix(trimmedQuery, ">") {
-        userID := strings.TrimSuffix(strings.TrimPrefix(trimmedQuery, "<@"), ">")
-        userID = strings.TrimPrefix(userID, "!")
-        if userID != "" {
-            member, err := session.GuildMember(guildID, userID)
-            if err == nil && member != nil {
-                return member, nil
-            }
-        }
-    }
+	// Mentions: <@123>, <@!123>
+	if strings.HasPrefix(trimmedQuery, "<@") && strings.HasSuffix(trimmedQuery, ">") {
+		userID := strings.TrimSuffix(strings.TrimPrefix(trimmedQuery, "<@"), ">")
+		userID = strings.TrimPrefix(userID, "!")
+		if userID != "" {
+			member, err := gm.GuildMember(guildID, userID)
+			if err == nil && member != nil {
+				return member, nil
+			}
+		}
+	}
 
-    // Raw snowflake ID
-    if isSnowflakeID(trimmedQuery) {
-        member, err := session.GuildMember(guildID, trimmedQuery)
-        if err == nil && member != nil {
-            return member, nil
-        }
-    }
+	// Raw snowflake ID
+	if isSnowflakeID(trimmedQuery) {
+		member, err := gm.GuildMember(guildID, trimmedQuery)
+		if err == nil && member != nil {
+			return member, nil
+		}
+	}
 
-    // Name search
-    members, err := session.GuildMembersSearch(guildID, trimmedQuery, 10)
-    if err != nil {
-        utils.CaptureError("Failed to search members", err)
-        return nil, fmt.Errorf("❌ Failed to search members: %v", err)
-    }
+	// Name search
+	members, err := gm.GuildMembersSearch(guildID, trimmedQuery, 10)
+	if err != nil {
+		utils.CaptureError("Failed to search members", err)
+		return nil, fmt.Errorf("❌ Failed to search members: %v", err)
+	}
 
-    switch len(members) {
-    case 0:
-        return nil, fmt.Errorf("❌ No member found matching '%s'", query)
-    case 1:
-        return members[0], nil
-    default:
-        return nil, fmt.Errorf("❌ Too many matches for '%s' (be more specific, or use a mention/ID)", query)
-    }
+	switch len(members) {
+	case 0:
+		return nil, fmt.Errorf("❌ No member found matching '%s'", query)
+	case 1:
+		return members[0], nil
+	default:
+		return nil, fmt.Errorf("❌ Too many matches for '%s' (be more specific, or use a mention/ID)", query)
+	}
 }
 
-func findGuildRoleIDByName(session *discordgo.Session, guildID, roleName string) (string, error) {
-    roles, err := session.GuildRoles(guildID)
-    if err != nil {
-        return "", err
-    }
+func findGuildRoleIDByName(gm GuildManager, guildID, roleName string) (string, error) {
+	roles, err := gm.GuildRoles(guildID)
+	if err != nil {
+		return "", err
+	}
 
-    for _, role := range roles {
-        if role != nil && role.Name == roleName {
-            return role.ID, nil
-        }
-    }
+	for _, role := range roles {
+		if role != nil && role.Name == roleName {
+			return role.ID, nil
+		}
+	}
 
-    return "", nil
+	return "", nil
 }
 
 func splitCommaSeparated(value string) []string {
-    parts := strings.Split(value, ",")
-    out := make([]string, 0, len(parts))
-    for _, part := range parts {
-        trimmed := strings.TrimSpace(part)
-        if trimmed != "" {
-            out = append(out, trimmed)
-        }
-    }
-    return out
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 func joinOrFallback(lines []string, fallback string) string {
-    joined := strings.Join(lines, "\n")
-    if strings.TrimSpace(joined) == "" {
-        return fallback
-    }
-    return joined
+	joined := strings.Join(lines, "\n")
+	if strings.TrimSpace(joined) == "" {
+		return fallback
+	}
+	return joined
 }
 
 // buildBulkAddSummary composes the bulk-add response message.
@@ -671,44 +702,44 @@ func joinOrFallback(lines []string, fallback string) string {
 // Failures are listed individually, then truncated if needed to stay
 // within Discord's 2000-character message limit.
 func buildBulkAddSummary(successCount int, failures []string) string {
-    const maxLen = 2000
+	const maxLen = 2000
 
-    var lines []string
-    if successCount > 0 {
-        lines = append(lines, fmt.Sprintf("✅ Added warden role(s) to %d user(s).", successCount))
-    }
-    lines = append(lines, failures...)
+	var lines []string
+	if successCount > 0 {
+		lines = append(lines, fmt.Sprintf("✅ Added warden role(s) to %d user(s).", successCount))
+	}
+	lines = append(lines, failures...)
 
-    if len(lines) == 0 {
-        return "⚠️ Nothing to do."
-    }
+	if len(lines) == 0 {
+		return "⚠️ Nothing to do."
+	}
 
-    msg := strings.Join(lines, "\n")
-    if len(msg) <= maxLen {
-        return msg
-    }
+	msg := strings.Join(lines, "\n")
+	if len(msg) <= maxLen {
+		return msg
+	}
 
-    // Truncate: fit as many lines as possible, then append an overflow count.
-    var kept []string
-    for i, line := range lines {
-        overflowNote := fmt.Sprintf("\n... and %d more.", len(lines)-i)
-        if len(strings.Join(append(kept, line), "\n"))+len(overflowNote) > maxLen {
-            kept = append(kept, fmt.Sprintf("... and %d more.", len(lines)-i))
-            break
-        }
-        kept = append(kept, line)
-    }
-    return strings.Join(kept, "\n")
+	// Truncate: fit as many lines as possible, then append an overflow count.
+	var kept []string
+	for i, line := range lines {
+		overflowNote := fmt.Sprintf("\n... and %d more.", len(lines)-i)
+		if len(strings.Join(append(kept, line), "\n"))+len(overflowNote) > maxLen {
+			kept = append(kept, fmt.Sprintf("... and %d more.", len(lines)-i))
+			break
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
 }
 
 func isSnowflakeID(value string) bool {
-    if len(value) < 15 {
-        return false
-    }
-    for _, runeValue := range value {
-        if runeValue < '0' || runeValue > '9' {
-            return false
-        }
-    }
-    return true
+	if len(value) < 15 {
+		return false
+	}
+	for _, runeValue := range value {
+		if runeValue < '0' || runeValue > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/commands/warden_test.go
+++ b/commands/warden_test.go
@@ -1,0 +1,466 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// fakeGuildManager is a deterministic GuildManager for /warden integration
+// tests. It records every call and serves canned data; per-method error queues
+// (popped FIFO via popErr) let a test inject a failure on a specific call. The
+// zero value answers role/member lookups from the maps below, so a test only
+// populates what it exercises.
+type fakeGuildManager struct {
+	mu    sync.Mutex
+	calls []string
+
+	// roles returned by GuildRoles (name->ID lookups and fetch-by-ID both read it).
+	roles []*discordgo.Role
+	// members keyed by the query (mention/ID/name) GuildMember/Search receives.
+	membersByID    map[string]*discordgo.Member
+	searchResults  map[string][]*discordgo.Member
+	channels       []*discordgo.Channel
+	createdRole    *discordgo.Role // returned by GuildRoleCreate
+	nextCreatedNum int
+
+	RolesErrs            []error
+	RoleCreateErrs       []error
+	RoleEditErrs         []error
+	RoleDeleteErrs       []error
+	ChannelsErrs         []error
+	ChannelPermSetErrs   []error
+	MemberErrs           []error
+	MembersSearchErrs    []error
+	MemberRoleAddErrs    []error
+	MemberRoleRemoveErrs []error
+}
+
+func (g *fakeGuildManager) record(name string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.calls = append(g.calls, name)
+}
+
+func (g *fakeGuildManager) Calls() []string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]string(nil), g.calls...)
+}
+
+func (g *fakeGuildManager) countCalls(name string) int {
+	n := 0
+	for _, c := range g.Calls() {
+		if c == name {
+			n++
+		}
+	}
+	return n
+}
+
+func (g *fakeGuildManager) GuildRoles(_ string) ([]*discordgo.Role, error) {
+	g.record("GuildRoles")
+	if err := popErr(&g.RolesErrs); err != nil {
+		return nil, err
+	}
+	return g.roles, nil
+}
+
+func (g *fakeGuildManager) GuildRoleCreate(_ string, _ *discordgo.RoleParams) (*discordgo.Role, error) {
+	g.record("GuildRoleCreate")
+	if err := popErr(&g.RoleCreateErrs); err != nil {
+		return nil, err
+	}
+	g.nextCreatedNum++
+	if g.createdRole != nil {
+		return g.createdRole, nil
+	}
+	return &discordgo.Role{ID: fmt.Sprintf("new-role-%d", g.nextCreatedNum)}, nil
+}
+
+func (g *fakeGuildManager) GuildRoleEdit(_, _ string, _ *discordgo.RoleParams) (*discordgo.Role, error) {
+	g.record("GuildRoleEdit")
+	if err := popErr(&g.RoleEditErrs); err != nil {
+		return nil, err
+	}
+	return &discordgo.Role{}, nil
+}
+
+func (g *fakeGuildManager) GuildRoleDelete(_, _ string) error {
+	g.record("GuildRoleDelete")
+	return popErr(&g.RoleDeleteErrs)
+}
+
+func (g *fakeGuildManager) GuildChannels(_ string) ([]*discordgo.Channel, error) {
+	g.record("GuildChannels")
+	if err := popErr(&g.ChannelsErrs); err != nil {
+		return nil, err
+	}
+	return g.channels, nil
+}
+
+func (g *fakeGuildManager) ChannelPermissionSet(_, _ string, _ discordgo.PermissionOverwriteType, _, _ int64) error {
+	g.record("ChannelPermissionSet")
+	return popErr(&g.ChannelPermSetErrs)
+}
+
+func (g *fakeGuildManager) GuildMember(_, userID string) (*discordgo.Member, error) {
+	g.record("GuildMember")
+	if err := popErr(&g.MemberErrs); err != nil {
+		return nil, err
+	}
+	if m, ok := g.membersByID[userID]; ok {
+		return m, nil
+	}
+	return nil, fmt.Errorf("member %s not found", userID)
+}
+
+func (g *fakeGuildManager) GuildMembersSearch(_, query string, _ int) ([]*discordgo.Member, error) {
+	g.record("GuildMembersSearch")
+	if err := popErr(&g.MembersSearchErrs); err != nil {
+		return nil, err
+	}
+	return g.searchResults[query], nil
+}
+
+func (g *fakeGuildManager) GuildMemberRoleAdd(_, _, _ string) error {
+	g.record("GuildMemberRoleAdd")
+	return popErr(&g.MemberRoleAddErrs)
+}
+
+func (g *fakeGuildManager) GuildMemberRoleRemove(_, _, _ string) error {
+	g.record("GuildMemberRoleRemove")
+	return popErr(&g.MemberRoleRemoveErrs)
+}
+
+// wardenInteraction builds an *InteractionCreate carrying the given option
+// values plus a GuildID, which runWarden requires (it rejects DM-context).
+func wardenInteraction(guildID string, opts ...*discordgo.ApplicationCommandInteractionDataOption) *discordgo.InteractionCreate {
+	i := fakeAppCommandInteraction(opts...)
+	i.GuildID = guildID
+	return i
+}
+
+// wardenRole is a convenience constructor for a guild role.
+func wardenRole(id, name string) *discordgo.Role {
+	return &discordgo.Role{ID: id, Name: name}
+}
+
+// noOverwriteDelay zeroes the purge throttle for the duration of a test so the
+// suite doesn't sleep 200ms per channel overwrite.
+func noOverwriteDelay(t *testing.T) {
+	t.Helper()
+	prev := wardenOverwriteDelay
+	wardenOverwriteDelay = 0
+	t.Cleanup(func() { wardenOverwriteDelay = prev })
+}
+
+// lastEditContent returns the Content of the last Edit call, or "<none>".
+func lastEditContent(calls []recordedCall) string {
+	for idx := len(calls) - 1; idx >= 0; idx-- {
+		if calls[idx].Method == "Edit" && calls[idx].Edit != nil && calls[idx].Edit.Content != nil {
+			return *calls[idx].Edit.Content
+		}
+	}
+	return "<none>"
+}
+
+// --- runWarden routing / deferred-ephemeral acknowledge path ---
+
+func TestRunWarden_AddDeferredEphemeralAcknowledge(t *testing.T) {
+	gm := &fakeGuildManager{
+		roles:       []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		membersByID: map[string]*discordgo.Member{"123456789012345678": {User: &discordgo.User{ID: "123456789012345678", Username: "trooper"}}},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1",
+		stringOption("command", "add"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "123456789012345678"),
+	)
+
+	runWarden(f, gm, i)
+
+	calls := f.Calls()
+	if len(calls) == 0 {
+		t.Fatal("expected at least one responder call")
+	}
+	// The deferred-ephemeral pattern is load-bearing: the first response MUST be
+	// a deferred-channel-message with the ephemeral flag set.
+	first := calls[0]
+	if first.Method != "Respond" {
+		t.Fatalf("calls[0]: expected Respond (defer), got %q", first.Method)
+	}
+	if first.Response.Type != discordgo.InteractionResponseDeferredChannelMessageWithSource {
+		t.Fatalf("expected deferred response type, got %v", first.Response.Type)
+	}
+	if first.Response.Data == nil || first.Response.Data.Flags&discordgo.MessageFlagsEphemeral == 0 {
+		t.Fatalf("expected MessageFlagsEphemeral on the defer; got flags=%v", first.Response.Data)
+	}
+	// Role added, success edit follows.
+	if gm.countCalls("GuildMemberRoleAdd") != 1 {
+		t.Fatalf("expected 1 GuildMemberRoleAdd, got %d (%v)", gm.countCalls("GuildMemberRoleAdd"), gm.Calls())
+	}
+	if got := lastEditContent(calls); !strings.Contains(got, "✅ Added warden role(s)") {
+		t.Fatalf("expected success edit, got %q", got)
+	}
+}
+
+func TestRunWarden_InvalidSubcommandSurfacesError(t *testing.T) {
+	gm := &fakeGuildManager{}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1",
+		stringOption("command", "bogus"),
+		stringOption("flag", "internal"),
+	)
+
+	runWarden(f, gm, i)
+
+	if len(f.Calls()) == 0 {
+		t.Fatal("expected an error response")
+	}
+	if len(gm.Calls()) != 0 {
+		t.Fatalf("invalid subcommand must not touch guild; got %v", gm.Calls())
+	}
+}
+
+func TestRunWarden_MissingGuildIDRejected(t *testing.T) {
+	gm := &fakeGuildManager{}
+	f := &fakeResponder{}
+	// No GuildID => DM context, must be rejected before any guild call.
+	i := fakeAppCommandInteraction(
+		stringOption("command", "add"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "x"),
+	)
+
+	runWarden(f, gm, i)
+
+	if len(gm.Calls()) != 0 {
+		t.Fatalf("DM-context must not touch guild; got %v", gm.Calls())
+	}
+}
+
+// --- purge: happy path ---
+
+func TestRunWardenPurge_HappyPath(t *testing.T) {
+	noOverwriteDelay(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("old-int", wardenRoleBaseName+" Internal")},
+		channels: []*discordgo.Channel{
+			{
+				ID: "chan-1",
+				PermissionOverwrites: []*discordgo.PermissionOverwrite{
+					{ID: "old-int", Type: discordgo.PermissionOverwriteTypeRole, Allow: 1, Deny: 0},
+				},
+			},
+		},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1")
+
+	runWardenPurge(f, gm, i, "guild-1", "internal")
+
+	// Role recreated: create + edit + one overwrite reapply + delete old.
+	if gm.countCalls("GuildRoleCreate") != 1 {
+		t.Fatalf("expected 1 GuildRoleCreate, got %v", gm.Calls())
+	}
+	if gm.countCalls("ChannelPermissionSet") != 1 {
+		t.Fatalf("expected 1 ChannelPermissionSet, got %v", gm.Calls())
+	}
+	if gm.countCalls("GuildRoleDelete") != 1 {
+		t.Fatalf("expected 1 GuildRoleDelete, got %v", gm.Calls())
+	}
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "✅ Recreated 'Verified Warden Internal'") {
+		t.Fatalf("expected success summary, got %q", got)
+	}
+	if !strings.Contains(got, "re-applied 1 overwrite(s)") {
+		t.Fatalf("expected overwrite count in summary, got %q", got)
+	}
+}
+
+func TestRunWardenPurge_BothScopeRecreatesTwoRoles(t *testing.T) {
+	noOverwriteDelay(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{
+			wardenRole("old-int", wardenRoleBaseName+" Internal"),
+			wardenRole("old-ext", wardenRoleBaseName+" External"),
+		},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1")
+
+	runWardenPurge(f, gm, i, "guild-1", "both")
+
+	if gm.countCalls("GuildRoleCreate") != 2 {
+		t.Fatalf("expected 2 role creates for 'both', got %d (%v)", gm.countCalls("GuildRoleCreate"), gm.Calls())
+	}
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Internal") || !strings.Contains(got, "External") {
+		t.Fatalf("expected both roles in summary, got %q", got)
+	}
+}
+
+// --- purge: partial failure (one role recreation fails) ---
+
+func TestRunWardenPurge_PartialFailureContinues(t *testing.T) {
+	noOverwriteDelay(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{
+			wardenRole("old-int", wardenRoleBaseName+" Internal"),
+			wardenRole("old-ext", wardenRoleBaseName+" External"),
+		},
+		// First create succeeds, second fails -> External role recreation errors,
+		// but the loop must continue and report a mixed summary.
+		RoleCreateErrs: []error{nil, fmt.Errorf("discord 500")},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1")
+
+	runWardenPurge(f, gm, i, "guild-1", "both")
+
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "✅ Recreated 'Verified Warden Internal'") {
+		t.Fatalf("expected the first role to succeed, got %q", got)
+	}
+	if !strings.Contains(got, "❌ Failed to recreate 'Verified Warden External'") {
+		t.Fatalf("expected the second role to be reported failed, got %q", got)
+	}
+	// The old External role must NOT be deleted when its recreation failed.
+	if gm.countCalls("GuildRoleDelete") != 1 {
+		t.Fatalf("expected exactly 1 delete (only the successful role), got %d (%v)", gm.countCalls("GuildRoleDelete"), gm.Calls())
+	}
+}
+
+// --- purge: guild not accessible (channels fetch fails) ---
+
+func TestRunWardenPurge_GuildChannelsErrorSurfaces(t *testing.T) {
+	noOverwriteDelay(t)
+	gm := &fakeGuildManager{
+		roles:        []*discordgo.Role{wardenRole("old-int", wardenRoleBaseName+" Internal")},
+		ChannelsErrs: []error{fmt.Errorf("missing access")},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1")
+
+	runWardenPurge(f, gm, i, "guild-1", "internal")
+
+	if gm.countCalls("GuildRoleCreate") != 0 {
+		t.Fatalf("must not recreate roles when channels are inaccessible; got %v", gm.Calls())
+	}
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "❌ Failed to retrieve guild channels") {
+		t.Fatalf("expected guild-channels error surfaced, got %q", got)
+	}
+}
+
+func TestRunWardenPurge_RoleNotFoundSurfaces(t *testing.T) {
+	noOverwriteDelay(t)
+	// No matching warden role in the guild -> resolveWardenRoleIDs errors out
+	// before any mutation.
+	gm := &fakeGuildManager{roles: []*discordgo.Role{wardenRole("x", "Some Other Role")}}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1")
+
+	runWardenPurge(f, gm, i, "guild-1", "internal")
+
+	if gm.countCalls("GuildChannels") != 0 {
+		t.Fatalf("must short-circuit before fetching channels; got %v", gm.Calls())
+	}
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "role not found in guild") {
+		t.Fatalf("expected role-not-found error, got %q", got)
+	}
+}
+
+// --- remove + bulkadd coverage ---
+
+func TestRunWarden_RemoveSuccess(t *testing.T) {
+	gm := &fakeGuildManager{
+		roles:       []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		membersByID: map[string]*discordgo.Member{"123456789012345678": {User: &discordgo.User{ID: "123456789012345678", Username: "trooper"}}},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1",
+		stringOption("command", "remove"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "123456789012345678"),
+	)
+
+	runWarden(f, gm, i)
+
+	if gm.countCalls("GuildMemberRoleRemove") != 1 {
+		t.Fatalf("expected 1 GuildMemberRoleRemove, got %v", gm.Calls())
+	}
+	if got := lastEditContent(f.Calls()); !strings.Contains(got, "✅ Removed warden role(s)") {
+		t.Fatalf("expected remove success, got %q", got)
+	}
+}
+
+func TestRunWarden_AddRoleAddFailureSurfaces(t *testing.T) {
+	gm := &fakeGuildManager{
+		roles:             []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		membersByID:       map[string]*discordgo.Member{"123456789012345678": {User: &discordgo.User{ID: "123456789012345678", Username: "trooper"}}},
+		MemberRoleAddErrs: []error{fmt.Errorf("forbidden")},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1",
+		stringOption("command", "add"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "123456789012345678"),
+	)
+
+	runWarden(f, gm, i)
+
+	if got := lastEditContent(f.Calls()); !strings.Contains(got, "❌ Failed to add 'Verified Warden Internal' role") {
+		t.Fatalf("expected role-add failure surfaced, got %q", got)
+	}
+}
+
+func TestRunWarden_BulkAddMixedResults(t *testing.T) {
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		searchResults: map[string][]*discordgo.Member{
+			"good": {{User: &discordgo.User{ID: "111", Username: "good"}}},
+			// "bad" has no search result -> findGuildMember returns not-found.
+		},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1",
+		stringOption("command", "bulkadd"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "good, bad"),
+	)
+
+	runWarden(f, gm, i)
+
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Added warden role(s) to 1 user(s)") {
+		t.Fatalf("expected 1 success in summary, got %q", got)
+	}
+	if !strings.Contains(got, "No member found matching 'bad'") {
+		t.Fatalf("expected 'bad' reported as failure, got %q", got)
+	}
+}
+
+func TestRunWarden_MissingDiscordnameForAdd(t *testing.T) {
+	gm := &fakeGuildManager{}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1",
+		stringOption("command", "add"),
+		stringOption("flag", "internal"),
+	)
+
+	runWarden(f, gm, i)
+
+	if len(gm.Calls()) != 0 {
+		t.Fatalf("missing discordname must short-circuit before guild calls; got %v", gm.Calls())
+	}
+	if len(f.Calls()) == 0 {
+		t.Fatal("expected an error response for missing discordname")
+	}
+}


### PR DESCRIPTION
Closes #106.

Converts `/warden` (deferred-ephemeral, Pattern C) to the test harness behind a new `GuildManager` seam, extracts the inline purge goroutine, and adds integration coverage.

## Changes
- `commands/guild_manager.go` (new): `GuildManager` interface (~10 guild role/member methods) + thin `sessionGuildManager` wrapper around `*discordgo.Session` (precedent: `utils.NewSessionResponder`).
- `commands/warden.go`: `handleWarden → runWarden(r, gm, i)`; inline purge `go func(){…}()` extracted to named `runWardenPurge(...)` (directly testable); deferred-ephemeral (`MessageFlagsEphemeral`, `deferEphemeral`/`editEphemeral`) **preserved**; `wardenOverwriteDelay` made a var so tests skip the sleep; `🚀 Starting`/`✨ Done!` logs. User-facing behavior byte-for-byte unchanged.
- `commands/warden_test.go` (new): 12 cases incl. the four required — deferred-ephemeral ack, happy-path purge, partial-failure purge, guild-not-accessible — via a recording `fakeGuildManager` with per-method error injection.
- `.github/scripts/check-coverage-floors.sh`: commands floor 60 → 75 (measured 76.4%).

Floor note: the wrapper's ~11 uncovered pass-throughs are fully absorbed — routing `/warden` through the fake lifted commands coverage 60.7% → 76.4%. Placed in `commands/` to avoid pressuring the tight utils-77 floor.

## Test plan
- `golangci-lint` clean, `go test ./...` green (commands 76.4% ≥ 75), `go test ./commands/ -race` clean, `go build` OK.

## Manual review gate
- Smoke test `/warden` on the test guild — deferred-ephemeral admin command, live gateway not exercisable in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)