### PR TITLE
test: wave-2 coverage (LOA concurrency+-race, deploy JWT, placeholder robustness) (#139 #138 #143)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
 github.com/7cav/cavbot2/utils	87
-github.com/7cav/cavbot2/commands	80
+github.com/7cav/cavbot2/commands	81
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
 github.com/7cav/cavbot2/utils	87
-github.com/7cav/cavbot2/commands	81
+github.com/7cav/cavbot2/commands	82
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           set -euo pipefail
-          go test ./... -cover -covermode=atomic | tee /tmp/cover.log
+          go test ./... -race -cover -covermode=atomic | tee /tmp/cover.log
 
       - name: Enforce coverage floors
         run: ./.github/scripts/check-coverage-floors.sh < /tmp/cover.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ The headings below are consumed by `syni-run-on-issue`. Edit freely; the orchest
 set -euo pipefail
 golangci-lint run --timeout=5m
 go mod tidy
-go test ./... -cover -covermode=atomic | tee /tmp/cover.log
+go test ./... -race -cover -covermode=atomic | tee /tmp/cover.log
 ./.github/scripts/check-coverage-floors.sh < /tmp/cover.log
 go build -o cavbot2
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ go test ./...
 Run tests with the coverage floor check (matches CI):
 
 ```bash
-go test ./... -cover | .github/scripts/check-coverage-floors.sh
+go test ./... -race -cover | .github/scripts/check-coverage-floors.sh
 ```
 
 CI enforces per-package coverage floors via `.github/scripts/check-coverage-floors.sh`. When a PR raises a package's coverage by more than a point or two, raise its floor in the same PR — that's how the suite ratchets up without the team having to think about it.

--- a/commands/afsm_test.go
+++ b/commands/afsm_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
 )
 
 // afsmRefDate is the pinned "now" for all AFSM unit tests. Choosing a fixed
@@ -572,6 +573,9 @@ func TestRunAFSM_HappyPathWithSkipped(t *testing.T) {
 	if calls[0].Method != "Respond" {
 		t.Fatalf("calls[0]: expected Respond, got %q", calls[0].Method)
 	}
+	if calls[0].Response.Type != discordgo.InteractionResponseChannelMessageWithSource {
+		t.Fatalf("calls[0]: expected placeholder Type ChannelMessageWithSource, got %v", calls[0].Response.Type)
+	}
 	if !strings.Contains(calls[0].Response.Data.Content, "S6") {
 		t.Fatalf("placeholder content should mention S6, got %q", calls[0].Response.Data.Content)
 	}
@@ -741,4 +745,18 @@ func TestRunAFSM_RosterFetch500(t *testing.T) {
 		}
 		t.Fatalf("expected 'Failed to fetch Members' in Edit fallback, got %q", got)
 	}
+}
+
+// TestRunAFSM_FirstRespondFails_BailsBeforeAPI covers the early-bail branch when
+// the placeholder InteractionRespond fails: runAFSM must call HandleError once
+// and return before fetching the roster (tripwire server fails the test if hit).
+func TestRunAFSM_FirstRespondFails_BailsBeforeAPI(t *testing.T) {
+	tripwireAPIServer(t)
+
+	f := &fakeResponder{RespondErrs: []error{errFirstRespond}}
+	i := fakeAppCommandInteraction(stringOption("department", "S6"))
+
+	runAFSM(f, i)
+
+	assertPlaceholderFailedBailout(t, f.Calls())
 }

--- a/commands/apps_deployer_test.go
+++ b/commands/apps_deployer_test.go
@@ -5,7 +5,9 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -40,6 +42,13 @@ func setGithubEnv(t *testing.T) {
 	t.Setenv("GITHUB_APP_CLIENT_ID", "Iv1.testclientid")
 }
 
+// githubCapture records the dispatch request the fake server saw, so a test can
+// assert the command path sent the expected payload without a live GitHub call.
+type githubCapture struct {
+	dispatchBody []byte
+	dispatchPath string
+}
+
 // githubMux is a configurable fake GitHub Apps API. Each phase can be made to
 // fail by status code; the happy path returns the canonical success codes.
 type githubMux struct {
@@ -47,6 +56,7 @@ type githubMux struct {
 	tokenStatus    int // POST .../access_tokens            (want 201)
 	branchStatus   int // GET .../branches/<branch>         (want 200)
 	dispatchStatus int // POST .../dispatches               (want 204)
+	capture        *githubCapture
 }
 
 func (g githubMux) server(t *testing.T) *httptest.Server {
@@ -74,6 +84,10 @@ func (g githubMux) server(t *testing.T) *httptest.Server {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
 			w.WriteHeader(or(g.branchStatus, http.StatusOK))
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/dispatches"):
+			if g.capture != nil {
+				g.capture.dispatchBody, _ = io.ReadAll(r.Body)
+				g.capture.dispatchPath = r.URL.Path
+			}
 			w.WriteHeader(or(g.dispatchStatus, http.StatusNoContent))
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -94,6 +108,25 @@ func findRespond(t *testing.T, calls []recordedCall) recordedCall {
 	}
 	t.Fatalf("no Respond call recorded; got %d calls", len(calls))
 	return recordedCall{}
+}
+
+func TestAppsBetaDeploy_Definition(t *testing.T) {
+	cmd := AppsBetaDeploy()
+	if cmd.Definition == nil {
+		t.Fatal("AppsBetaDeploy must return a Definition")
+	}
+	if cmd.Definition.Name != "apps_beta_deploy" {
+		t.Fatalf("command name = %q, want apps_beta_deploy", cmd.Definition.Name)
+	}
+	if len(cmd.Definition.Options) != 1 || cmd.Definition.Options[0].Name != "branch" {
+		t.Fatalf("expected a required 'branch' option, got %+v", cmd.Definition.Options)
+	}
+	if !cmd.Definition.Options[0].Required {
+		t.Fatal("branch option must be required")
+	}
+	if cmd.Handler == nil {
+		t.Fatal("AppsBetaDeploy must wire a Handler")
+	}
 }
 
 func TestRunAppsBetaDeploy_SuccessfulDispatch(t *testing.T) {
@@ -122,6 +155,121 @@ func TestRunAppsBetaDeploy_SuccessfulDispatch(t *testing.T) {
 	}
 	if !strings.Contains(followup.Params.Content, "deployment started for branch `feature-x`") {
 		t.Fatalf("unexpected followup content: %q", followup.Params.Content)
+	}
+}
+
+// TestRunAppsBetaDeploy_DispatchPayloadAndAttribution drives the full confirm
+// path and asserts (a) the dispatch the command sent targets dev_deploy.yml on
+// 7cav/adr with ref=main and inputs.branch=<branch>, and (b) the success
+// followup attributes the deploy to the invoking user and links the status URL.
+func TestRunAppsBetaDeploy_DispatchPayloadAndAttribution(t *testing.T) {
+	setGithubEnv(t)
+	cap := &githubCapture{}
+	githubMux{capture: cap}.server(t)
+
+	r := &fakeResponder{}
+	i := fakeMessageComponentInteraction("apps_beta_deploy::confirm::feature-x")
+	runAppsBetaDeploy(r, i)
+
+	// Dispatch payload: targets the expected workflow with the right ref/branch.
+	if want := "/repos/7cav/adr/actions/workflows/dev_deploy.yml/dispatches"; cap.dispatchPath != want {
+		t.Fatalf("dispatch path = %q, want %q", cap.dispatchPath, want)
+	}
+	var payload struct {
+		Ref    string `json:"ref"`
+		Inputs struct {
+			Branch string `json:"branch"`
+		} `json:"inputs"`
+	}
+	if err := json.Unmarshal(cap.dispatchBody, &payload); err != nil {
+		t.Fatalf("dispatch body not JSON: %v (raw=%q)", err, cap.dispatchBody)
+	}
+	if payload.Ref != "main" || payload.Inputs.Branch != "feature-x" {
+		t.Fatalf("unexpected dispatch payload: ref=%q branch=%q", payload.Ref, payload.Inputs.Branch)
+	}
+
+	// Followup attributes the invoking user (ID 999, see fake interaction) and
+	// includes the workflow status URL.
+	var followup *recordedCall
+	for idx := range r.Calls() {
+		if r.Calls()[idx].Method == "Followup" {
+			followup = &r.Calls()[idx]
+		}
+	}
+	if followup == nil {
+		t.Fatalf("expected a Followup call on success; calls=%+v", r.Calls())
+	}
+	if !strings.Contains(followup.Params.Content, "<@999>") {
+		t.Fatalf("followup must attribute invoking user <@999>: %q", followup.Params.Content)
+	}
+	if !strings.Contains(followup.Params.Content, "https://github.com/7cav/adr/actions/workflows/dev_deploy.yml") {
+		t.Fatalf("followup must include status URL: %q", followup.Params.Content)
+	}
+}
+
+func TestRunAppsBetaDeploy_MissingAppKey(t *testing.T) {
+	// Client ID present, app key cleared → specific config error, no dispatch.
+	t.Setenv("GITHUB_APP_CLIENT_ID", "Iv1.testclientid")
+	t.Setenv("GITHUB_APP_KEY", "")
+	cap := &githubCapture{}
+	githubMux{capture: cap}.server(t)
+
+	r := &fakeResponder{}
+	i := fakeMessageComponentInteraction("apps_beta_deploy::confirm::feature-x")
+	runAppsBetaDeploy(r, i)
+
+	if !errorContent(r.Calls(), "GitHub App key not configured") {
+		t.Fatalf("expected missing-app-key error; calls=%+v", r.Calls())
+	}
+	if cap.dispatchBody != nil {
+		t.Fatalf("must not dispatch when app key is missing; body=%q", cap.dispatchBody)
+	}
+	if hasFollowup(r.Calls()) {
+		t.Fatalf("config error must not send a success followup")
+	}
+}
+
+func TestRunAppsBetaDeploy_BadBase64Key(t *testing.T) {
+	// App key set but not valid base64 → decode error, no dispatch.
+	t.Setenv("GITHUB_APP_CLIENT_ID", "Iv1.testclientid")
+	t.Setenv("GITHUB_APP_KEY", "not!valid!base64!")
+	cap := &githubCapture{}
+	githubMux{capture: cap}.server(t)
+
+	r := &fakeResponder{}
+	i := fakeMessageComponentInteraction("apps_beta_deploy::confirm::feature-x")
+	runAppsBetaDeploy(r, i)
+
+	if !errorContent(r.Calls(), "Failed to decode private key") {
+		t.Fatalf("expected base64-decode error; calls=%+v", r.Calls())
+	}
+	if cap.dispatchBody != nil {
+		t.Fatalf("must not dispatch on bad base64 key; body=%q", cap.dispatchBody)
+	}
+	if hasFollowup(r.Calls()) {
+		t.Fatalf("config error must not send a success followup")
+	}
+}
+
+func TestRunAppsBetaDeploy_MissingClientID(t *testing.T) {
+	// Valid app key, client ID cleared → specific config error, no dispatch.
+	t.Setenv("GITHUB_APP_KEY", testGithubPEM(t))
+	t.Setenv("GITHUB_APP_CLIENT_ID", "")
+	cap := &githubCapture{}
+	githubMux{capture: cap}.server(t)
+
+	r := &fakeResponder{}
+	i := fakeMessageComponentInteraction("apps_beta_deploy::confirm::feature-x")
+	runAppsBetaDeploy(r, i)
+
+	if !errorContent(r.Calls(), "GitHub App client ID not configured") {
+		t.Fatalf("expected missing-client-id error; calls=%+v", r.Calls())
+	}
+	if cap.dispatchBody != nil {
+		t.Fatalf("must not dispatch when client ID is missing; body=%q", cap.dispatchBody)
+	}
+	if hasFollowup(r.Calls()) {
+		t.Fatalf("config error must not send a success followup")
 	}
 }
 

--- a/commands/gamertag_search_test.go
+++ b/commands/gamertag_search_test.go
@@ -162,6 +162,56 @@ func TestRunGamertagSearch_BadUniformURL_FallsThroughHandleError(t *testing.T) {
 // errAlreadyAcked simulates the SDK error string HandleError matches on.
 var errAlreadyAcked = stubError("HTTP 400 Bad Request, {\"message\": \"Interaction has already been acknowledged.\", \"code\": 40060}")
 
+// errFirstRespond is a plain (non-already-acknowledged) failure used to fail the
+// FIRST placeholder InteractionRespond. Because it does NOT match
+// isAlreadyAcknowledged, HandleError's own Respond succeeds and it does not fall
+// back to Edit — so the placeholder-fails path produces exactly 2 Respond calls.
+var errFirstRespond = stubError("HTTP 503 Service Unavailable: gateway temporarily down")
+
 type stubError string
 
 func (e stubError) Error() string { return string(e) }
+
+// tripwireAPIServer stands up an httptest.Server that fails the test if it
+// receives ANY request, and points makeAPIRequest at it via
+// SetAPIBaseURLForTest. Used by the placeholder-fails tests to prove the command
+// bails before touching the upstream milpac API. Returns the server so callers
+// can assert hit count if needed (currently the t.Errorf is sufficient).
+func tripwireAPIServer(t *testing.T) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("upstream API must not be called after placeholder respond fails; got request to %s", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+}
+
+// assertPlaceholderFailedBailout is the shared assertion for the
+// "first InteractionRespond fails" path: the command must call HandleError
+// exactly once (which itself emits a single Respond), yielding exactly two
+// Respond calls total and no Edit. errFirstRespond is non-acked, so HandleError
+// does not fall back to Edit.
+func assertPlaceholderFailedBailout(t *testing.T, calls []recordedCall) {
+	t.Helper()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (placeholder Respond fails + single HandleError Respond), got %d: %+v", len(calls), calls)
+	}
+	if calls[0].Method != "Respond" {
+		t.Fatalf("calls[0]: expected placeholder Respond, got %q", calls[0].Method)
+	}
+	if calls[1].Method != "Respond" {
+		t.Fatalf("calls[1]: expected HandleError Respond (no Edit fallback for non-acked error), got %q", calls[1].Method)
+	}
+}
+
+func TestRunGamertagSearch_FirstRespondFails_BailsBeforeAPI(t *testing.T) {
+	tripwireAPIServer(t)
+
+	f := &fakeResponder{RespondErrs: []error{errFirstRespond}}
+	i := fakeAppCommandInteraction(stringOption("gamertag", "SpecOps"))
+
+	runGamertagSearch(f, i)
+
+	assertPlaceholderFailedBailout(t, f.Calls())
+}

--- a/commands/loa_test.go
+++ b/commands/loa_test.go
@@ -48,6 +48,36 @@ func loaMember(username, milpacID string) utils.LiteProfileResponse {
 	}
 }
 
+// tripwireLOAView is a loaCacheView that fails the test if either method is
+// called. Used by the first-respond-fails test to prove runLoa bails before
+// touching the cache (the health probe / per-member lookups) as well as the API.
+type tripwireLOAView struct{ t *testing.T }
+
+func (v tripwireLOAView) GetEntry(string) (utils.LOAEntry, bool) {
+	v.t.Errorf("cache.GetEntry must not be called after placeholder respond fails")
+	return utils.LOAEntry{}, false
+}
+
+func (v tripwireLOAView) IsHealthy(time.Duration) (bool, time.Time) {
+	v.t.Errorf("cache.IsHealthy must not be called after placeholder respond fails")
+	return false, time.Time{}
+}
+
+// TestRunLoa_FirstRespondFails_BailsBeforeCacheAndAPI covers the early-bail
+// branch when the placeholder InteractionRespond fails: runLoa must call
+// HandleError once and return before probing the cache or fetching the roster
+// (both tripwires fail the test if touched).
+func TestRunLoa_FirstRespondFails_BailsBeforeCacheAndAPI(t *testing.T) {
+	tripwireAPIServer(t)
+
+	f := &fakeResponder{RespondErrs: []error{errFirstRespond}}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runLoa(f, tripwireLOAView{t: t}, loaRefDate, i)
+
+	assertPlaceholderFailedBailout(t, f.Calls())
+}
+
 func TestRunLoa_RosterFetch500SurfacesError(t *testing.T) {
 	serveAwolRoster(t, utils.LiteRosterResponse{}, http.StatusInternalServerError)
 

--- a/commands/milpac_test.go
+++ b/commands/milpac_test.go
@@ -180,6 +180,9 @@ func TestRunMilpac_SuccessByDiscordID(t *testing.T) {
 	if calls[0].Method != "Respond" {
 		t.Fatalf("calls[0]: expected Respond, got %q", calls[0].Method)
 	}
+	if calls[0].Response.Type != discordgo.InteractionResponseChannelMessageWithSource {
+		t.Fatalf("calls[0]: expected placeholder Type ChannelMessageWithSource, got %v", calls[0].Response.Type)
+	}
 	if !strings.Contains(calls[0].Response.Data.Content, "Fetching Milpac data") {
 		t.Fatalf("calls[0]: expected placeholder content, got %q", calls[0].Response.Data.Content)
 	}
@@ -391,4 +394,19 @@ func TestRunMilpac_MalformedPromotionDate_FallsThroughHandleError(t *testing.T) 
 		}
 		t.Fatalf("calls[2]: expected 'Failed to parse promotion date', got %q", got)
 	}
+}
+
+// TestRunMilpac_FirstRespondFails_BailsBeforeAPI covers the early-bail branch
+// when the placeholder InteractionRespond fails: runMilpac must call HandleError
+// once and return before fetching the milpac (tripwire server fails the test if
+// hit).
+func TestRunMilpac_FirstRespondFails_BailsBeforeAPI(t *testing.T) {
+	tripwireAPIServer(t)
+
+	f := &fakeResponder{RespondErrs: []error{errFirstRespond}}
+	i := fakeAppCommandInteraction(userOption("user", "111"))
+
+	runMilpac(f, i)
+
+	assertPlaceholderFailedBailout(t, f.Calls())
 }

--- a/commands/s6_trackers_test.go
+++ b/commands/s6_trackers_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
 )
 
 // s6RefDate is the pinned "now" for all S6-IT unit tests; chosen so the
@@ -515,6 +516,9 @@ func TestRunS6ITCheck_HappyPathWithSkipped(t *testing.T) {
 	if calls[0].Method != "Respond" || calls[0].Response.Data.Content != "Fetching S6 IT Check data..." {
 		t.Fatalf("calls[0]: expected placeholder Respond, got %+v", calls[0])
 	}
+	if calls[0].Response.Type != discordgo.InteractionResponseChannelMessageWithSource {
+		t.Fatalf("calls[0]: expected placeholder Type ChannelMessageWithSource, got %v", calls[0].Response.Type)
+	}
 	if calls[1].Method != "Edit" || calls[1].Edit.Content == nil {
 		t.Fatalf("calls[1]: expected Edit with non-nil Content, got %+v", calls[1])
 	}
@@ -666,4 +670,19 @@ func TestRunS6ITCheck_RosterFetch500(t *testing.T) {
 		}
 		t.Fatalf("expected 'Failed to fetch S6 Members' in Edit fallback, got %q", got)
 	}
+}
+
+// TestRunS6ITCheck_FirstRespondFails_BailsBeforeAPI covers the early-bail branch
+// when the placeholder InteractionRespond fails: runS6ITCheck must call
+// HandleError once and return before fetching the roster (tripwire server fails
+// the test if hit).
+func TestRunS6ITCheck_FirstRespondFails_BailsBeforeAPI(t *testing.T) {
+	tripwireAPIServer(t)
+
+	f := &fakeResponder{RespondErrs: []error{errFirstRespond}}
+	i := fakeAppCommandInteraction()
+
+	runS6ITCheck(f, i)
+
+	assertPlaceholderFailedBailout(t, f.Calls())
 }

--- a/utils/github_test.go
+++ b/utils/github_test.go
@@ -4,26 +4,51 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
+
+// testRSAKey generates a throwaway RSA private key and returns it both as a
+// parseable PEM (the form GithubAuth consumes) and as the *rsa.PrivateKey, so a
+// test can verify the RS256 signature GithubAuth produces against the public
+// half.
+func testRSAKey(t *testing.T) ([]byte, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return pemBytes, key
+}
 
 // testRSAPEM generates a throwaway RSA private key and returns it PEM-encoded.
 // GithubAuth parses it with jwt.ParseRSAPrivateKeyFromPEM, so the bytes must be
 // a real, parseable RSA key.
 func testRSAPEM(t *testing.T) []byte {
 	t.Helper()
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("generate rsa key: %v", err)
-	}
-	return pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	})
+	pemBytes, _ := testRSAKey(t)
+	return pemBytes
+}
+
+// ghCapture records request details the fake server saw, so a test can assert
+// the Authorization header (the minted JWT) and the dispatch payload without a
+// live GitHub call.
+type ghCapture struct {
+	installAuth  string // Authorization header on GET /app/installations
+	dispatchBody []byte // raw body of POST .../dispatches
+	dispatchPath string // request path of POST .../dispatches
 }
 
 // ghMux is a configurable fake GitHub Apps API. Each phase defaults to its
@@ -35,6 +60,7 @@ type ghMux struct {
 	tokenBody      string // override the 201 body
 	branchStatus   int    // GET .../branches/<branch>  (want 200)
 	dispatchStatus int    // POST .../dispatches        (want 204)
+	capture        *ghCapture
 }
 
 func (g ghMux) server(t *testing.T) *httptest.Server {
@@ -48,6 +74,9 @@ func (g ghMux) server(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/app/installations":
+			if g.capture != nil {
+				g.capture.installAuth = r.Header.Get("Authorization")
+			}
 			st := or(g.installStatus, http.StatusOK)
 			w.WriteHeader(st)
 			if st == http.StatusOK {
@@ -70,6 +99,10 @@ func (g ghMux) server(t *testing.T) *httptest.Server {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
 			w.WriteHeader(or(g.branchStatus, http.StatusOK))
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/dispatches"):
+			if g.capture != nil {
+				g.capture.dispatchBody, _ = io.ReadAll(r.Body)
+				g.capture.dispatchPath = r.URL.Path
+			}
 			w.WriteHeader(or(g.dispatchStatus, http.StatusNoContent))
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -89,6 +122,89 @@ func TestGithubAuth_Success(t *testing.T) {
 	}
 	if token != "ghs_testtoken" {
 		t.Fatalf("expected minted token, got %q", token)
+	}
+}
+
+// TestGithubAuth_JWTClaimsAndSignature captures the Bearer JWT GithubAuth sends
+// to the installations endpoint and verifies its issuer, ~5-minute expiry
+// window, and RS256 signature against the test key's public half. This pins the
+// GitHub App authentication contract — a regression in signing alg or claims
+// would otherwise pass silently behind the status-only fake.
+func TestGithubAuth_JWTClaimsAndSignature(t *testing.T) {
+	pemBytes, key := testRSAKey(t)
+	cap := &ghCapture{}
+	ghMux{capture: cap}.server(t)
+
+	before := time.Now()
+	if _, err := GithubAuth("Iv1.testclientid", pemBytes); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after := time.Now()
+
+	const prefix = "Bearer "
+	if !strings.HasPrefix(cap.installAuth, prefix) {
+		t.Fatalf("expected Bearer auth header, got %q", cap.installAuth)
+	}
+	raw := strings.TrimPrefix(cap.installAuth, prefix)
+
+	claims := jwt.MapClaims{}
+	parsed, err := jwt.ParseWithClaims(raw, claims, func(tok *jwt.Token) (interface{}, error) {
+		if _, ok := tok.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, jwt.ErrSignatureInvalid
+		}
+		return &key.PublicKey, nil
+	})
+	if err != nil {
+		t.Fatalf("JWT failed to verify against test public key: %v", err)
+	}
+	if !parsed.Valid {
+		t.Fatal("parsed JWT reported invalid")
+	}
+	if alg, _ := parsed.Header["alg"].(string); alg != "RS256" {
+		t.Fatalf("expected RS256 alg header, got %q", alg)
+	}
+	if iss, _ := claims["iss"].(string); iss != "Iv1.testclientid" {
+		t.Fatalf("expected iss==clientID, got %q", iss)
+	}
+
+	// exp must sit ~5 minutes ahead of iat; allow slack for the wall-clock
+	// window the call spanned.
+	iat, ok1 := claims["iat"].(float64)
+	exp, ok2 := claims["exp"].(float64)
+	if !ok1 || !ok2 {
+		t.Fatalf("missing iat/exp claims: %v", claims)
+	}
+	if d := exp - iat; d < 290 || d > 301 {
+		t.Fatalf("expected ~300s expiry window, got %.0fs", d)
+	}
+	if exp < float64(before.Add(4*time.Minute).Unix()) || exp > float64(after.Add(6*time.Minute).Unix()) {
+		t.Fatalf("exp %.0f outside expected ~5-min-from-now window [%d,%d]", exp, before.Unix(), after.Unix())
+	}
+}
+
+func TestGithubAuth_MalformedInstallationsJSON(t *testing.T) {
+	// 200 with a body that isn't the expected JSON array → unmarshal error.
+	ghMux{installBody: `{not valid json`}.server(t)
+
+	_, err := GithubAuth("Iv1.testclientid", testRSAPEM(t))
+	if err == nil {
+		t.Fatal("expected error on malformed installations JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to unmarshal installations") {
+		t.Fatalf("expected unmarshal-installations error, got %v", err)
+	}
+}
+
+func TestGithubAuth_MalformedTokenJSON(t *testing.T) {
+	// Installations succeed; the access-token 201 body is unparseable.
+	ghMux{tokenBody: `{not valid json`}.server(t)
+
+	_, err := GithubAuth("Iv1.testclientid", testRSAPEM(t))
+	if err == nil {
+		t.Fatal("expected error on malformed token JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to unmarshal jwtToken") {
+		t.Fatalf("expected unmarshal-token error, got %v", err)
 	}
 }
 
@@ -146,6 +262,39 @@ func TestTriggerGithubDeployment_Success(t *testing.T) {
 	err := TriggerGithubDeployment("feature-x", "tok", "7cav", "adr", "dev_deploy.yml", "main")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestTriggerGithubDeployment_Payload captures the workflow-dispatch request and
+// asserts it carries the expected ref + inputs.branch and targets the right
+// workflow path. Without this, the status-only fake would accept a dispatch
+// pointed at the wrong branch or workflow.
+func TestTriggerGithubDeployment_Payload(t *testing.T) {
+	cap := &ghCapture{}
+	ghMux{capture: cap}.server(t)
+
+	if err := TriggerGithubDeployment("feature-x", "tok", "7cav", "adr", "dev_deploy.yml", "main"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if want := "/repos/7cav/adr/actions/workflows/dev_deploy.yml/dispatches"; cap.dispatchPath != want {
+		t.Fatalf("dispatch path = %q, want %q", cap.dispatchPath, want)
+	}
+
+	var payload struct {
+		Ref    string `json:"ref"`
+		Inputs struct {
+			Branch string `json:"branch"`
+		} `json:"inputs"`
+	}
+	if err := json.Unmarshal(cap.dispatchBody, &payload); err != nil {
+		t.Fatalf("dispatch body not JSON: %v (raw=%q)", err, cap.dispatchBody)
+	}
+	if payload.Ref != "main" {
+		t.Fatalf("ref = %q, want main", payload.Ref)
+	}
+	if payload.Inputs.Branch != "feature-x" {
+		t.Fatalf("inputs.branch = %q, want feature-x", payload.Inputs.Branch)
 	}
 }
 

--- a/utils/loa_test.go
+++ b/utils/loa_test.go
@@ -3,6 +3,9 @@ package utils
 import (
 	"database/sql"
 	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -431,6 +434,80 @@ func TestRefresh_RowsErrMidStream_DoesNotCount(t *testing.T) {
 		t.Fatalf("lastSuccessfulRefresh moved to %v, want unchanged %v "+
 			"(mid-stream failures must not count as success)",
 			c.lastSuccessfulRefresh, seed)
+	}
+}
+
+// concurrentLOAFetcher is a loaPostFetcher safe for concurrent refresh calls. It
+// returns a fresh, distinct post on every call (advancing post_date and rotating
+// the username) so each Refresh mutates the entries map and the lastSynced cursor
+// — maximizing the window for an unprotected read to observe a torn write. It holds
+// no lock of its own: the contention under test is on LOACache's own RWMutex, so a
+// thread-safe fetcher keeps any race the detector flags squarely in the cache.
+type concurrentLOAFetcher struct {
+	n atomic.Int64
+}
+
+func (f *concurrentLOAFetcher) fetchLOAPosts(_ int, _ int64) ([]loaPostRow, error) {
+	i := f.n.Add(1)
+	user := "user" + strconv.FormatInt(i%8, 10)
+	return []loaPostRow{{
+		message:  loaPost(user, "Jan 1, 2099", "Jan 31, 2099"),
+		postDate: time.Now().Unix() + i,
+		threadID: i,
+	}}, nil
+}
+
+// TestLOACache_ConcurrentRefreshAndReads fans out many goroutines that hammer
+// Refresh (writer path) alongside GetEntry / IsOnLOA / IsHealthy (reader paths) on
+// one cache. Its job is to fail under `go test -race` if the cache's locking ever
+// regresses — e.g. a dropped Lock/RLock or a read of a guarded field outside the
+// mutex. With locking intact it is a fast, deterministic no-op assertion (the cache
+// stays usable); under -race a lock regression trips the detector and fails the run.
+func TestLOACache_ConcurrentRefreshAndReads(t *testing.T) {
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	fetcher := &concurrentLOAFetcher{}
+	nodeIDs := []int{180, 400, 540}
+
+	const (
+		writers      = 8
+		readers      = 16
+		opsPerWriter = 50
+		opsPerReader = 100
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerWriter; j++ {
+				c.refresh(fetcher, nodeIDs)
+			}
+		}()
+	}
+
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerReader; j++ {
+				// Touch every guarded read path; results are intentionally
+				// ignored — the race detector, not an assertion, is the oracle.
+				_, _ = c.GetEntry("user1")
+				_ = c.IsOnLOA("user2")
+				_, _ = c.IsHealthy(30 * time.Minute)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Sanity: after the storm the cache is still coherent and readable under lock.
+	if ok, _ := c.IsHealthy(time.Hour); !ok {
+		t.Fatalf("cache should report healthy after concurrent refreshes")
+	}
+	if _, ok := c.GetEntry("user1"); !ok {
+		t.Fatalf("expected at least one rotated user entry to be present")
 	}
 }
 


### PR DESCRIPTION
Swarm wave 2 — three independent test-coverage issues integrated on one branch (shared coverage-floor script reconciled once to combined coverage).

## Closes
- Closes #139 — LOA cache concurrency + enable -race in CI
- Closes #138 — /apps_beta_deploy GitHub dispatch payload + JWT
- Closes #143 — placeholder-pattern command robustness (first-respond-fails + Type)

## What
Test-only, plus a CI hardening change (#139 enables `-race`). No production code behavior changed.

- **#139** — `TestLOACache_ConcurrentRefreshAndReads`: 8 writer + 16 reader goroutines over the fetcher seam, proven to trip `-race` when an RLock is dropped. Enables `-race` in `build_test.yml` and syncs the documented CI-gate command in README + CLAUDE.md. (No data race detected — locking is sound.)
- **#138** — captures the workflow-dispatch body (asserts `ref`, `inputs.branch`, `dev_deploy.yml` target); verifies the minted JWT issuer/expiry/RS256 signature against the test key; covers malformed-JSON unmarshal branches and the three config-error paths (missing key, missing client ID, bad base64). `golang-jwt/jwt/v5` already a dep — no go.mod change.
- **#143** — one "first `InteractionRespond` fails" test per placeholder command (`/afsm`, `/milpac`, `/s6-it-check`, `/gamertag-search`, `/loa`) asserting single-`HandleError` bail + no upstream API call (tripwire server); pins placeholder `Type == ChannelMessageWithSource` for `/afsm`, `/milpac`, `/s6-it-check`.

## Coverage (ADR 0005)
Combined (with `-race`): utils 87.8%, commands 82.1%. Floor raised commands 81→82 (utils stays 87).

## CI gate
Local gate green incl. `-race`: lint 0, `go mod tidy` clean, tests pass, floor check pass, build OK.

## Manual gates
- Smoke test: **skipped** — test-only + CI-config change, zero command-behavior change.
- Env-var parity: N/A — no new vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)