### PR TITLE
fix(utils): de-flake FormatTimeSinceDuration test (red develop)

### DIFF
--- a/utils/time_util.go
+++ b/utils/time_util.go
@@ -21,8 +21,14 @@ func daysInMonth(month, year int) int {
 }
 
 func FormatTimeSinceDuration(startDate time.Time) string {
-	endDate := time.Now()
+	return formatTimeSince(startDate, time.Now())
+}
 
+// formatTimeSince is the clock-injected core of FormatTimeSinceDuration. Tests
+// drive it with a fixed endDate so boundary cases stay deterministic — anchoring
+// to time.Now() makes the month-length AddDate math flaky near month boundaries
+// (e.g. on the 31st, "one month ago" overflows to the 1st of the current month).
+func formatTimeSince(startDate, endDate time.Time) string {
 	years := endDate.Year() - startDate.Year()
 	months := int(endDate.Month() - startDate.Month())
 	days := endDate.Day() - startDate.Day()

--- a/utils/time_util_test.go
+++ b/utils/time_util_test.go
@@ -34,31 +34,50 @@ func TestDaysInMonth(t *testing.T) {
 	}
 }
 
-func TestFormatTimeSinceDuration(t *testing.T) {
-	now := time.Now()
+func TestFormatTimeSince(t *testing.T) {
+	// Fixed dates keep boundary cases deterministic regardless of the run date.
+	// Anchoring to time.Now() (the old test) was flaky: on month-boundary days
+	// AddDate overflows, e.g. 31MAY - 1 month -> 01MAY, yielding "30 days".
+	date := func(y int, m time.Month, d int) time.Time {
+		return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+	}
 
 	tests := []struct {
 		name  string
 		start time.Time
+		end   time.Time
 		want  string
 	}{
-		{"zero duration", now, "0 days"},
-		{"one day", now.AddDate(0, 0, -1), "1 day"},
-		{"several days", now.AddDate(0, 0, -5), "5 days"},
-		{"one month", now.AddDate(0, -1, 0), "1 month"},
-		{"one year", now.AddDate(-1, 0, 0), "1 year"},
-		{"two years", now.AddDate(-2, 0, 0), "2 years"},
-		{"year plus month plus day", now.AddDate(-1, -1, -1), "1 year, 1 month, 1 day"},
-		{"large duration", now.AddDate(-10, -3, -2), "10 years, 3 months, 2 days"},
-		{"two months no days", now.AddDate(0, -2, 0), "2 months"},
-		{"year plus days", now.AddDate(-3, 0, -4), "3 years, 4 days"},
+		{"zero duration", date(2026, time.May, 15), date(2026, time.May, 15), "0 days"},
+		{"one day", date(2026, time.May, 14), date(2026, time.May, 15), "1 day"},
+		{"several days", date(2026, time.May, 10), date(2026, time.May, 15), "5 days"},
+		{"one month", date(2026, time.April, 15), date(2026, time.May, 15), "1 month"},
+		{"two months no days", date(2026, time.March, 15), date(2026, time.May, 15), "2 months"},
+		{"one year", date(2025, time.May, 15), date(2026, time.May, 15), "1 year"},
+		{"two years", date(2024, time.May, 15), date(2026, time.May, 15), "2 years"},
+		{"year plus month plus day", date(2024, time.April, 14), date(2025, time.May, 15), "1 year, 1 month, 1 day"},
+		{"large duration", date(2013, time.February, 13), date(2023, time.May, 15), "10 years, 3 months, 2 days"},
+		{"year plus days", date(2023, time.May, 11), date(2026, time.May, 15), "3 years, 4 days"},
+		// Boundary: 01MAY -> 31MAY is 30 days, NOT "1 month" — the exact case
+		// that flaked the old now.AddDate(0,-1,0) test on the 31st.
+		{"thirty days not one month", date(2026, time.May, 1), date(2026, time.May, 31), "30 days"},
+		// day borrow across a 30-day month (April)
+		{"day borrow across short month", date(2026, time.April, 20), date(2026, time.May, 10), "20 days"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := FormatTimeSinceDuration(tc.start); got != tc.want {
-				t.Fatalf("FormatTimeSinceDuration(%v) = %q, want %q", tc.start, got, tc.want)
+			if got := formatTimeSince(tc.start, tc.end); got != tc.want {
+				t.Fatalf("formatTimeSince(%v, %v) = %q, want %q", tc.start, tc.end, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestFormatTimeSinceDuration covers the public time.Now()-anchored wrapper.
+// Only the zero-duration case is stable against a live clock.
+func TestFormatTimeSinceDuration(t *testing.T) {
+	if got := FormatTimeSinceDuration(time.Now()); got != "0 days" {
+		t.Fatalf("FormatTimeSinceDuration(now) = %q, want %q", got, "0 days")
 	}
 }


### PR DESCRIPTION
**Fixes red `develop`** — CI run [26698378453](https://github.com/7Cav/cavbot2/actions/runs/26698378453) failed on `ad2b3a3`:

```
--- FAIL: TestFormatTimeSinceDuration/one_month
    time_util_test.go:60: FormatTimeSinceDuration(2026-05-01 …) = "30 days", want "1 month"
```

## Root cause
The #107 test anchored cases to `time.Now().AddDate(...)` and asserted exact labels (`"1 month"`). `FormatTimeSinceDuration` measures elapsed time against `time.Now()`, and `AddDate` overflows on month-boundary dates: on **31 May**, `now.AddDate(0, -1, 0)` → **1 May** (April has 30 days), so the gap is 30 days → renders `"30 days"`. The test passed only on its merge date (30 May) and went red when CI ran on 31 May. Flaky by construction near any month boundary.

## Fix
- Extract `formatTimeSince(start, end time.Time)` — the clock-free core. `FormatTimeSinceDuration(start)` now wraps it with `time.Now()`. **No behavior change.**
- Rewrite the table (`TestFormatTimeSince`) to drive the core with **fixed UTC dates** → deterministic regardless of run date. Adds the `01MAY → 31MAY = "30 days"` boundary that flaked, plus a short-month day-borrow case.
- Keep one `time.Now()`-anchored zero-duration case (`TestFormatTimeSinceDuration`) to cover the public wrapper.

Same injectable-seam pattern used by #109/#119.

## Test plan
- Targeted suite run **3× clean** (deterministic). Full gate green: `golangci-lint` 0 issues, `go mod tidy` no-diff, `go test ./... -race` pass, floors green (**utils 83.7% ≥ 82**, commands 76.4% ≥ 75), build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)