### PR TITLE
test(utils): cover loa parseLOAPost and refresh logic (#109)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 # heredoc, read returns 1 at EOF. Without `|| true`, `set -e` would kill the
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
-github.com/7cav/cavbot2/utils	77
+github.com/7cav/cavbot2/utils	82
 github.com/7cav/cavbot2/commands	75
 EOF
 

--- a/utils/loa.go
+++ b/utils/loa.go
@@ -67,11 +67,73 @@ func (c *LOACache) IsHealthy(maxAge time.Duration) (bool, time.Time) {
 	return time.Since(c.lastSuccessfulRefresh) <= maxAge, c.lastSuccessfulRefresh
 }
 
+// loaPostRow is one forum post row fetched for a node: the raw message body and
+// the post/thread identifiers the core refresh loop needs.
+type loaPostRow struct {
+	message  string
+	postDate int64
+	threadID int64
+}
+
+// loaPostFetcher abstracts the per-node forum fetch so the refresh/prune core can
+// be exercised with a fake instead of a live MySQL connection. The production
+// implementation (sqlLOAFetcher) wraps *sql.DB and preserves the exact query and
+// row/stream-error semantics the cache relies on. This is a narrow test seam only;
+// it does not replace the process-global GlobalLOACache singleton with DI.
+type loaPostFetcher interface {
+	// fetchLOAPosts returns all visible LOA posts in nodeID with post_date > since,
+	// ordered oldest-first. A non-nil error means the node fetch failed (including a
+	// mid-stream rows error) and must not count as a successful node.
+	fetchLOAPosts(nodeID int, since int64) ([]loaPostRow, error)
+}
+
+// sqlLOAFetcher is the production loaPostFetcher backed by the Xenforo forum DB.
+type sqlLOAFetcher struct {
+	db *sql.DB
+}
+
+func (f sqlLOAFetcher) fetchLOAPosts(nodeID int, since int64) ([]loaPostRow, error) {
+	rows, err := f.db.Query(`
+		SELECT p.message, t.post_date, t.thread_id
+		FROM xf_thread t
+		JOIN xf_post p ON p.post_id = t.first_post_id
+		WHERE t.node_id = ?
+		  AND t.discussion_state = 'visible'
+		  AND t.post_date > ?
+		ORDER BY t.post_date ASC
+	`, nodeID, since)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []loaPostRow
+	for rows.Next() {
+		var r loaPostRow
+		if err := rows.Scan(&r.message, &r.postDate, &r.threadID); err != nil {
+			Warn("LOA row scan failed", "node_id", nodeID, "error", err)
+			continue
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Refresh fetches LOA posts from the forum DB incrementally and updates the cache.
 // On first call it fetches posts from the past year; subsequent calls fetch only newer posts.
 // Multiple node IDs are supported to cover all LOA forum sections; each node is queried
 // separately so per-node parse counts can be logged for diagnostics.
 func (c *LOACache) Refresh(db *sql.DB, nodeIDs []int) {
+	c.refresh(sqlLOAFetcher{db: db}, nodeIDs)
+}
+
+// refresh is the fetcher-agnostic core of Refresh: it computes the incremental
+// `since` cursor, prunes ended entries, then applies each node's fetched posts.
+// Refresh wires in the production sqlLOAFetcher; tests supply a fake.
+func (c *LOACache) refresh(fetcher loaPostFetcher, nodeIDs []int) {
 	c.mu.RLock()
 	since := c.lastSyncedPostDate
 	c.mu.RUnlock()
@@ -96,46 +158,25 @@ func (c *LOACache) Refresh(db *sql.DB, nodeIDs []int) {
 	successfulNodes := 0
 
 	for _, nodeID := range nodeIDs {
-		rows, err := db.Query(`
-			SELECT p.message, t.post_date, t.thread_id
-			FROM xf_thread t
-			JOIN xf_post p ON p.post_id = t.first_post_id
-			WHERE t.node_id = ?
-			  AND t.discussion_state = 'visible'
-			  AND t.post_date > ?
-			ORDER BY t.post_date ASC
-		`, nodeID, since)
+		posts, err := fetcher.fetchLOAPosts(nodeID, since)
 		if err != nil {
 			Warn("LOA cache refresh failed", "node_id", nodeID, "error", err)
 			continue
 		}
 
 		nodeParsed := 0
-		for rows.Next() {
-			var message string
-			var postDate, threadID int64
-			if err := rows.Scan(&message, &postDate, &threadID); err != nil {
-				Warn("LOA row scan failed", "node_id", nodeID, "error", err)
-				continue
-			}
-			entry, ok := parseLOAPost(message)
+		for _, p := range posts {
+			entry, ok := parseLOAPost(p.message)
 			if !ok {
-				Debug("LOA post skipped (parse failed)", "node_id", nodeID, "post_date", postDate)
+				Debug("LOA post skipped (parse failed)", "node_id", nodeID, "post_date", p.postDate)
 				continue
 			}
-			entry.ThreadID = threadID
+			entry.ThreadID = p.threadID
 			c.entries[strings.ToLower(entry.Username)] = entry
-			if postDate > maxPostDate {
-				maxPostDate = postDate
+			if p.postDate > maxPostDate {
+				maxPostDate = p.postDate
 			}
 			nodeParsed++
-		}
-		rowsErr := rows.Err()
-		_ = rows.Close()
-
-		if rowsErr != nil {
-			Warn("LOA cache refresh failed mid-stream", "node_id", nodeID, "error", rowsErr)
-			continue
 		}
 
 		Info("LOA node refreshed", "node_id", nodeID, "new_parsed", nodeParsed)

--- a/utils/loa_test.go
+++ b/utils/loa_test.go
@@ -9,6 +9,273 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
+// loaPost builds a forum post body in the canonical yellow-label template that
+// parseLOAPost expects: a Username line (label, optional colon, value on the same
+// line) followed by Start Date / End Date labels each with their value on the NEXT
+// line. Callers pass raw date strings so malformed-date cases can be exercised.
+func loaPost(username, start, end string) string {
+	return "[B][COLOR=rgb(213, 185, 0)]Username[/COLOR][/B]: " + username + "\n" +
+		"[B][COLOR=rgb(213, 185, 0)]Start Date[/COLOR][/B]\n" + start + "\n" +
+		"[B][COLOR=rgb(213, 185, 0)]End Date[/COLOR][/B]\n" + end + "\n"
+}
+
+// TestParseLOAPost locks in the CURRENT contract of the brittle BBCode regexes.
+// Each case asserts actual observed behavior of the existing regexes (verified by
+// probe), not aspirational behavior — so this catches Xenforo template drift.
+func TestParseLOAPost(t *testing.T) {
+	tests := []struct {
+		name      string
+		msg       string
+		wantOK    bool
+		wantUser  string
+		wantStart string // "2006-01-02"; checked only when wantOK
+		wantEnd   string
+	}{
+		{
+			name:      "well-formed yellow-label template",
+			msg:       loaPost("TestUser", "Jan 1, 2099", "Jan 31, 2099"),
+			wantOK:    true,
+			wantUser:  "TestUser",
+			wantStart: "2099-01-01",
+			wantEnd:   "2099-01-31",
+		},
+		{
+			name:      "rgb without spaces still matches",
+			msg:       "[B][COLOR=rgb(213,185,0)]Username[/COLOR][/B]: Nospace\n[B][COLOR=rgb(213,185,0)]Start Date[/COLOR][/B]\nFeb 2, 2099\n[B][COLOR=rgb(213,185,0)]End Date[/COLOR][/B]\nFeb 9, 2099\n",
+			wantOK:    true,
+			wantUser:  "Nospace",
+			wantStart: "2099-02-02",
+			wantEnd:   "2099-02-09",
+		},
+		{
+			name:      "username without colon separator",
+			msg:       "[B][COLOR=rgb(213, 185, 0)]Username[/COLOR][/B] NoColon\n[B][COLOR=rgb(213, 185, 0)]Start Date[/COLOR][/B]\nMar 1, 2099\n[B][COLOR=rgb(213, 185, 0)]End Date[/COLOR][/B]\nMar 5, 2099\n",
+			wantOK:    true,
+			wantUser:  "NoColon",
+			wantStart: "2099-03-01",
+			wantEnd:   "2099-03-05",
+		},
+		{
+			name:      "CRLF line endings still parse",
+			msg:       "[B][COLOR=rgb(213, 185, 0)]Username[/COLOR][/B]: CrlfUser\r\n[B][COLOR=rgb(213, 185, 0)]Start Date[/COLOR][/B]\r\nApr 1, 2099\r\n[B][COLOR=rgb(213, 185, 0)]End Date[/COLOR][/B]\r\nApr 4, 2099\r\n",
+			wantOK:    true,
+			wantUser:  "CrlfUser",
+			wantStart: "2099-04-01",
+			wantEnd:   "2099-04-04",
+		},
+		{
+			name:      "username with space captures only first token (\\S+ stops at space)",
+			msg:       loaPost("First Last", "May 1, 2099", "May 9, 2099"),
+			wantOK:    true,
+			wantUser:  "First",
+			wantStart: "2099-05-01",
+			wantEnd:   "2099-05-09",
+		},
+		{
+			name:   "missing Username field",
+			msg:    "[B][COLOR=rgb(213, 185, 0)]Start Date[/COLOR][/B]\nJan 1, 2099\n[B][COLOR=rgb(213, 185, 0)]End Date[/COLOR][/B]\nJan 31, 2099\n",
+			wantOK: false,
+		},
+		{
+			name:   "missing Start Date field",
+			msg:    "[B][COLOR=rgb(213, 185, 0)]Username[/COLOR][/B]: NoStart\n[B][COLOR=rgb(213, 185, 0)]End Date[/COLOR][/B]\nJan 31, 2099\n",
+			wantOK: false,
+		},
+		{
+			name:   "missing End Date field",
+			msg:    "[B][COLOR=rgb(213, 185, 0)]Username[/COLOR][/B]: NoEnd\n[B][COLOR=rgb(213, 185, 0)]Start Date[/COLOR][/B]\nJan 1, 2099\n",
+			wantOK: false,
+		},
+		{
+			name:   "malformed start date (ISO format not accepted)",
+			msg:    loaPost("BadStart", "2099-01-01", "Jan 31, 2099"),
+			wantOK: false,
+		},
+		{
+			name:   "malformed end date (ISO format not accepted)",
+			msg:    loaPost("BadEnd", "Jan 1, 2099", "2099-01-31"),
+			wantOK: false,
+		},
+		{
+			name:   "legacy variant: date inline with label on same line does not parse",
+			msg:    "[B][COLOR=rgb(213, 185, 0)]Username[/COLOR][/B]: Inline\n[B][COLOR=rgb(213, 185, 0)]Start Date[/COLOR][/B] Jan 1, 2099\n[B][COLOR=rgb(213, 185, 0)]End Date[/COLOR][/B] Jan 31, 2099\n",
+			wantOK: false,
+		},
+		{
+			name:   "legacy variant: wrong color (non-yellow label) does not match",
+			msg:    "[B][COLOR=rgb(0, 0, 0)]Username[/COLOR][/B]: Black\n[B][COLOR=rgb(0, 0, 0)]Start Date[/COLOR][/B]\nJan 1, 2099\n[B][COLOR=rgb(0, 0, 0)]End Date[/COLOR][/B]\nJan 31, 2099\n",
+			wantOK: false,
+		},
+		{
+			name:   "completely unrelated post content",
+			msg:    "Hey everyone, just wanted to say thanks for the great op last night o7",
+			wantOK: false,
+		},
+		{
+			name:   "empty body",
+			msg:    "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseLOAPost(tt.msg)
+			if ok != tt.wantOK {
+				t.Fatalf("parseLOAPost ok = %v, want %v (entry=%+v)", ok, tt.wantOK, got)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got.Username != tt.wantUser {
+				t.Errorf("Username = %q, want %q", got.Username, tt.wantUser)
+			}
+			if gotStart := got.StartDate.Format("2006-01-02"); gotStart != tt.wantStart {
+				t.Errorf("StartDate = %q, want %q", gotStart, tt.wantStart)
+			}
+			if gotEnd := got.EndDate.Format("2006-01-02"); gotEnd != tt.wantEnd {
+				t.Errorf("EndDate = %q, want %q", gotEnd, tt.wantEnd)
+			}
+		})
+	}
+}
+
+// fakeLOAFetcher is a loaPostFetcher test double. It records the `since` cursor it
+// was called with per node and returns canned posts (or a canned error) per node,
+// so the refresh/prune core can be exercised without MySQL.
+type fakeLOAFetcher struct {
+	byNode    map[int][]loaPostRow
+	errByNode map[int]error
+	gotSince  map[int]int64
+	calls     int
+}
+
+func (f *fakeLOAFetcher) fetchLOAPosts(nodeID int, since int64) ([]loaPostRow, error) {
+	if f.gotSince == nil {
+		f.gotSince = map[int]int64{}
+	}
+	f.gotSince[nodeID] = since
+	f.calls++
+	if err := f.errByNode[nodeID]; err != nil {
+		return nil, err
+	}
+	return f.byNode[nodeID], nil
+}
+
+func TestRefresh_IncrementalAdvance(t *testing.T) {
+	c := &LOACache{entries: map[string]LOAEntry{}}
+
+	// First refresh: cold cache → since should be ~one year ago (non-zero), and
+	// lastSyncedPostDate should advance to the max post_date observed.
+	firstPost := time.Now().Add(-48 * time.Hour).Unix()
+	f := &fakeLOAFetcher{byNode: map[int][]loaPostRow{
+		180: {{message: loaPost("alpha", "Jan 1, 2099", "Jan 31, 2099"), postDate: firstPost, threadID: 1}},
+	}}
+	c.refresh(f, []int{180})
+
+	if c.lastSyncedPostDate != firstPost {
+		t.Fatalf("after first refresh lastSyncedPostDate = %d, want %d", c.lastSyncedPostDate, firstPost)
+	}
+	yearAgo := time.Now().AddDate(-1, 0, 0).Unix()
+	if got := f.gotSince[180]; got > yearAgo+5 || got < yearAgo-5 {
+		t.Fatalf("cold-cache since = %d, want ~%d (one year ago)", got, yearAgo)
+	}
+	if _, ok := c.GetEntry("alpha"); !ok {
+		t.Fatalf("expected alpha entry present after first refresh")
+	}
+
+	// Second refresh: warm cache → since must equal the prior high-water mark, and a
+	// newer post advances the cursor again.
+	secondPost := time.Now().Add(-1 * time.Hour).Unix()
+	f2 := &fakeLOAFetcher{byNode: map[int][]loaPostRow{
+		180: {{message: loaPost("bravo", "Jan 1, 2099", "Jan 31, 2099"), postDate: secondPost, threadID: 2}},
+	}}
+	c.refresh(f2, []int{180})
+
+	if f2.gotSince[180] != firstPost {
+		t.Fatalf("warm-cache since = %d, want prior high-water %d", f2.gotSince[180], firstPost)
+	}
+	if c.lastSyncedPostDate != secondPost {
+		t.Fatalf("after second refresh lastSyncedPostDate = %d, want %d", c.lastSyncedPostDate, secondPost)
+	}
+}
+
+func TestRefresh_PrunesExpiredEntries(t *testing.T) {
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	// Seed: one expired (EndDate in the past) and one still-active entry.
+	c.entries["expired"] = LOAEntry{Username: "expired", StartDate: time.Now().Add(-72 * time.Hour), EndDate: time.Now().Add(-24 * time.Hour)}
+	c.entries["active"] = LOAEntry{Username: "active", StartDate: time.Now().Add(-24 * time.Hour), EndDate: time.Now().Add(24 * time.Hour)}
+	c.lastSyncedPostDate = 100 // warm cache so since is deterministic
+
+	f := &fakeLOAFetcher{byNode: map[int][]loaPostRow{180: nil}}
+	c.refresh(f, []int{180})
+
+	if _, ok := c.GetEntry("expired"); ok {
+		t.Errorf("expired entry should have been pruned")
+	}
+	if _, ok := c.GetEntry("active"); !ok {
+		t.Errorf("active entry must survive prune")
+	}
+}
+
+func TestRefresh_NoNewPosts_IsNoOp(t *testing.T) {
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	c.entries["keep"] = LOAEntry{Username: "keep", StartDate: time.Now().Add(-1 * time.Hour), EndDate: time.Now().Add(72 * time.Hour)}
+	c.lastSyncedPostDate = 555
+
+	// Node returns no rows; the cursor must not move and the existing entry stays.
+	f := &fakeLOAFetcher{byNode: map[int][]loaPostRow{180: {}}}
+	c.refresh(f, []int{180})
+
+	if c.lastSyncedPostDate != 555 {
+		t.Errorf("lastSyncedPostDate moved to %d on no-op, want 555", c.lastSyncedPostDate)
+	}
+	if _, ok := c.GetEntry("keep"); !ok {
+		t.Errorf("active entry must remain after no-op refresh")
+	}
+	if f.gotSince[180] != 555 {
+		t.Errorf("since = %d, want warm-cache cursor 555", f.gotSince[180])
+	}
+}
+
+func TestRefresh_FetcherError_DoesNotAdvanceCursor(t *testing.T) {
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	c.lastSyncedPostDate = 42
+	f := &fakeLOAFetcher{errByNode: map[int]error{180: errors.New("boom")}}
+
+	c.refresh(f, []int{180})
+
+	if c.lastSyncedPostDate != 42 {
+		t.Errorf("cursor advanced on fetch error: %d, want 42", c.lastSyncedPostDate)
+	}
+	if !c.lastSuccessfulRefresh.IsZero() {
+		t.Errorf("failed-only refresh must not record success")
+	}
+}
+
+func TestGetEntryAndIsOnLOA(t *testing.T) {
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	c.entries["onloa"] = LOAEntry{Username: "OnLOA", StartDate: time.Now().Add(-1 * time.Hour), EndDate: time.Now().Add(1 * time.Hour)}
+	c.entries["future"] = LOAEntry{Username: "Future", StartDate: time.Now().Add(24 * time.Hour), EndDate: time.Now().Add(48 * time.Hour)}
+
+	// GetEntry is case-insensitive on the lookup key.
+	if _, ok := c.GetEntry("ONLOA"); !ok {
+		t.Errorf("GetEntry should be case-insensitive")
+	}
+	if _, ok := c.GetEntry("missing"); ok {
+		t.Errorf("GetEntry for absent user should be false")
+	}
+	if !c.IsOnLOA("onloa") {
+		t.Errorf("IsOnLOA should be true for currently-active window")
+	}
+	if c.IsOnLOA("future") {
+		t.Errorf("IsOnLOA should be false before StartDate")
+	}
+	if c.IsOnLOA("missing") {
+		t.Errorf("IsOnLOA should be false for unknown user")
+	}
+}
+
 func TestIsHealthy(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Closes #109.

Locks in the brittle LOA BBCode parser contract and decouples refresh/prune logic from MySQL for test.

## Changes
- `utils/loa.go`: extract a minimal `loaPostFetcher` interface (`fetchLOAPosts(nodeID, since) ([]loaPostRow, error)`); production `sqlLOAFetcher` holds the exact original SELECT/scan/`rows.Err()` semantics (mid-stream row error still fails the node). `Refresh(db, nodeIDs)` is now a one-line wrapper over a fetcher-agnostic `refresh(fetcher, nodeIDs)` core — same cursor, prune, and successful-node accounting. `GlobalLOACache` singleton untouched (no DI sprawl — that's the separate `/loa` issue).
- `utils/loa_test.go` (+267): 14 `parseLOAPost` cases (5 success + 9 failure/edge: missing fields, malformed dates, legacy variants, unrelated/empty), asserting **actual** regex behavior. Decoupled refresh tests via fake fetcher: incremental cursor advance, expired-entry prune, no-op on zero new posts, fetch-error cursor stability. The 4 pre-existing sqlmock `TestRefresh_*` tests pass unchanged (behavior-preserving).
- `.github/scripts/check-coverage-floors.sh`: utils floor 77 → 82 (measured 82.7%).

No regex/struct/signature changes.

## Test plan
- `golangci-lint` clean, `go test ./...` green (utils 82.7% ≥ 82), `go test ./utils/ -race` clean, `go build` OK.

## Manual review gate
- None (utility tests + behavior-preserving seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)