### PR TITLE
chore(review): address post-merge review findings (comments, loa boundary helper, floor headroom)

### DIFF
--- a/.github/scripts/check-coverage-floors.sh
+++ b/.github/scripts/check-coverage-floors.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # script before any check runs. Don't "clean up" the `|| true`.
 read -r -d '' FLOORS <<'EOF' || true
 github.com/7cav/cavbot2/utils	87
-github.com/7cav/cavbot2/commands	82
+github.com/7cav/cavbot2/commands	81
 EOF
 
 # Read `go test -cover` output from stdin.

--- a/commands/awol_test.go
+++ b/commands/awol_test.go
@@ -89,8 +89,10 @@ func healthyCache(entries map[string]utils.LOAEntry) *fakeLOACache {
 // whose IsOnLOA returns true for any existing entry regardless of dates. This lets
 // an /awol test exercise the "entry exists but is not active today" path (upcoming
 // or expired), proving such a member is excluded from the (N on LOA) tally and the
-// [LOA] decoration on the healthy path. `at` is pinned to the same instant the
-// handler is given as `now`, so the cache's verdict and the handler agree on "today".
+// [LOA] decoration on the healthy path. This fake substitutes its own fixed clock
+// `at` for the wall clock that production's utils.LOACache.IsOnLOA reads internally
+// (the real method takes no time argument). The two are fidelity-equivalent only
+// because the test windows are weeks wide relative to the `at`-vs-wall-now skew.
 type dateAwareLOACache struct {
 	entries map[string]utils.LOAEntry
 	at      time.Time

--- a/commands/gamertag_search_test.go
+++ b/commands/gamertag_search_test.go
@@ -175,8 +175,8 @@ func (e stubError) Error() string { return string(e) }
 // tripwireAPIServer stands up an httptest.Server that fails the test if it
 // receives ANY request, and points makeAPIRequest at it via
 // SetAPIBaseURLForTest. Used by the placeholder-fails tests to prove the command
-// bails before touching the upstream milpac API. Returns the server so callers
-// can assert hit count if needed (currently the t.Errorf is sufficient).
+// bails before touching the upstream milpac API. The t.Errorf on any request is
+// the assertion; the server and URL override are torn down via t.Cleanup.
 func tripwireAPIServer(t *testing.T) {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/commands/s3aar_test.go
+++ b/commands/s3aar_test.go
@@ -496,7 +496,8 @@ func TestRunS3aar_EmbedPlaytimeAndCount(t *testing.T) {
 // the specific followup and no embed/file.
 func TestRunS3aar_InvalidStartDate(t *testing.T) {
 	r := &fakeResponder{}
-	// "99XXX25" is the wrong-length-but-also-bad-month case; parseDateTime fails.
+	// "BADDATE" is 7 chars (passes parseDateTime's length check) but "DDA" is not
+	// a valid month abbreviation, so it fails on the month lookup.
 	i := s3aarOptions("Tac1", "BADDATE", "10NOV25", "1800", "2000", 30, "")
 	runS3aar(r, i)
 

--- a/utils/loa.go
+++ b/utils/loa.go
@@ -42,21 +42,32 @@ func (c *LOACache) GetEntry(username string) (LOAEntry, bool) {
 	return e, ok
 }
 
+// hasEnded reports whether the entry's EndDate is strictly before `now`. It is
+// the single source of truth for the upper boundary shared by isActiveAt and
+// isExpiredAt, so the two predicates can't drift: an entry on its EndDate
+// (End==now) has NOT ended (active, not yet prunable); one whose EndDate is
+// already past has ended.
+func (e LOAEntry) hasEnded(now time.Time) bool {
+	return now.After(e.EndDate)
+}
+
 // isActiveAt reports whether the entry's LOA window is active at the instant
 // `now`. The window is inclusive at both bounds: an entry is active from its
 // StartDate through its EndDate (so Start==now and End==now both count as active).
-// Clock-injected so the boundary semantics are unit-testable at the exact edge
-// (cf. PR #135); the production callers pass time.Now().
+// The upper bound is hasEnded (shared with isExpiredAt) — keep them coupled so
+// End==now stays both active here and not-yet-expired there. Clock-injected so
+// the boundary semantics are unit-testable at the exact edge (cf. PR #135); the
+// production callers pass time.Now().
 func (e LOAEntry) isActiveAt(now time.Time) bool {
-	return !now.Before(e.StartDate) && !now.After(e.EndDate)
+	return !now.Before(e.StartDate) && !e.hasEnded(now)
 }
 
 // isExpiredAt reports whether the entry's LOA window has ended strictly before
-// `now` — the prune cutoff. It is the strict complement of the inclusive upper
-// bound in isActiveAt: an entry on its EndDate (End==now) is NOT yet expired and
-// survives a prune cycle; one whose EndDate is already past is pruned.
+// `now` — the prune cutoff. It is the strict complement of isActiveAt's inclusive
+// upper bound (both via hasEnded): an entry on its EndDate (End==now) is NOT yet
+// expired and survives a prune cycle; one whose EndDate is already past is pruned.
 func (e LOAEntry) isExpiredAt(now time.Time) bool {
-	return now.After(e.EndDate)
+	return e.hasEnded(now)
 }
 
 // IsOnLOA returns true if the username has a currently active LOA.


### PR DESCRIPTION
Cleanup from the multi-agent review of the test-coverage swarm (#144 #145 #146, all merged). All findings were minor; this PR clears the actionable ones. **No production behavior change.**

## Changes
- **`utils/loa.go`** — extracted `LOAEntry.hasEnded(now)` as the single source of truth for the `EndDate` upper boundary, now shared by `isActiveAt` and `isExpiredAt`. Previously the strict-complement relationship lived only in comments; a one-sided edit to either bound could silently open a gap (End==now neither active nor pruned). Behavior identical.
- **`commands/s3aar_test.go`** — comment rot: referenced a nonexistent `"99XXX25"` literal and called `"BADDATE"` a wrong-length case (it's 7 chars → passes length, fails on bad month).
- **`commands/awol_test.go`** — `dateAwareLOACache` doc over-claimed clock fidelity; corrected to state it substitutes its own fixed clock for the wall clock prod's `IsOnLOA` reads internally.
- **`commands/gamertag_search_test.go`** — `tripwireAPIServer` doc promised a return value the signature doesn't have.
- **`.github/scripts/check-coverage-floors.sh`** — `commands` floor 82→81 to restore headroom (achieved 82.1%; 0.1pt was one uncovered branch away from breaking unrelated CI).

## Follow-ups filed separately (pre-existing, not this swarm)
Review also surfaced two pre-existing `s3aar.go` items → filed as issues (swallowed `enrichPlayer` error; duplicate rank sort). Not in scope here.

## CI gate
Green incl. `-race`: lint 0, `go mod tidy` clean, utils 87.8% / commands 82.1%, floors pass, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)