### PR TITLE
fix(awol): skip unparseable roster records instead of aborting the report

### DIFF
--- a/commands/awol.go
+++ b/commands/awol.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -212,11 +211,11 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 		}
 
 		if daysAWOL > 0 {
-			matches := regexp.MustCompile(`/\d+/(\d+)\.jpg`).FindStringSubmatch(member.UniformUrl)
-			if len(matches) < 2 {
+			milpacID, err := utils.ExtractMilpacIDFromUniformURL(member.UniformUrl)
+			if err != nil {
 				utils.CaptureError(
 					"AWOL member skipped: unparseable uniform URL",
-					fmt.Errorf("uniform URL %q does not match milpac-ID pattern", member.UniformUrl),
+					err,
 					"username", member.User.Username,
 					"discord_id", member.DiscordID,
 					"uniform_url", member.UniformUrl,
@@ -226,7 +225,7 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 			}
 			awolUsers = append(awolUsers, AwolUser{
 				Username:         member.User.Username,
-				MilpacUrl:        fmt.Sprintf("https://7cav.us/rosters/profile/%s", matches[1]),
+				MilpacUrl:        fmt.Sprintf("https://7cav.us/rosters/profile/%s", milpacID),
 				LastPostDate:     lastPostDate,
 				DaysAWOL:         daysAWOL,
 				RawDaysSincePost: rawDays,
@@ -351,8 +350,10 @@ func awolEmbedTitle(position string, idx, total int) string {
 }
 
 // awolSkippedNote renders the visible partial-coverage annotation for the report
-// (issue #163): "⚠️ N record(s) skipped due to errors (reported)", mirroring
-// /afsm's wording. Returns "" when nothing was skipped.
+// (issue #163): "⚠️ N record(s) skipped due to errors (reported)" — same shape
+// and "(reported)" suffix as /afsm's note, but with a "record(s)" noun since
+// /awol skips raw roster records rather than evaluated members. Returns ""
+// when nothing was skipped.
 func awolSkippedNote(skipped int) string {
 	if skipped == 0 {
 		return ""

--- a/commands/awol.go
+++ b/commands/awol.go
@@ -168,15 +168,28 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 		return
 	}
 
+	// Issue #163: a single unparseable record must not abort the whole report.
+	// Both parse failures below are genuine upstream errors (the forum should
+	// always return a parseable date; a roster profile should always carry a
+	// valid uniform URL), so each is captured to Sentry naming the member and
+	// the bad value (ADR 0001), then skipped — mirroring /afsm.
 	awolUsers := []AwolUser{}
+	skippedCount := 0
 	for _, member := range roster.LiteProfiles {
 		if member.User.Username == "Tester.B" || strings.Contains(member.Rank.RankFull, "General") {
 			continue
 		}
 		lastPostDate, err := time.Parse("2006-01-02 15:04:05", member.LastForumPostDate)
 		if err != nil {
-			utils.HandleError(r, i, fmt.Sprintf("❌ Failed to parse last forum post date: %v", err))
-			return
+			utils.CaptureError(
+				"AWOL member skipped: unparseable last forum post date",
+				err,
+				"username", member.User.Username,
+				"discord_id", member.DiscordID,
+				"last_forum_post_date", member.LastForumPostDate,
+			)
+			skippedCount++
+			continue
 		}
 
 		rawDays := utils.DaysSinceLastPost(lastPostDate, now)
@@ -201,8 +214,15 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 		if daysAWOL > 0 {
 			matches := regexp.MustCompile(`/\d+/(\d+)\.jpg`).FindStringSubmatch(member.UniformUrl)
 			if len(matches) < 2 {
-				utils.HandleError(r, i, "❌ Failed to parse uniform URL")
-				return
+				utils.CaptureError(
+					"AWOL member skipped: unparseable uniform URL",
+					fmt.Errorf("uniform URL %q does not match milpac-ID pattern", member.UniformUrl),
+					"username", member.User.Username,
+					"discord_id", member.DiscordID,
+					"uniform_url", member.UniformUrl,
+				)
+				skippedCount++
+				continue
 			}
 			awolUsers = append(awolUsers, AwolUser{
 				Username:         member.User.Username,
@@ -213,6 +233,10 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 				loaWindow:        loaWindow,
 			})
 		}
+	}
+
+	if skippedCount > 0 {
+		utils.Info("⚠️ Members skipped during AWOL check", "position", position, "count", skippedCount)
 	}
 
 	// Sort worst-first by days AWOL; tie-break username ascending so the order is
@@ -226,6 +250,11 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 
 	if len(awolUsers) == 0 {
 		response := fmt.Sprintf("Search completed successfully: no users matching \"%s\" are AWOL.", position)
+		if note := awolSkippedNote(skippedCount); note != "" {
+			// Issue #163: never a silent all-clear when records were skipped — a
+			// skipped member could have been the one who was AWOL.
+			response += "\n" + note
+		}
 		if !cacheHealthy {
 			// Never a silent all-clear while degraded: raw figures are >= the
 			// LOA-adjusted figure so no AWOL member is hidden, but staff must still
@@ -247,10 +276,16 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 	}
 
 	// Discord caps an embed description at 4096 chars. The final description is
-	// summaryLine + "\n\n" + chunk, so the chunk budget must reserve room for that
-	// rendered prefix — otherwise a near-4096 chunk overflows once the summary is
-	// prepended (Discord 400). Reserve the longest prefix any embed could carry.
-	descPrefix := awolSummaryLine(len(awolUsers)) + "\n\n"
+	// the summary block + "\n\n" + chunk, so the chunk budget must reserve room
+	// for that rendered prefix — otherwise a near-4096 chunk overflows once the
+	// summary is prepended (Discord 400). Reserve the longest prefix any embed
+	// could carry. The block includes the skipped-records note when present
+	// (issue #163) so staff see the report is partial.
+	summaryBlock := awolSummaryLine(len(awolUsers))
+	if note := awolSkippedNote(skippedCount); note != "" {
+		summaryBlock += "\n" + note
+	}
+	descPrefix := summaryBlock + "\n\n"
 	chunkBudget := discordEmbedDescriptionLimit - len(descPrefix)
 
 	var chunks []string
@@ -270,12 +305,12 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 	utils.Info("Debug chunks info", "chunks_length", len(chunks), "max_embeds", maxEmbedsPerMsg)
 	if len(chunks) > maxEmbedsPerMsg {
 		utils.Info("⚠️ Too many AWOL users for embeds, falling back to file upload", "count", len(awolUsers))
-		sendAwolFile(r, i, awolUsers, position, forceFile, cacheHealthy, now)
+		sendAwolFile(r, i, awolUsers, position, forceFile, cacheHealthy, now, skippedCount)
 		utils.Info("✨ Done!", "command", "Awol")
 		return
 	} else if forceFile {
 		utils.Info("⚠️ Force file output enabled, falling back to embeds", "count", len(awolUsers))
-		sendAwolFile(r, i, awolUsers, position, forceFile, cacheHealthy, now)
+		sendAwolFile(r, i, awolUsers, position, forceFile, cacheHealthy, now, skippedCount)
 		utils.Info("✨ Done!", "command", "Awol")
 		return
 	}
@@ -285,7 +320,7 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 		title := awolEmbedTitle(position, idx, len(chunks))
 		embed := &discordgo.MessageEmbed{
 			Title:       title,
-			Description: awolSummaryLine(len(awolUsers)) + "\n\n" + chunk,
+			Description: summaryBlock + "\n\n" + chunk,
 			Color:       0xfbcc29,
 			Footer: &discordgo.MessageEmbedFooter{
 				Text: footerText,
@@ -313,6 +348,20 @@ func awolEmbedTitle(position string, idx, total int) string {
 		return fmt.Sprintf("AWOL — %s", position)
 	}
 	return fmt.Sprintf("AWOL — %s (Page %d/%d)", position, idx+1, total)
+}
+
+// awolSkippedNote renders the visible partial-coverage annotation for the report
+// (issue #163): "⚠️ N record(s) skipped due to errors (reported)", mirroring
+// /afsm's wording. Returns "" when nothing was skipped.
+func awolSkippedNote(skipped int) string {
+	if skipped == 0 {
+		return ""
+	}
+	noun := "records"
+	if skipped == 1 {
+		noun = "record"
+	}
+	return fmt.Sprintf("⚠️ %d %s skipped due to errors (reported)", skipped, noun)
 }
 
 // awolSummaryLine renders "N flagged" — the count of AWOL-flagged members. The
@@ -346,12 +395,16 @@ func awolUserLine(u AwolUser) string {
 	)
 }
 
-func sendAwolFile(r utils.InteractionResponder, i *discordgo.InteractionCreate, awolUsers []AwolUser, position string, forceFile, cacheHealthy bool, now time.Time) {
+func sendAwolFile(r utils.InteractionResponder, i *discordgo.InteractionCreate, awolUsers []AwolUser, position string, forceFile, cacheHealthy bool, now time.Time, skippedCount int) {
 	var content strings.Builder
 	_, _ = fmt.Fprintf(&content, "AWOL Report for %s\nGenerated: %s\n%s\n\n",
 		position,
 		now.Format("2006-01-02 15:04:05"),
 		awolSummaryLine(len(awolUsers)))
+	if note := awolSkippedNote(skippedCount); note != "" {
+		// Issue #163: the file report must surface partial coverage too.
+		_, _ = fmt.Fprintf(&content, "%s\n\n", note)
+	}
 	if !cacheHealthy {
 		// ADR 0008: surface the degraded warning in the file too — same figures
 		// (raw) and the same "adjustment skipped" wording as the embed.

--- a/commands/awol_test.go
+++ b/commands/awol_test.go
@@ -818,3 +818,182 @@ func TestRunAwol_MultipleWindowsMergedNoDoubleCount(t *testing.T) {
 		t.Fatalf("overlapping windows must merge (7d AWOL, raw 30d).\nGot line: %q", line)
 	}
 }
+
+// TestRunAwol_MalformedDateSkipsMemberNotReport pins issue #163: one member with
+// an unparseable LastForumPostDate is skipped (and reported), the rest of the
+// roster still renders, and the report carries a visible skipped-count note.
+func TestRunAwol_MalformedDateSkipsMemberNotReport(t *testing.T) {
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+			"200": awolMember("Broken.B", "200", "not-a-date"),
+			"300": awolMember("Trooper.C", "300", "2026-04-01 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+	runAwol(f, healthyCache(nil), awolRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (placeholder + Edit), got %d: %+v", len(calls), calls)
+	}
+	edit := calls[1].Edit
+	if edit.Embeds == nil || len(*edit.Embeds) == 0 {
+		t.Fatalf("report must still render as embeds; got Embeds=%v Content=%v", edit.Embeds, edit.Content)
+	}
+	desc := (*edit.Embeds)[0].Description
+	for _, want := range []string{"Trooper.A", "Trooper.C"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("remaining member %q must still render.\nGot:\n%s", want, desc)
+		}
+	}
+	if strings.Contains(desc, "Broken.B") {
+		t.Fatalf("skipped member must not render.\nGot:\n%s", desc)
+	}
+	if !strings.Contains(desc, "⚠️ 1 record skipped due to errors (reported)") {
+		t.Fatalf("report must carry the skipped-count note.\nGot:\n%s", desc)
+	}
+}
+
+// TestRunAwol_MalformedUniformURLSkipsMemberNotReport pins the second issue #163
+// call site: an AWOL member whose uniform URL doesn't match the milpac-ID pattern
+// is skipped (and reported); the rest still render with the skipped note.
+func TestRunAwol_MalformedUniformURLSkipsMemberNotReport(t *testing.T) {
+	badUniform := awolMember("Badjpg.B", "999", "2026-03-01 12:00:00")
+	badUniform.UniformUrl = "https://7cav.us/data/roster_uniforms/no-milpac-id-here.png"
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+			"200": badUniform,
+			"300": awolMember("Trooper.C", "300", "2026-04-01 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+	runAwol(f, healthyCache(nil), awolRefDate, i)
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (placeholder + Edit), got %d: %+v", len(calls), calls)
+	}
+	edit := calls[1].Edit
+	if edit.Embeds == nil || len(*edit.Embeds) == 0 {
+		t.Fatalf("report must still render as embeds; got Embeds=%v Content=%v", edit.Embeds, edit.Content)
+	}
+	desc := (*edit.Embeds)[0].Description
+	for _, want := range []string{"Trooper.A", "Trooper.C"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("remaining member %q must still render.\nGot:\n%s", want, desc)
+		}
+	}
+	if strings.Contains(desc, "Badjpg.B") {
+		t.Fatalf("skipped member must not render.\nGot:\n%s", desc)
+	}
+	if !strings.Contains(desc, "⚠️ 1 record skipped due to errors (reported)") {
+		t.Fatalf("report must carry the skipped-count note.\nGot:\n%s", desc)
+	}
+}
+
+// TestRunAwol_BothMalformedRecordsSkippedTogether pins the issue #163 acceptance
+// scenario verbatim: one malformed date record AND one malformed uniform URL in
+// the same roster — both skipped, the rest render, plural note shows the count.
+func TestRunAwol_BothMalformedRecordsSkippedTogether(t *testing.T) {
+	badUniform := awolMember("Badjpg.B", "999", "2026-03-01 12:00:00")
+	badUniform.UniformUrl = "https://7cav.us/data/roster_uniforms/no-milpac-id-here.png"
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+			"200": awolMember("Baddate.D", "200", "not-a-date"),
+			"300": badUniform,
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+	runAwol(f, healthyCache(nil), awolRefDate, i)
+
+	desc := (*f.Calls()[1].Edit.Embeds)[0].Description
+	if !strings.Contains(desc, "Trooper.A") {
+		t.Fatalf("remaining member must still render.\nGot:\n%s", desc)
+	}
+	for _, skipped := range []string{"Baddate.D", "Badjpg.B"} {
+		if strings.Contains(desc, skipped) {
+			t.Fatalf("skipped member %q must not render.\nGot:\n%s", skipped, desc)
+		}
+	}
+	if !strings.Contains(desc, "⚠️ 2 records skipped due to errors (reported)") {
+		t.Fatalf("report must carry the plural skipped-count note.\nGot:\n%s", desc)
+	}
+}
+
+// TestRunAwol_FileOutputCarriesSkippedNote pins that the file rendering path
+// (force_file_output) surfaces the same skipped-records note as the embed path —
+// the omission must not become silent just because the report went to a file.
+func TestRunAwol_FileOutputCarriesSkippedNote(t *testing.T) {
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+			"200": awolMember("Baddate.D", "200", "not-a-date"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(
+		stringOption("position", "1-7"),
+		boolOption("force_file_output", true),
+	)
+	runAwol(f, healthyCache(nil), awolRefDate, i)
+
+	edit := f.Calls()[1].Edit
+	if len(edit.Files) != 1 {
+		t.Fatalf("expected 1 file attachment, got %d", len(edit.Files))
+	}
+	raw, _ := io.ReadAll(edit.Files[0].Reader)
+	body := string(raw)
+	if !strings.Contains(body, "Trooper.A") {
+		t.Fatalf("remaining member must still render in file.\nGot:\n%s", body)
+	}
+	if strings.Contains(body, "Baddate.D") {
+		t.Fatalf("skipped member must not render in file.\nGot:\n%s", body)
+	}
+	if !strings.Contains(body, "⚠️ 1 record skipped due to errors (reported)") {
+		t.Fatalf("file report must carry the skipped-count note.\nGot:\n%s", body)
+	}
+}
+
+// TestRunAwol_SkippedNoteOnNoAwolPath pins that a "no users AWOL" outcome is not
+// a silent all-clear when records were skipped: the only flaggable member failed
+// to parse, so the response must carry the skipped-count note.
+func TestRunAwol_SkippedNoteOnNoAwolPath(t *testing.T) {
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			// Recent post → not AWOL.
+			"100": awolMember("Active.A", "100", "2026-05-14 12:00:00"),
+			// Unparseable date → skipped.
+			"200": awolMember("Baddate.D", "200", "not-a-date"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("position", "1-7"))
+	runAwol(f, healthyCache(nil), awolRefDate, i)
+
+	edit := f.Calls()[1].Edit
+	if edit.Content == nil {
+		t.Fatalf("expected text response on no-AWOL path")
+	}
+	if !strings.Contains(*edit.Content, "no users matching") {
+		t.Fatalf("expected no-AWOL message, got %q", *edit.Content)
+	}
+	if !strings.Contains(*edit.Content, "⚠️ 1 record skipped due to errors (reported)") {
+		t.Fatalf("no-AWOL response must carry the skipped-count note, got %q", *edit.Content)
+	}
+}


### PR DESCRIPTION
Closes #163.

/awol used to abort the whole roster report when a single member record failed to parse. Two call sites in the per-member loop called `HandleError` and returned: an unparseable last forum post date, and a uniform URL that didn't match the milpac-ID pattern. One bad record killed the report for everyone, and the error named neither the member nor the bad value.

Both sites now skip the record and continue, following the /afsm pattern:

- Each skipped record goes to Sentry via `utils.CaptureError` with the member's username, discord id, and the offending value. These are genuine upstream data errors, so per ADR 0001 they belong on the capture path, not the user-facing one. The issue draft suggested WARN logging; the agent brief and the /afsm precedent settled on `CaptureError`, which logs at ERROR and reports to Sentry.
- When anything was skipped, the report shows `⚠️ N record(s) skipped due to errors (reported)` on every render path: embed summary, file output, and the no-AWOL all-clear text, so a skipped record can't produce a silent clean report. An INFO summary line logs the count.
- The uniform-URL path now uses the shared `utils.ExtractMilpacIDFromUniformURL` helper instead of a duplicated inline regex.

Five new tests drive `runAwol` with injected rosters: malformed date, malformed uniform URL, both at once, the file-output note, and the no-AWOL-path note. Coverage floors hold (commands 83.8%, utils 90.6%).

Manual gate: this changes user-facing /awol output, so it needs a smoke test on the test guild before merge.

This was generated by AI