### PR TITLE
test: wave-1 coverage (milpacs wrappers, tenure math, /s3aar) (#141 #142 #137)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -17,8 +17,8 @@ set -euo pipefail
 # heredoc, read returns 1 at EOF. Without `|| true`, `set -e` would kill the
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
-github.com/7cav/cavbot2/utils	82
-github.com/7cav/cavbot2/commands	75
+github.com/7cav/cavbot2/utils	84
+github.com/7cav/cavbot2/commands	77
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
 github.com/7cav/cavbot2/utils	82
-github.com/7cav/cavbot2/commands	75
+github.com/7cav/cavbot2/commands	79
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -17,8 +17,8 @@ set -euo pipefail
 # heredoc, read returns 1 at EOF. Without `|| true`, `set -e` would kill the
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
-github.com/7cav/cavbot2/utils	86
-github.com/7cav/cavbot2/commands	75
+github.com/7cav/cavbot2/utils	87
+github.com/7cav/cavbot2/commands	80
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 # heredoc, read returns 1 at EOF. Without `|| true`, `set -e` would kill the
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
-github.com/7cav/cavbot2/utils	82
+github.com/7cav/cavbot2/utils	86
 github.com/7cav/cavbot2/commands	75
 EOF
 

--- a/commands/milpac_test.go
+++ b/commands/milpac_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/7cav/cavbot2/utils"
 	"github.com/bwmarrin/discordgo"
@@ -75,6 +76,91 @@ func milpacProfileWithSecondaries() utils.ProfileResponse {
 		Records: []utils.Record{
 			{RecordType: "RECORD_TYPE_ASSIGNMENT", RecordDate: "2023-01-15", RecordDetails: "Enlisted into the 7th Cavalry"},
 		},
+	}
+}
+
+// TestDetermineEnlistmentRecordType mirrors the afsm TestDetermineRecordType
+// table test. determineEnlistmentRecordType classifies a milpac record's detail
+// string as "leave" (Retired / Placed on ELOA / Discharge) or "join"
+// (everything else: Enlisted, Reinstated, Returned, Assigned, ...). The "join"
+// default is what feeds the start of a service period in calculateTotalService.
+func TestDetermineEnlistmentRecordType(t *testing.T) {
+	cases := []struct {
+		name    string
+		details string
+		want    string
+	}{
+		{"enlisted is join", "Enlisted into the 7th Cavalry", "join"},
+		{"reinstated is join", "Reinstated to active duty", "join"},
+		{"returned is join", "Returned from ELOA", "join"},
+		{"retired is leave", "Retired from the regiment", "leave"},
+		{"placed on eloa is leave", "Placed on ELOA", "leave"},
+		{"discharge is leave", "Discharged from the regiment", "leave"},
+		// "Returned from ELOA" contains the substring "ELOA" but NOT "Placed on
+		// ELOA" — it must classify as join, guarding the exact-phrase check.
+		{"eloa substring without 'Placed on' is join", "ELOA ended, member returned", "join"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := determineEnlistmentRecordType(tc.details); got != tc.want {
+				t.Fatalf("determineEnlistmentRecordType(%q) = %q, want %q", tc.details, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCalculateTotalService_MultiPeriod drives the multi-period accumulation:
+// join -> leave -> rejoin. The first closed period (2020-01-01 .. 2021-01-01)
+// contributes a fixed 366-day span (2020 is a leap year). The trailing rejoin
+// has no closing leave, so it accumulates time.Since(rejoin) — wall-clock
+// dependent — which is why only the closed-period contribution is asserted
+// exactly, and the trailing period is asserted as a lower bound.
+func TestCalculateTotalService_MultiPeriod(t *testing.T) {
+	date := func(s string) time.Time { return mustParseDate(s) }
+	rejoin := date("2022-06-01")
+
+	assignments := []map[string]interface{}{
+		{"record_date": date("2020-01-01"), "record_type": "join", "record_details": "Enlisted"},
+		{"record_date": date("2021-01-01"), "record_type": "leave", "record_details": "Discharged"},
+		{"record_date": rejoin, "record_type": "join", "record_details": "Reinstated"},
+	}
+
+	got := calculateTotalService(assignments)
+
+	closedPeriod := date("2021-01-01").Sub(date("2020-01-01")) // 366 days (leap)
+	trailing := time.Since(rejoin)
+	wantMin := closedPeriod + trailing - time.Minute // allow tiny exec slack
+	if got < wantMin {
+		t.Fatalf("calculateTotalService = %s, want >= %s (closed %s + trailing %s)",
+			got, wantMin, closedPeriod, trailing)
+	}
+	// Upper sanity bound: must not exceed closed + trailing + slack.
+	if got > closedPeriod+trailing+time.Minute {
+		t.Fatalf("calculateTotalService = %s, want <= %s", got, closedPeriod+trailing+time.Minute)
+	}
+}
+
+// TestCalculateTotalService_ConsecutiveJoinsAndTrailing covers the
+// "two consecutive joins" branch (second join does not reset the period start)
+// and the no-active-period branch (a leave with no open period is a no-op).
+func TestCalculateTotalService_ConsecutiveJoinsAndTrailing(t *testing.T) {
+	date := func(s string) time.Time { return mustParseDate(s) }
+
+	// leave-before-any-join is a no-op; two joins in a row keep the earlier
+	// start; final leave closes the single accumulated period.
+	assignments := []map[string]interface{}{
+		{"record_date": date("2019-01-01"), "record_type": "leave", "record_details": "Discharged"},
+		{"record_date": date("2020-01-01"), "record_type": "join", "record_details": "Enlisted"},
+		{"record_date": date("2020-03-01"), "record_type": "join", "record_details": "Reinstated"},
+		{"record_date": date("2020-06-01"), "record_type": "leave", "record_details": "Retired"},
+	}
+
+	got := calculateTotalService(assignments)
+	// Period start is the FIRST join (2020-01-01), not the second, because a
+	// second consecutive join must not overwrite currentPeriodStart.
+	want := date("2020-06-01").Sub(date("2020-01-01"))
+	if got != want {
+		t.Fatalf("calculateTotalService = %s, want %s (start at first join, single closed period)", got, want)
 	}
 }
 
@@ -237,5 +323,72 @@ func TestRunMilpac_BadUniformURL_FallsThroughHandleError(t *testing.T) {
 			got = *calls[2].Edit.Content
 		}
 		t.Fatalf("calls[2]: expected 'uniform URL' error, got %q", got)
+	}
+}
+
+// TestRunMilpac_EmptyPromotionDate_FallsBackToJoinDate exercises the
+// PromotionDate == "" branch: promotionDate is set to joinDate, so the embed's
+// "Promoted:" line renders the (uppercased) join date. The fixture also carries
+// a join -> leave -> rejoin record set so the full-handler service-math path
+// (assignment filtering -> sort -> calculateTotalService) runs end-to-end.
+func TestRunMilpac_EmptyPromotionDate_FallsBackToJoinDate(t *testing.T) {
+	profile := milpacProfileWithSecondaries()
+	profile.PromotionDate = "" // trigger fallback to JoinDate
+	profile.Records = []utils.Record{
+		{RecordType: "RECORD_TYPE_ASSIGNMENT", RecordDate: "2023-01-15", RecordDetails: "Enlisted into the 7th Cavalry"},
+		{RecordType: "RECORD_TYPE_DISCHARGE", RecordDate: "2023-06-15", RecordDetails: "Discharged from the regiment"},
+		{RecordType: "RECORD_TYPE_ASSIGNMENT", RecordDate: "2024-01-15", RecordDetails: "Reinstated to active duty"},
+	}
+	serveMilpacByDiscordID(t, profile)
+
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(userOption("user", "111"))
+
+	runMilpac(f, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (placeholder + Edit), got %d: %+v", len(calls), calls)
+	}
+	embed := (*calls[1].Edit.Embeds)[0]
+	var rankField string
+	for _, fld := range embed.Fields {
+		if fld.Name == "Rank" {
+			rankField = fld.Value
+		}
+	}
+	if rankField == "" {
+		t.Fatalf("expected a Rank field, got fields %+v", embed.Fields)
+	}
+	// JoinDate 2023-01-15 -> "15JAN2023" (uppercased 02Jan2006). Fallback means
+	// the promotion line equals the join date.
+	if !strings.Contains(rankField, "15JAN2023") {
+		t.Fatalf("Rank field = %q, want promotion date to fall back to join date 15JAN2023", rankField)
+	}
+}
+
+// TestRunMilpac_MalformedPromotionDate_FallsThroughHandleError exercises the
+// PromotionDate parse-error path: a non-empty but unparseable value makes
+// time.Parse fail, surfacing "Failed to parse promotion date" via HandleError.
+func TestRunMilpac_MalformedPromotionDate_FallsThroughHandleError(t *testing.T) {
+	profile := milpacProfileWithSecondaries()
+	profile.PromotionDate = "not-a-date" // non-empty, unparseable
+	serveMilpacByDiscordID(t, profile)
+
+	f := &fakeResponder{RespondErrs: []error{nil, errAlreadyAcked}}
+	i := fakeAppCommandInteraction(userOption("user", "111"))
+
+	runMilpac(f, i)
+
+	calls := f.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls (placeholder + HandleError Respond + Edit fallback), got %d: %+v", len(calls), calls)
+	}
+	if calls[2].Edit.Content == nil || !strings.Contains(*calls[2].Edit.Content, "Failed to parse promotion date") {
+		got := "<nil>"
+		if calls[2].Edit.Content != nil {
+			got = *calls[2].Edit.Content
+		}
+		t.Fatalf("calls[2]: expected 'Failed to parse promotion date', got %q", got)
 	}
 }

--- a/commands/s3aar_test.go
+++ b/commands/s3aar_test.go
@@ -83,6 +83,83 @@ func serveBattleMetricsError(t *testing.T, status int) {
 	t.Cleanup(func() { bmBaseURL = prevBM })
 }
 
+// serveBattleMetricsWithProfiles stands up a fake BattleMetrics sessions API
+// returning the given sessions AND a fake milpacs API that returns a successful
+// ProfileResponse for /milpacs/profile/username/<name> when <name> is present in
+// profilesByUsername (404 otherwise). This drives SUCCESSFUL enrichPlayer paths
+// — the half of /s3aar (combat-roster filter, rank-ID sort, forum BBCode line,
+// AAR file body) that serveBattleMetrics's all-404 stub never reaches.
+//
+// The milpac lookup key is the *cleaned* name (cleanName(session.Name)); keys in
+// profilesByUsername must match that cleaned form.
+func serveBattleMetricsWithProfiles(t *testing.T, sessions []bmSession, profilesByUsername map[string]utils.ProfileResponse) {
+	t.Helper()
+	t.Setenv("BM_TOKEN", "test-token")
+
+	payload := map[string]any{"data": make([]map[string]any, 0, len(sessions))}
+	for _, s := range sessions {
+		payload["data"] = append(payload["data"].([]map[string]any), map[string]any{
+			"attributes": map[string]any{
+				"start": s.Start,
+				"stop":  s.Stop,
+				"name":  s.Name,
+			},
+		})
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("serveBattleMetricsWithProfiles marshal: %v", err)
+	}
+
+	bmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/relationships/sessions") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(bmSrv.Close)
+
+	prevBM := bmBaseURL
+	bmBaseURL = bmSrv.URL
+	t.Cleanup(func() { bmBaseURL = prevBM })
+
+	encoded := make(map[string][]byte, len(profilesByUsername))
+	for name, p := range profilesByUsername {
+		b, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("serveBattleMetricsWithProfiles marshal profile %q: %v", name, err)
+		}
+		encoded[name] = b
+	}
+	milpacSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/milpacs/profile/username/") {
+			name := strings.TrimPrefix(r.URL.Path, "/milpacs/profile/username/")
+			if pb, ok := encoded[name]; ok {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(pb)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(milpacSrv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(milpacSrv.URL))
+}
+
+// combatProfile is a small constructor for a successful enrichment fixture. The
+// UniformUrl matches the /\d+/(\d+)\.jpg regex enrichPlayer extracts the milpac
+// ID from, so the forum link resolves to https://7cav.us/rosters/profile/<id>.
+func combatProfile(username, rankFull, rankID, roster, id string) utils.ProfileResponse {
+	return utils.ProfileResponse{
+		User:       utils.User{Username: username},
+		Rank:       utils.Rank{RankFull: rankFull, RankID: rankID},
+		Roster:     roster,
+		UniformUrl: fmt.Sprintf("https://7cav.us/data/roster_uniforms/0/%s.jpg", id),
+	}
+}
+
 // s3aarOptions builds the required /s3aar option set, with an optional debug
 // value appended when non-empty.
 func s3aarOptions(server, startDate, endDate, startTime, endTime string, minAttendance int, debug string) *discordgo.InteractionCreate {
@@ -240,5 +317,355 @@ func TestRunS3aar_BattleMetricsUpstreamError(t *testing.T) {
 	// No embed/file followup on the error path.
 	if len(fups[0].Params.Embeds) != 0 || len(fups[0].Params.Files) != 0 {
 		t.Fatalf("error followup must be plain content, got %+v", fups[0].Params)
+	}
+}
+
+// readAARFile finds the aar_roster.txt file followup and returns its decoded
+// body. Fails the test if no such followup exists.
+func readAARFile(t *testing.T, fups []recordedCall) string {
+	t.Helper()
+	for idx := range fups {
+		for _, f := range fups[idx].Params.Files {
+			if f.Name == "aar_roster.txt" {
+				raw, err := io.ReadAll(f.Reader)
+				if err != nil {
+					t.Fatalf("read aar_roster.txt: %v", err)
+				}
+				return string(raw)
+			}
+		}
+	}
+	t.Fatalf("no aar_roster.txt file followup found; got %+v", fups)
+	return ""
+}
+
+// TestRunS3aar_CombatRosterOutput drives SUCCESSFUL milpac enrichment for three
+// players: two combat (different ranks) and one reserve. It asserts the combat-
+// only filter, ascending rank-ID ordering, the exact forum BBCode line format,
+// and the AAR file body (read from the file reader, not just the caption).
+func TestRunS3aar_CombatRosterOutput(t *testing.T) {
+	start := time.Date(2025, 11, 10, 18, 0, 0, 0, time.UTC)
+	stop := start.Add(2 * time.Hour)
+
+	// Raw BM names → cleaned keys: cleanName("ABC.Alpha.A") == "Alpha.A", etc.
+	serveBattleMetricsWithProfiles(t,
+		[]bmSession{
+			{Name: "ABC.Alpha.A", Start: start, Stop: stop},   // combat, rank 5
+			{Name: "ABC.Bravo.B", Start: start, Stop: stop},    // combat, rank 2
+			{Name: "ABC.Reserve.R", Start: start, Stop: stop},  // reserve → filtered out
+		},
+		map[string]utils.ProfileResponse{
+			"Alpha.A":   combatProfile("AlphaUser", "Sergeant", "5", "ROSTER_TYPE_COMBAT", "101"),
+			"Bravo.B":   combatProfile("BravoUser", "Major", "2", "ROSTER_TYPE_COMBAT", "202"),
+			"Reserve.R": combatProfile("ReserveUser", "Private", "9", "ROSTER_TYPE_RESERVE", "303"),
+		},
+	)
+
+	r := &fakeResponder{}
+	i := s3aarOptions("Tac1", "10NOV25", "10NOV25", "1800", "2000", 30, "")
+	runS3aar(r, i)
+
+	body := readAARFile(t, followups(r.Calls()))
+
+	// Combat-only filter: the reserve player must not appear.
+	if strings.Contains(body, "ReserveUser") {
+		t.Fatalf("reserve player must be filtered from combat roster; body:\n%s", body)
+	}
+
+	// Ascending rank-ID order: Bravo (rank 2) before Alpha (rank 5).
+	bravoLine := "[URL='https://7cav.us/rosters/profile/202']Major BravoUser[/URL]"
+	alphaLine := "[URL='https://7cav.us/rosters/profile/101']Sergeant AlphaUser[/URL]"
+	want := bravoLine + "\n" + alphaLine
+	if body != want {
+		t.Fatalf("AAR roster body mismatch.\nwant:\n%s\ngot:\n%s", want, body)
+	}
+
+	// Exact forum BBCode line format assertions (redundant with the full-body
+	// equality above, but pin the [URL='...']<rank> <user>[/URL] shape explicitly).
+	if !strings.Contains(body, bravoLine) {
+		t.Fatalf("missing exact BBCode line for Bravo; body:\n%s", body)
+	}
+	idxBravo := strings.Index(body, "BravoUser")
+	idxAlpha := strings.Index(body, "AlphaUser")
+	if idxBravo == -1 || idxAlpha == -1 || idxBravo > idxAlpha {
+		t.Fatalf("expected ascending rank-ID order (Bravo before Alpha); body:\n%s", body)
+	}
+}
+
+// TestRunS3aar_EnrichGamertagFallback covers enrichPlayer's second branch: the
+// username milpac lookup 404s, but the gamertag lookup (/milpac/gamertag/<name>)
+// succeeds, so enrichment still populates CavName/Roster/RankID and the player
+// lands on the combat roster.
+func TestRunS3aar_EnrichGamertagFallback(t *testing.T) {
+	start := time.Date(2025, 11, 10, 18, 0, 0, 0, time.UTC)
+	stop := start.Add(2 * time.Hour)
+	t.Setenv("BM_TOKEN", "test-token")
+
+	payload := map[string]any{"data": []map[string]any{
+		{"attributes": map[string]any{"start": start, "stop": stop, "name": "ABC.Gamer.G"}},
+	}}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	bmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/relationships/sessions") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(bmSrv.Close)
+	prevBM := bmBaseURL
+	bmBaseURL = bmSrv.URL
+	t.Cleanup(func() { bmBaseURL = prevBM })
+
+	profile := combatProfile("GamerUser", "Corporal", "6", "ROSTER_TYPE_COMBAT", "404")
+	profBody, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatalf("marshal profile: %v", err)
+	}
+	milpacSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Username lookup 404s; gamertag lookup succeeds → exercises fallback.
+		if strings.HasPrefix(r.URL.Path, "/milpac/gamertag/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(profBody)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(milpacSrv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(milpacSrv.URL))
+
+	r := &fakeResponder{}
+	i := s3aarOptions("Tac1", "10NOV25", "10NOV25", "1800", "2000", 30, "")
+	runS3aar(r, i)
+
+	wantLine := "[URL='https://7cav.us/rosters/profile/404']Corporal GamerUser[/URL]"
+	if body := readAARFile(t, followups(r.Calls())); body != wantLine {
+		t.Fatalf("gamertag-fallback enrichment did not populate combat roster.\nwant: %s\ngot:  %s", wantLine, body)
+	}
+}
+
+// TestRunS3aar_EmbedPlaytimeAndCount asserts the attendance embed's playtime
+// formatting (Xh Ym) and player-count title, not merely that a name substring
+// survives. Two players with different playtimes; enrichment succeeds.
+func TestRunS3aar_EmbedPlaytimeAndCount(t *testing.T) {
+	start := time.Date(2025, 11, 10, 18, 0, 0, 0, time.UTC)
+	// Long player: full 2h05m window. Short player: 45m.
+	longStop := start.Add(2*time.Hour + 5*time.Minute)
+	shortStop := start.Add(45 * time.Minute)
+
+	serveBattleMetricsWithProfiles(t,
+		[]bmSession{
+			{Name: "ABC.Long.L", Start: start, Stop: longStop},
+			{Name: "ABC.Short.S", Start: start, Stop: shortStop},
+		},
+		map[string]utils.ProfileResponse{
+			"Long.L":  combatProfile("LongUser", "Sergeant", "5", "ROSTER_TYPE_COMBAT", "111"),
+			"Short.S": combatProfile("ShortUser", "Private", "9", "ROSTER_TYPE_COMBAT", "222"),
+		},
+	)
+
+	r := &fakeResponder{}
+	// Window is 2h05m; min attendance 30 keeps both players.
+	i := s3aarOptions("Tac1", "10NOV25", "10NOV25", "1800", "2005", 30, "")
+	runS3aar(r, i)
+
+	fups := followups(r.Calls())
+	if len(fups) == 0 || len(fups[0].Params.Embeds) == 0 {
+		t.Fatalf("expected attendance embed in first followup; got %+v", fups)
+	}
+	embed := fups[0].Params.Embeds[0]
+
+	// Player count is rendered in the title.
+	if embed.Title != "Attendance Summary — 2 Players" {
+		t.Fatalf("unexpected embed title: %q", embed.Title)
+	}
+	// Playtime formatting: 125 min → "2h 5m"; 45 min → "0h 45m".
+	if !strings.Contains(embed.Description, "**ABC.Long.L** — 2h 5m") {
+		t.Fatalf("expected long player playtime '2h 5m'; got %q", embed.Description)
+	}
+	if !strings.Contains(embed.Description, "**ABC.Short.S** — 0h 45m") {
+		t.Fatalf("expected short player playtime '0h 45m'; got %q", embed.Description)
+	}
+}
+
+// TestRunS3aar_InvalidStartDate asserts the bad-start-date validation path emits
+// the specific followup and no embed/file.
+func TestRunS3aar_InvalidStartDate(t *testing.T) {
+	r := &fakeResponder{}
+	// "99XXX25" is the wrong-length-but-also-bad-month case; parseDateTime fails.
+	i := s3aarOptions("Tac1", "BADDATE", "10NOV25", "1800", "2000", 30, "")
+	runS3aar(r, i)
+
+	fups := followups(r.Calls())
+	if len(fups) != 1 {
+		t.Fatalf("bad start date must produce exactly one followup; got %d: %+v", len(fups), fups)
+	}
+	if !strings.HasPrefix(fups[0].Params.Content, "Invalid start date/time:") {
+		t.Fatalf("unexpected start-date error content: %q", fups[0].Params.Content)
+	}
+	assertNoRosterFollowup(t, fups)
+}
+
+// TestRunS3aar_InvalidEndDate asserts the bad-end-date path. Start date is valid
+// so parseDateTime fails only on the second call.
+func TestRunS3aar_InvalidEndDate(t *testing.T) {
+	r := &fakeResponder{}
+	i := s3aarOptions("Tac1", "10NOV25", "10ZZZ25", "1800", "2000", 30, "")
+	runS3aar(r, i)
+
+	fups := followups(r.Calls())
+	if len(fups) != 1 {
+		t.Fatalf("bad end date must produce exactly one followup; got %d: %+v", len(fups), fups)
+	}
+	if !strings.HasPrefix(fups[0].Params.Content, "Invalid end date/time:") {
+		t.Fatalf("unexpected end-date error content: %q", fups[0].Params.Content)
+	}
+	assertNoRosterFollowup(t, fups)
+}
+
+// TestRunS3aar_NotAvailableServer asserts the NotAvailable server choice routes
+// to the invalid-server followup (getServerID's default branch) and emits no
+// roster output.
+func TestRunS3aar_NotAvailableServer(t *testing.T) {
+	r := &fakeResponder{}
+	i := s3aarOptions("NotAvailable", "10NOV25", "10NOV25", "1800", "2000", 30, "")
+	runS3aar(r, i)
+
+	fups := followups(r.Calls())
+	if len(fups) != 1 {
+		t.Fatalf("NotAvailable server must produce exactly one followup; got %d: %+v", len(fups), fups)
+	}
+	if !strings.HasPrefix(fups[0].Params.Content, "Invalid server selection:") {
+		t.Fatalf("unexpected server error content: %q", fups[0].Params.Content)
+	}
+	assertNoRosterFollowup(t, fups)
+}
+
+// TestRunS3aar_UnsetBMToken asserts that with a valid date+server but no
+// BM_TOKEN, fetchBattleMetricsSessions fails and the specific followup is sent
+// with no roster output.
+func TestRunS3aar_UnsetBMToken(t *testing.T) {
+	t.Setenv("BM_TOKEN", "")
+	r := &fakeResponder{}
+	i := s3aarOptions("Tac1", "10NOV25", "10NOV25", "1800", "2000", 30, "")
+	runS3aar(r, i)
+
+	fups := followups(r.Calls())
+	if len(fups) != 1 {
+		t.Fatalf("unset BM_TOKEN must produce exactly one followup; got %d: %+v", len(fups), fups)
+	}
+	if !strings.Contains(fups[0].Params.Content, "Failed to fetch BattleMetrics data") ||
+		!strings.Contains(fups[0].Params.Content, "BM_TOKEN not set") {
+		t.Fatalf("unexpected BM_TOKEN error content: %q", fups[0].Params.Content)
+	}
+	assertNoRosterFollowup(t, fups)
+}
+
+// assertNoRosterFollowup fails if any followup carries an embed or a file —
+// the validation/error paths must not emit roster output.
+func assertNoRosterFollowup(t *testing.T, fups []recordedCall) {
+	t.Helper()
+	for _, f := range fups {
+		if len(f.Params.Embeds) != 0 {
+			t.Fatalf("no embed followup expected on this path; got %+v", f.Params)
+		}
+		if len(f.Params.Files) != 0 {
+			t.Fatalf("no file followup expected on this path; got %+v", f.Params)
+		}
+	}
+}
+
+func TestGetServerID(t *testing.T) {
+	cases := []struct {
+		server  string
+		want    string
+		wantErr bool
+	}{
+		{"Tac1", "35142042", false},
+		{"Tac2", "32703792", false},
+		{"TS1", "32703836", false},
+		{"TS2", "32708755", false},
+		{"NotAvailable", "", true},
+		{"bogus", "", true},
+		{"", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.server, func(t *testing.T) {
+			got, err := getServerID(c.server)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("getServerID(%q) expected error, got %q", c.server, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("getServerID(%q) unexpected error: %v", c.server, err)
+			}
+			if got != c.want {
+				t.Fatalf("getServerID(%q) = %q, want %q", c.server, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseDateTime(t *testing.T) {
+	cases := []struct {
+		name     string
+		date     string
+		time     string
+		wantErr  bool
+		wantISO  string // expected UTC time when no error, RFC3339
+	}{
+		{"valid", "10NOV25", "1830", false, "2025-11-10T18:30:00Z"},
+		{"valid lowercase month", "10nov25", "0000", false, "2025-11-10T00:00:00Z"},
+		{"bad date length short", "1NOV25", "1830", true, ""},
+		{"bad date length long", "100NOV25", "1830", true, ""},
+		{"bad time length", "10NOV25", "183", true, ""},
+		{"bad month", "10ZZZ25", "1830", true, ""},
+		{"non-numeric day yields parse error", "XXNOV25", "1830", true, ""},
+		{"non-numeric time yields parse error", "10NOV25", "XX30", true, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseDateTime(c.date, c.time)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("parseDateTime(%q,%q) expected error, got %v", c.date, c.time, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDateTime(%q,%q) unexpected error: %v", c.date, c.time, err)
+			}
+			if got.UTC().Format(time.RFC3339) != c.wantISO {
+				t.Fatalf("parseDateTime(%q,%q) = %s, want %s", c.date, c.time, got.UTC().Format(time.RFC3339), c.wantISO)
+			}
+		})
+	}
+}
+
+func TestCleanName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"prefix extraction", "ABC.Smith.J", "Smith.J"},
+		{"prefix extraction two-letter suffix", "7Cv.Doe.Jo", "Doe.Jo"},
+		{"prefix extraction with surrounding space", "  XYZ.Brown.K  ", "Brown.K"},
+		{"already cleaned passthrough", "Smith.J", "Smith.J"},
+		{"plain gamertag passthrough", "RandomGamer", "RandomGamer"},
+		{"no dotted suffix passthrough", "ABC123", "ABC123"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := cleanName(c.in); got != c.want {
+				t.Fatalf("cleanName(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
 	}
 }

--- a/utils/milpacs_test.go
+++ b/utils/milpacs_test.go
@@ -192,3 +192,113 @@ func TestMakeAPIRequest_TransportError(t *testing.T) {
 		t.Fatalf("expected wrapped 'failed to fetch milpacs' error, got: %v", err)
 	}
 }
+
+// TestTypedWrappers_RequestPaths asserts the EXACT request path each typed
+// wrapper issues. These are golden-path assertions pinned to current
+// production behaviour — note the deliberate `milpac/` vs `milpacs/` prefix
+// inconsistency between wrappers. The intent is to catch a future typo (wrong
+// prefix → 404 → "no X found"), not to assert which prefix is "correct".
+func TestTypedWrappers_RequestPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		arg      string
+		wantPath string
+		call     func(ctx context.Context, arg string) error
+	}{
+		{
+			name:     "GetMilpacByUsername",
+			arg:      "alice",
+			wantPath: "/milpacs/profile/username/alice",
+			call: func(ctx context.Context, arg string) error {
+				_, err := GetMilpacByUsername(ctx, arg)
+				return err
+			},
+		},
+		{
+			name:     "GetMilpacByDiscordID",
+			arg:      "123456789",
+			wantPath: "/milpac/discord/123456789",
+			call: func(ctx context.Context, arg string) error {
+				_, err := GetMilpacByDiscordID(ctx, arg)
+				return err
+			},
+		},
+		{
+			name:     "GetRosterByFuzzyPositionSearch",
+			arg:      "medic",
+			wantPath: "/milpacs/position/search/medic",
+			call: func(ctx context.Context, arg string) error {
+				_, err := GetRosterByFuzzyPositionSearch(ctx, arg)
+				return err
+			},
+		},
+		{
+			name:     "GetUserByGamertag",
+			arg:      "tag42",
+			wantPath: "/milpac/gamertag/tag42",
+			call: func(ctx context.Context, arg string) error {
+				_, err := GetUserByGamertag(ctx, arg)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, `{}`)
+			}))
+			t.Cleanup(srv.Close)
+			withTestAPIServer(t, srv)
+
+			if err := tc.call(context.Background(), tc.arg); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotPath != tc.wantPath {
+				t.Fatalf("request path = %q, want %q", gotPath, tc.wantPath)
+			}
+		})
+	}
+}
+
+func TestGetRosterStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		roster string
+		want   string
+	}{
+		{
+			name:   "known status maps to friendly label",
+			roster: "ROSTER_TYPE_COMBAT",
+			want:   "Active Duty",
+		},
+		{
+			name:   "another known status maps to friendly label",
+			roster: "ROSTER_TYPE_WALL_OF_HONOR",
+			want:   "Wall of Honor",
+		},
+		{
+			name:   "unknown status passes through raw",
+			roster: "ROSTER_TYPE_SOMETHING_NEW",
+			want:   "ROSTER_TYPE_SOMETHING_NEW",
+		},
+		{
+			name:   "empty status passes through raw",
+			roster: "",
+			want:   "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &ProfileResponse{Roster: tc.roster}
+			if got := r.GetRosterStatus(); got != tc.want {
+				t.Fatalf("GetRosterStatus() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/utils/time_util_test.go
+++ b/utils/time_util_test.go
@@ -63,6 +63,14 @@ func TestFormatTimeSince(t *testing.T) {
 		{"thirty days not one month", date(2026, time.May, 1), date(2026, time.May, 31), "30 days"},
 		// day borrow across a 30-day month (April)
 		{"day borrow across short month", date(2026, time.April, 20), date(2026, time.May, 10), "20 days"},
+		// Cross-year month borrow: Dec 15 -> Feb 10. months = Feb-Dec = -10, days
+		// = 10-15 = -5. Day borrow: months-- (-11), days += daysInMonth(Jan) (31)
+		// -> 26. Month borrow: months < 0 so years-- (0), months += 12 -> 1.
+		// Exercises the previously-dead `months < 0` branch.
+		{"cross-year month borrow", date(2025, time.December, 15), date(2026, time.February, 10), "1 month, 26 days"},
+		// Cross-year borrow with no day borrow, exercising months<0 in isolation:
+		// Nov 15 2025 -> Feb 15 2026. months = Feb-Nov = -9 -> +12 = 3, years 1->0.
+		{"cross-year month borrow no day borrow", date(2025, time.November, 15), date(2026, time.February, 15), "3 months"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Swarm wave 1 — three independent test-coverage issues integrated on one branch (shared 2-line coverage-floor script reconciled once to combined coverage).

## Closes
- Closes #141 — milpacs API-client wrappers + GetRosterStatus
- Closes #142 — tenure / service-time math (/milpac + time_util cross-year borrow)
- Closes #137 — /s3aar combat-roster output + validation paths

## What
Test-only. No production behavior changed in any of the three.

- **#141** — table test drives all 4 typed wrappers (`GetMilpacByUsername`, `GetMilpacByDiscordID`, `GetUserByGamertag`, `GetRosterByFuzzyPositionSearch`) through the httptest seam asserting exact request paths (catches `milpac/` vs `milpacs/` typos); `GetRosterStatus` mapped + passthrough. Wrappers 0%→100%.
- **#142** — `calculateTotalService` join/leave/rejoin; `determineEnlistmentRecordType` table (Enlisted/Retired/ELOA/Discharge); `/milpac` empty + malformed `PromotionDate`; `formatTimeSince` cross-year `months<0` borrow.
- **#137** — `/s3aar` happy path with successful enrichment (combat-only filter, ascending rank-ID sort, exact `[URL='...']<rank> <user>[/URL]` BBCode, AAR file body); validation paths (bad dates, NotAvailable server, unset BM_TOKEN); `getServerID`/`parseDateTime`/`cleanName` tables.

## Coverage (ADR 0005)
Combined: utils 87.1%, commands 80.6%. Floors raised utils 82→87, commands 75→80.

## CI gate
Local gate green: lint 0, `go mod tidy` clean, tests pass, floor check pass, build OK.

## Manual gates
- Smoke test: **skipped** — test-only, zero command-behavior change.
- Env-var parity: N/A — no new vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)