### PR TITLE
fix(loa): parse LOA posts regardless of label formatting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ For command registration, interaction routing, and error-handling conventions, s
 
 `utils.GlobalLOACache` is a process-global, mutex-guarded cache of forum LOA posts. `initLOACache()` in `main.go` does an initial refresh on startup, then runs `Refresh` every 15 minutes in a goroutine. Refresh is **incremental** — `lastSyncedPostDate` tracks the high-water mark and subsequent queries only pull newer posts. Entries whose `EndDate` has passed are pruned each refresh.
 
-Parsing depends on a specific Xenforo BBCode template (yellow `[COLOR=rgb(213, 185, 0)]` labels for `Username`, `Start Date`, `End Date`). If the forum template changes, the regexes in `utils/loa.go` will silently stop matching — `parseLOAPost` returns `false` and the post is logged at DEBUG level.
+Parsing keys off the `Username`, `Start Date`, and `End Date` field labels. `parseLOAPost` first strips formatting-only BBCode (`[B]`, `[COLOR=…]`, `[SIZE=…]`, etc.) so label/value matching is agnostic to the post's bold/color/size wrapping — real posts vary widely (plain `[B]Start Date[/B]`, no formatting, non-yellow colors, `[SIZE]`-wrapped dates). Date values accept abbreviated or full month names, with or without the comma (`loaDateLayouts`). Posts that still don't match (free-text dates, `Start:`/`End:` label variants, dates only in the title) return `false` and are logged at DEBUG. If the forum changes the *label wording* itself, matching breaks silently — the regression cases in `loa_test.go` are seeded from real forum bodies to catch drift.
 
 ### External integrations
 

--- a/utils/loa.go
+++ b/utils/loa.go
@@ -8,13 +8,33 @@ import (
 	"time"
 )
 
+// reFormatBBCode matches formatting-only BBCode tags (bold/italic/underline/
+// color/size/font, open or close, with or without an attribute). Forum LOA posts
+// wrap the field labels and values in an inconsistent mix of these — the canonical
+// template uses [B][COLOR=rgb(213, 185, 0)]…[/COLOR][/B], but real posts use plain
+// [B]…[/B], no formatting at all, a different color, or [SIZE]-wrapped values.
+// Stripping these tags before matching makes label/value extraction agnostic to the
+// formatting, which is the whole source of historical silent parse failures
+// (cf. the brittleness note in CLAUDE.md / utils/loa.go header).
+var reFormatBBCode = regexp.MustCompile(`(?i)\[/?(?:b|i|u|s|color|size|font)(?:=[^\]]*)?\]`)
+
 var (
-	reUsername  = regexp.MustCompile(`\[B\]\[COLOR=rgb\(213,\s*185,\s*0\)\]Username\[/COLOR\]\[/B\]\s*:?\s*(\S+)`)
-	reStartDate = regexp.MustCompile(`\[B\]\[COLOR=rgb\(213,\s*185,\s*0\)\]Start Date\[/COLOR\]\[/B\]\s*[\r\n]+([^\r\n]+)`)
-	reEndDate   = regexp.MustCompile(`\[B\]\[COLOR=rgb\(213,\s*185,\s*0\)\]End Date\[/COLOR\]\[/B\]\s*[\r\n]+([^\r\n]+)`)
+	reUsername  = regexp.MustCompile(`(?i)Username\s*:?\s*(\S+)`)
+	reStartDate = regexp.MustCompile(`(?i)Start Date\s*:?\s*[\r\n]+\s*([^\r\n]+)`)
+	reEndDate   = regexp.MustCompile(`(?i)End Date\s*:?\s*[\r\n]+\s*([^\r\n]+)`)
 )
 
-const loaDateLayout = "Jan 2, 2006"
+const loaDateLayout = "Jan 2, 2006" // canonical; also used by tests for fixed-instant boundary cases
+
+// loaDateLayouts are the date formats accepted for the Start/End values, tried in
+// order. The forum has no input mask, so troopers file dates in several shapes:
+// abbreviated or full month name, with or without the comma after the day.
+var loaDateLayouts = []string{
+	loaDateLayout,
+	"January 2, 2006",
+	"Jan 2 2006",
+	"January 2 2006",
+}
 
 type LOAEntry struct {
 	Username  string
@@ -224,6 +244,10 @@ func (c *LOACache) refresh(fetcher loaPostFetcher, nodeIDs []int) {
 }
 
 func parseLOAPost(msg string) (LOAEntry, bool) {
+	// Strip formatting-only BBCode first so label/value matching is agnostic to the
+	// post's bold/color/size wrapping (the source of historical silent failures).
+	msg = reFormatBBCode.ReplaceAllString(msg, "")
+
 	usernameMatch := reUsername.FindStringSubmatch(msg)
 	startMatch := reStartDate.FindStringSubmatch(msg)
 	endMatch := reEndDate.FindStringSubmatch(msg)
@@ -233,12 +257,12 @@ func parseLOAPost(msg string) (LOAEntry, bool) {
 	}
 
 	username := strings.TrimSpace(usernameMatch[1])
-	startDate, err := time.Parse(loaDateLayout, strings.TrimSpace(startMatch[1]))
-	if err != nil {
+	startDate, ok := parseLOADate(startMatch[1])
+	if !ok {
 		return LOAEntry{}, false
 	}
-	endDate, err := time.Parse(loaDateLayout, strings.TrimSpace(endMatch[1]))
-	if err != nil {
+	endDate, ok := parseLOADate(endMatch[1])
+	if !ok {
 		return LOAEntry{}, false
 	}
 
@@ -247,4 +271,17 @@ func parseLOAPost(msg string) (LOAEntry, bool) {
 		StartDate: startDate,
 		EndDate:   endDate,
 	}, true
+}
+
+// parseLOADate parses a Start/End date value against each accepted layout. The raw
+// value is trimmed first; a value that matches no layout (free-text like
+// "probably May 8, 2026") yields ok=false and the whole post is skipped.
+func parseLOADate(raw string) (time.Time, bool) {
+	v := strings.TrimSpace(raw)
+	for _, layout := range loaDateLayouts {
+		if t, err := time.Parse(layout, v); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }

--- a/utils/loa_test.go
+++ b/utils/loa_test.go
@@ -115,8 +115,67 @@ func TestParseLOAPost(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:   "legacy variant: wrong color (non-yellow label) does not match",
-			msg:    "[B][COLOR=rgb(0, 0, 0)]Username[/COLOR][/B]: Black\n[B][COLOR=rgb(0, 0, 0)]Start Date[/COLOR][/B]\nJan 1, 2099\n[B][COLOR=rgb(0, 0, 0)]End Date[/COLOR][/B]\nJan 31, 2099\n",
+			// Behavior change (issue: cross-month/non-canonical LOAs silently dropped):
+			// the yellow-color wrapper is no longer required. A well-formed post in any
+			// (or no) label color now parses — formatting BBCode is stripped before matching.
+			name:      "non-yellow label color still parses (color no longer required)",
+			msg:       "[B][COLOR=rgb(0, 0, 0)]Username[/COLOR][/B]: Black\n[B][COLOR=rgb(0, 0, 0)]Start Date[/COLOR][/B]\nJan 1, 2099\n[B][COLOR=rgb(0, 0, 0)]End Date[/COLOR][/B]\nJan 31, 2099\n",
+			wantOK:    true,
+			wantUser:  "Black",
+			wantStart: "2099-01-01",
+			wantEnd:   "2099-01-31",
+		},
+		{
+			// Real mirror variant (thread 87170): bold labels, NO color wrapper — the
+			// single most common cause of historical silent failures.
+			name:      "bold label without color wrapper parses",
+			msg:       "[B]Username[/B]: Alpine.A\n[B]Start Date[/B]\nDec 6, 2025\n[B]End Date[/B]\nDec 22, 2025\n",
+			wantOK:    true,
+			wantUser:  "Alpine.A",
+			wantStart: "2025-12-06",
+			wantEnd:   "2025-12-22",
+		},
+		{
+			// Real mirror variant (thread 83158): no formatting BBCode at all.
+			name:      "plain labels with no formatting parse",
+			msg:       "Username: Videnovic.Y\nStart Date\nOct 4, 2025\nEnd Date\nOct 17, 2025\n",
+			wantOK:    true,
+			wantUser:  "Videnovic.Y",
+			wantStart: "2025-10-04",
+			wantEnd:   "2025-10-17",
+		},
+		{
+			// Real mirror variant (thread 87307): the date value is wrapped in [SIZE].
+			name:      "size-wrapped date value parses",
+			msg:       "[B]Username[/B]: Lake.W\n[B][SIZE=4]Start Date[/SIZE][/B]\n[SIZE=4]Jan 3, 2026[/SIZE]\n[B][SIZE=4]End Date[/SIZE][/B]\n[SIZE=4]Jan 16, 2026[/SIZE]\n",
+			wantOK:    true,
+			wantUser:  "Lake.W",
+			wantStart: "2026-01-03",
+			wantEnd:   "2026-01-16",
+		},
+		{
+			// Real mirror variant (thread 93288): full month name instead of abbreviation.
+			name:      "full month name parses",
+			msg:       loaPost("Lawrie.A", "April 1, 2026", "April 23, 2026"),
+			wantOK:    true,
+			wantUser:  "Lawrie.A",
+			wantStart: "2026-04-01",
+			wantEnd:   "2026-04-23",
+		},
+		{
+			// Real mirror variant (thread 94302): day with no comma before the year.
+			name:      "date with no comma parses",
+			msg:       loaPost("Siervo.W", "Apr 12 2026", "Apr 19 2026"),
+			wantOK:    true,
+			wantUser:  "Siervo.W",
+			wantStart: "2026-04-12",
+			wantEnd:   "2026-04-19",
+		},
+		{
+			// Free-text date (thread 95564, "probably May 8, 2026") must still be rejected —
+			// leniency covers template variation, not unparseable prose.
+			name:   "free-text uncertain date is still rejected",
+			msg:    loaPost("Robinson.G", "May 3, 2026", "probably May 8, 2026"),
 			wantOK: false,
 		},
 		{


### PR DESCRIPTION
## Problem

LOA posts were only recognised when they used the exact canonical BBCode template — bold **and** the specific yellow `[COLOR=rgb(213, 185, 0)]` wrapper around the `Username`, `Start Date`, and `End Date` labels. Real forum posts vary a lot:

- bold but **no** color wrapper (`[B]Start Date[/B]`)
- no formatting at all
- a different label color
- the date value wrapped in `[SIZE]`
- full month names (`April`) or a missing comma (`Apr 12 2026`)

Any post in one of these variants failed all three label regexes at once, so the trooper was silently treated as *not* on LOA. An audit across the LOA forum sections showed roughly **1.8% of visible posts** were being dropped this way.

The "cross-month" report that surfaced this was a coincidence — cross-month LOAs parse fine in the canonical template; the one that went missing just happened to use a non-canonical one.

## Fix

- `parseLOAPost` now strips formatting-only BBCode (`[B]`, `[COLOR=…]`, `[SIZE=…]`, …) **before** matching, so label/value extraction is agnostic to bold/color/size wrapping.
- Date values are parsed against several layouts: abbreviated or full month name, with or without the comma after the day.
- Genuinely unstructured posts (free-text dates like "probably May 8", dates only in the thread title) are still skipped.

### Behaviour change

The yellow-color requirement is dropped — a well-formed post in **any** label color now parses. The query still only scans the LOA forum sections and still requires all three labelled fields, so false-positive risk stays low.

## Tests

`loa_test.go` gains regression cases seeded from real forum post bodies, one per recovered variant (no-color, no-formatting, `[SIZE]`-wrapped, full month name, no comma), plus a guard that free-text dates are still rejected. The previous "non-yellow color does not parse" case is flipped to assert it now parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)