### PR TITLE
test(loa): LOA active-window + prune boundaries; drop dead awol consts (#140)

### DIFF
--- a/commands/awol.go
+++ b/commands/awol.go
@@ -17,8 +17,6 @@ func stringPtr(s string) *string {
 }
 
 const (
-	maxEmbedLength    = 6000
-	maxFieldsPerEmbed = 25
 	maxEmbedsPerMsg   = 10
 	awolThresholdDays = 8
 )

--- a/commands/awol_test.go
+++ b/commands/awol_test.go
@@ -84,6 +84,36 @@ func healthyCache(entries map[string]utils.LOAEntry) *fakeLOACache {
 	return &fakeLOACache{entries: entries, healthy: true, lastRefresh: awolRefDate}
 }
 
+// dateAwareLOACache is a loaCacheReader whose IsOnLOA respects each entry's
+// StartDate/EndDate window evaluated at a FIXED `at` instant — unlike fakeLOACache,
+// whose IsOnLOA returns true for any existing entry regardless of dates. This lets
+// an /awol test exercise the "entry exists but is not active today" path (upcoming
+// or expired), proving such a member is excluded from the (N on LOA) tally and the
+// [LOA] decoration on the healthy path. `at` is pinned to the same instant the
+// handler is given as `now`, so the cache's verdict and the handler agree on "today".
+type dateAwareLOACache struct {
+	entries map[string]utils.LOAEntry
+	at      time.Time
+}
+
+func (f *dateAwareLOACache) GetEntry(username string) (utils.LOAEntry, bool) {
+	e, ok := f.entries[strings.ToLower(username)]
+	return e, ok
+}
+
+func (f *dateAwareLOACache) IsOnLOA(username string) bool {
+	e, ok := f.entries[strings.ToLower(username)]
+	if !ok {
+		return false
+	}
+	// Mirror utils.LOACache's inclusive active window evaluated at `at`.
+	return !f.at.Before(e.StartDate) && !f.at.After(e.EndDate)
+}
+
+func (f *dateAwareLOACache) IsHealthy(_ time.Duration) (bool, time.Time) {
+	return true, f.at // always healthy: this fake exercises the date-window path
+}
+
 func boolOption(name string, value bool) *discordgo.ApplicationCommandInteractionDataOption {
 	return &discordgo.ApplicationCommandInteractionDataOption{
 		Name:  name,
@@ -330,6 +360,85 @@ func TestRunAwol_OnLOAAnnotationRenders(t *testing.T) {
 			got = footer.Text
 		}
 		t.Fatalf("footer should report 1 on LOA; got %q", got)
+	}
+}
+
+func TestRunAwol_InactiveLOAEntryNotCountedOrTagged(t *testing.T) {
+	// Three AWOL members on the healthy path, each with a cache entry, but only
+	// Trooper.B's window covers awolRefDate (2026-05-15):
+	//   - Trooper.A: UPCOMING (starts after now) → not active → no tag, not counted.
+	//   - Trooper.B: ACTIVE (window straddles now) → tagged + counted.
+	//   - Trooper.C: EXPIRED (ended before now) → not active → no tag, not counted.
+	// Asserts the (N on LOA) tally is exactly 1 and only the active member is tagged.
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+			"200": awolMember("Trooper.B", "200", "2026-03-15 12:00:00"),
+			"300": awolMember("Trooper.C", "300", "2026-04-01 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	cache := &dateAwareLOACache{
+		at: awolRefDate,
+		entries: map[string]utils.LOAEntry{
+			"trooper.a": { // upcoming: starts AFTER awolRefDate
+				Username:  "Trooper.A",
+				StartDate: mustParseAwolDate("2026-06-01 00:00:00"),
+				EndDate:   mustParseAwolDate("2026-06-30 00:00:00"),
+				ThreadID:  1111,
+			},
+			"trooper.b": { // active: window straddles awolRefDate
+				Username:  "Trooper.B",
+				StartDate: mustParseAwolDate("2026-05-01 00:00:00"),
+				EndDate:   mustParseAwolDate("2026-05-31 00:00:00"),
+				ThreadID:  2222,
+			},
+			"trooper.c": { // expired: ended BEFORE awolRefDate
+				Username:  "Trooper.C",
+				StartDate: mustParseAwolDate("2026-04-01 00:00:00"),
+				EndDate:   mustParseAwolDate("2026-04-30 00:00:00"),
+				ThreadID:  3333,
+			},
+		},
+	}
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+
+	runAwol(f, cache, awolRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %+v", len(calls), calls)
+	}
+	edit := calls[1].Edit
+	if edit.Embeds == nil || len(*edit.Embeds) == 0 {
+		t.Fatalf("expected embeds; got Embeds=%v", edit.Embeds)
+	}
+	desc := (*edit.Embeds)[0].Description
+	// All three members still listed (AWOL is independent of LOA state).
+	for _, want := range []string{"Trooper.A", "Trooper.B", "Trooper.C"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("embed description missing %q.\nGot:\n%s", want, desc)
+		}
+	}
+	// Only the ACTIVE member is decorated; the upcoming/expired threads must not appear.
+	if !strings.Contains(desc, "https://7cav.us/threads/2222/") {
+		t.Fatalf("active member Trooper.B should be LOA-tagged to thread 2222.\nGot:\n%s", desc)
+	}
+	for _, badThread := range []string{"threads/1111", "threads/3333"} {
+		if strings.Contains(desc, badThread) {
+			t.Fatalf("inactive (upcoming/expired) entry must NOT be LOA-tagged (%s leaked).\nGot:\n%s", badThread, desc)
+		}
+	}
+	// Footer tally counts ONLY the currently-active LOA: exactly 1 of 3.
+	footer := (*edit.Embeds)[0].Footer
+	if footer == nil || !strings.Contains(footer.Text, "Total AWOL: 3 (1 on LOA)") {
+		got := "<nil>"
+		if footer != nil {
+			got = footer.Text
+		}
+		t.Fatalf("footer should report exactly 1 on LOA (active only); got %q", got)
 	}
 }
 

--- a/utils/loa.go
+++ b/utils/loa.go
@@ -42,6 +42,23 @@ func (c *LOACache) GetEntry(username string) (LOAEntry, bool) {
 	return e, ok
 }
 
+// isActiveAt reports whether the entry's LOA window is active at the instant
+// `now`. The window is inclusive at both bounds: an entry is active from its
+// StartDate through its EndDate (so Start==now and End==now both count as active).
+// Clock-injected so the boundary semantics are unit-testable at the exact edge
+// (cf. PR #135); the production callers pass time.Now().
+func (e LOAEntry) isActiveAt(now time.Time) bool {
+	return !now.Before(e.StartDate) && !now.After(e.EndDate)
+}
+
+// isExpiredAt reports whether the entry's LOA window has ended strictly before
+// `now` — the prune cutoff. It is the strict complement of the inclusive upper
+// bound in isActiveAt: an entry on its EndDate (End==now) is NOT yet expired and
+// survives a prune cycle; one whose EndDate is already past is pruned.
+func (e LOAEntry) isExpiredAt(now time.Time) bool {
+	return now.After(e.EndDate)
+}
+
 // IsOnLOA returns true if the username has a currently active LOA.
 func (c *LOACache) IsOnLOA(username string) bool {
 	c.mu.RLock()
@@ -50,8 +67,7 @@ func (c *LOACache) IsOnLOA(username string) bool {
 	if !ok {
 		return false
 	}
-	now := time.Now()
-	return !now.Before(entry.StartDate) && !now.After(entry.EndDate)
+	return entry.isActiveAt(time.Now())
 }
 
 // IsHealthy reports whether the cache has been successfully refreshed within
@@ -148,7 +164,7 @@ func (c *LOACache) refresh(fetcher loaPostFetcher, nodeIDs []int) {
 	// Prune entries whose LOA has ended.
 	now := time.Now()
 	for k, e := range c.entries {
-		if now.After(e.EndDate) {
+		if e.isExpiredAt(now) {
 			delete(c.entries, k)
 		}
 	}

--- a/utils/loa_test.go
+++ b/utils/loa_test.go
@@ -22,6 +22,16 @@ func loaPost(username, start, end string) string {
 		"[B][COLOR=rgb(213, 185, 0)]End Date[/COLOR][/B]\n" + end + "\n"
 }
 
+// mustLOATime parses a date in the canonical LOA layout ("Jan 2, 2006") for
+// fixed-instant boundary tests; it panics on a malformed literal in test code.
+func mustLOATime(s string) time.Time {
+	t, err := time.Parse(loaDateLayout, s)
+	if err != nil {
+		panic("mustLOATime: " + err.Error())
+	}
+	return t
+}
+
 // TestParseLOAPost locks in the CURRENT contract of the brittle BBCode regexes.
 // Each case asserts actual observed behavior of the existing regexes (verified by
 // probe), not aspirational behavior — so this catches Xenforo template drift.
@@ -276,6 +286,151 @@ func TestGetEntryAndIsOnLOA(t *testing.T) {
 	}
 	if c.IsOnLOA("missing") {
 		t.Errorf("IsOnLOA should be false for unknown user")
+	}
+}
+
+// TestLOAEntry_isActiveAt pins the inclusive active-window contract at the EXACT
+// boundary instants. isActiveAt is clock-injected (cf. PR #135) precisely so the
+// Start==now and End==now edges can be asserted against a fixed `now` — something
+// IsOnLOA's live time.Now() can never hit deterministically. The window is
+// inclusive at both bounds.
+func TestLOAEntry_isActiveAt(t *testing.T) {
+	now := mustLOATime("Jun 15, 2099")
+	entry := LOAEntry{
+		Username:  "Boundary",
+		StartDate: mustLOATime("Jun 10, 2099"),
+		EndDate:   mustLOATime("Jun 20, 2099"),
+	}
+
+	tests := []struct {
+		name string
+		now  time.Time
+		want bool
+	}{
+		{"Start==now is active (inclusive lower bound)", entry.StartDate, true},
+		{"End==now is active (inclusive upper bound)", entry.EndDate, true},
+		{"strictly inside the window is active", now, true},
+		{"one tick before Start is not active", entry.StartDate.Add(-time.Nanosecond), false},
+		{"one tick after End is not active", entry.EndDate.Add(time.Nanosecond), false},
+		{"wholly before window is not active", entry.StartDate.AddDate(0, 0, -5), false},
+		{"wholly after window is not active", entry.EndDate.AddDate(0, 0, 5), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := entry.isActiveAt(tt.now); got != tt.want {
+				t.Errorf("isActiveAt(%s) = %v, want %v", tt.now.Format(loaDateLayout), got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLOAEntry_isExpiredAt pins the prune cutoff at the EXACT EndDate boundary:
+// expiry is strict (now.After(EndDate)), so an entry whose End==now is NOT yet
+// expired (survives the cycle) while one already one tick past End is pruned. This
+// is the strict complement of isActiveAt's inclusive upper bound.
+func TestLOAEntry_isExpiredAt(t *testing.T) {
+	entry := LOAEntry{Username: "Boundary", EndDate: mustLOATime("Jun 20, 2099")}
+
+	if entry.isExpiredAt(entry.EndDate) {
+		t.Errorf("End==now must NOT be expired (final day survives prune)")
+	}
+	if entry.isExpiredAt(entry.EndDate.Add(-time.Nanosecond)) {
+		t.Errorf("one tick before End must NOT be expired")
+	}
+	if !entry.isExpiredAt(entry.EndDate.Add(time.Nanosecond)) {
+		t.Errorf("one tick after End must be expired")
+	}
+}
+
+// TestIsOnLOA_ActiveWindowBoundaries cross-checks the live-clock IsOnLOA wrapper
+// (which delegates to isActiveAt with time.Now()) against entries positioned
+// relative to a captured `now`. The exact-edge contract is pinned by
+// TestLOAEntry_isActiveAt; this guards the wrapper's wiring (lock, lookup,
+// time.Now() delegation) end-to-end.
+func TestIsOnLOA_ActiveWindowBoundaries(t *testing.T) {
+	now := time.Now()
+	const slack = time.Minute // dwarfs the captured-now vs internal-now gap
+
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	c.entries["active"] = LOAEntry{Username: "Active", StartDate: now.Add(-slack), EndDate: now.Add(slack)}
+	c.entries["past"] = LOAEntry{Username: "Past", StartDate: now.Add(-2 * slack), EndDate: now.Add(-slack)}
+	c.entries["futurewin"] = LOAEntry{Username: "FutureWin", StartDate: now.Add(slack), EndDate: now.Add(2 * slack)}
+
+	if !c.IsOnLOA("active") {
+		t.Errorf("IsOnLOA: entry within its window must be active")
+	}
+	if c.IsOnLOA("past") {
+		t.Errorf("IsOnLOA: wholly-past window must not be active")
+	}
+	if c.IsOnLOA("futurewin") {
+		t.Errorf("IsOnLOA: wholly-future window must not be active")
+	}
+}
+
+// TestRefresh_PruneBoundary cross-checks the prune step in refresh (which calls
+// isExpiredAt with time.Now()): an entry whose EndDate is still ahead of now
+// survives a refresh cycle, while one already past is pruned. The exact EndDate==now
+// edge is pinned by TestLOAEntry_isExpiredAt; this guards the prune wiring.
+func TestRefresh_PruneBoundary(t *testing.T) {
+	now := time.Now()
+	const slack = time.Minute
+
+	c := &LOACache{entries: map[string]LOAEntry{}}
+	c.entries["survivor"] = LOAEntry{Username: "Survivor", StartDate: now.Add(-slack), EndDate: now.Add(slack)}
+	c.entries["pruned"] = LOAEntry{Username: "Pruned", StartDate: now.Add(-2 * slack), EndDate: now.Add(-slack)}
+	c.lastSyncedPostDate = 100 // warm cache ⇒ deterministic since, no new posts
+
+	f := &fakeLOAFetcher{byNode: map[int][]loaPostRow{180: nil}}
+	c.refresh(f, []int{180})
+
+	if _, ok := c.GetEntry("survivor"); !ok {
+		t.Errorf("entry whose EndDate is still ahead of now must survive one refresh cycle")
+	}
+	if _, ok := c.GetEntry("pruned"); ok {
+		t.Errorf("entry whose EndDate is already past must be pruned")
+	}
+}
+
+// TestRefresh_LatestLOAWins pins the username-keyed overwrite in refresh: when a
+// later refresh observes a new valid post for an already-cached username, the new
+// entry replaces the old one ("latest LOA wins"). Keyed by lowercased username, so
+// the windows/threads must be distinct to prove the replacement actually happened.
+func TestRefresh_LatestLOAWins(t *testing.T) {
+	c := &LOACache{entries: map[string]LOAEntry{}}
+
+	// First post: an LOA for "delta" with one window/thread.
+	firstPost := time.Now().Add(-48 * time.Hour).Unix()
+	f1 := &fakeLOAFetcher{byNode: map[int][]loaPostRow{
+		180: {{message: loaPost("delta", "Jan 1, 2099", "Jan 31, 2099"), postDate: firstPost, threadID: 11}},
+	}}
+	c.refresh(f1, []int{180})
+
+	got, ok := c.GetEntry("delta")
+	if !ok {
+		t.Fatalf("expected delta entry after first refresh")
+	}
+	if got.ThreadID != 11 || got.EndDate.Format("2006-01-02") != "2099-01-31" {
+		t.Fatalf("first refresh entry = %+v, want thread 11 / end 2099-01-31", got)
+	}
+
+	// Second post: a NEW LOA for the same username with a later window and a
+	// different thread. After refresh the cache must hold ONLY the newer entry.
+	secondPost := time.Now().Add(-1 * time.Hour).Unix()
+	f2 := &fakeLOAFetcher{byNode: map[int][]loaPostRow{
+		180: {{message: loaPost("delta", "Feb 1, 2099", "Feb 28, 2099"), postDate: secondPost, threadID: 22}},
+	}}
+	c.refresh(f2, []int{180})
+
+	got, ok = c.GetEntry("delta")
+	if !ok {
+		t.Fatalf("expected delta entry after second refresh")
+	}
+	if got.ThreadID != 22 {
+		t.Errorf("latest LOA wins: ThreadID = %d, want 22 (newer post)", got.ThreadID)
+	}
+	if got.StartDate.Format("2006-01-02") != "2099-02-01" || got.EndDate.Format("2006-01-02") != "2099-02-28" {
+		t.Errorf("latest LOA wins: window = %s..%s, want 2099-02-01..2099-02-28",
+			got.StartDate.Format("2006-01-02"), got.EndDate.Format("2006-01-02"))
 	}
 }
 


### PR DESCRIPTION
Swarm wave 3 (final) — single issue.

## Closes
- Closes #140 — LOA active-window & prune-boundary semantics (utils + /awol)

## What
- **Boundary tests** for `IsOnLOA` (Start==now → active, End==now → active, wholly-past → inactive) and prune (EndDate==now survives one cycle; just-past is pruned), plus "latest LOA wins" overwrite.
- **/awol** test: an upcoming/expired (not-active-today) cache entry is excluded from the `(N on LOA)` count and gets no `[LOA]` tag on the healthy path (date-aware fake).
- **Dead code removed**: `maxEmbedLength` / `maxFieldsPerEmbed` consts in `commands/awol.go` (referenced nowhere; kept the in-use `maxEmbedsPerMsg` / `awolThresholdDays`).
- **Behavior-preserving refactor** in `utils/loa.go`: extracted clock-injected `LOAEntry.isActiveAt(now)` (inclusive both bounds) and `isExpiredAt(now)` (strict upper) so the exact boundary edges are unit-testable at a fixed instant (cf. PR #135). `IsOnLOA` + refresh-prune delegate to them — the expressions are identical to the prior inline logic; window/prune semantics unchanged.

## Coverage (ADR 0005)
utils 87.8%, commands 82.1% — steady (boundary tests replaced no-op paths). No floor bump; floors stay 87 / 82.

## CI gate
Local gate green incl. `-race`: lint 0, `go mod tidy` clean, tests pass, floor check pass, build OK.

## Manual gates
- Smoke test: **skipped** — behavior-preserving refactor + dead-code removal, zero command-behavior change.
- Env-var parity: N/A — no new vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)