### PR TITLE
fix(warden): reject over-length member-search queries before the API call

### DIFF
--- a/commands/warden.go
+++ b/commands/warden.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -623,6 +624,14 @@ func findGuildMember(gm GuildManager, guildID, query string) (*discordgo.Member,
 	trimmedQuery := strings.TrimSpace(query)
 	if trimmedQuery == "" {
 		return nil, fmt.Errorf("❌ Empty query")
+	}
+
+	// Discord's member-search query is limited to 1-100 characters; reject an
+	// over-length name here so it never reaches GuildMembersSearch (which 400s
+	// and gets captured to Sentry). Mentions/IDs below short-circuit before this
+	// matters in practice, but the guard covers the name-search fall-through.
+	if utf8.RuneCountInString(trimmedQuery) > 100 {
+		return nil, fmt.Errorf("❌ Query too long (max 100 characters); use a mention/ID instead")
 	}
 
 	// Mentions: <@123>, <@!123>

--- a/commands/warden.go
+++ b/commands/warden.go
@@ -626,10 +626,11 @@ func findGuildMember(gm GuildManager, guildID, query string) (*discordgo.Member,
 		return nil, fmt.Errorf("❌ Empty query")
 	}
 
-	// Discord's member-search query is limited to 1-100 characters; reject an
-	// over-length name here so it never reaches GuildMembersSearch (which 400s
-	// and gets captured to Sentry). Mentions/IDs below short-circuit before this
-	// matters in practice, but the guard covers the name-search fall-through.
+	// Discord's member-search query must be 1-100 characters. Reject an
+	// over-length input here, before it reaches GuildMembersSearch and 400s
+	// (which gets captured to Sentry as an error). This runs ahead of the
+	// mention/ID branches below, but real mentions and snowflakes are well
+	// under 100 chars, so in practice only a long name search trips it.
 	if utf8.RuneCountInString(trimmedQuery) > 100 {
 		return nil, fmt.Errorf("❌ Query too long (max 100 characters); use a mention/ID instead")
 	}

--- a/commands/warden_test.go
+++ b/commands/warden_test.go
@@ -464,3 +464,22 @@ func TestRunWarden_MissingDiscordnameForAdd(t *testing.T) {
 		t.Fatal("expected an error response for missing discordname")
 	}
 }
+
+// CAVBOT2-6: a name search longer than Discord's 100-char query limit must be
+// rejected locally, not forwarded to GuildMembersSearch (which 400s with
+// "Invalid Form Body" and gets captured to Sentry as an error).
+func TestFindGuildMember_OverLengthQueryRejectedBeforeSearch(t *testing.T) {
+	gm := &fakeGuildManager{
+		// Mimic Discord rejecting an over-length query with a 400.
+		MembersSearchErrs: []error{fmt.Errorf(`HTTP 400 Bad Request, {"message": "Invalid Form Body", "code": 50035}`)},
+	}
+	longQuery := strings.Repeat("a", 101)
+
+	_, err := findGuildMember(gm, "guild-1", longQuery)
+	if err == nil {
+		t.Fatal("expected an error for an over-length query")
+	}
+	if gm.countCalls("GuildMembersSearch") != 0 {
+		t.Fatalf("over-length query must be rejected before hitting Discord; got calls %v", gm.Calls())
+	}
+}

--- a/commands/warden_test.go
+++ b/commands/warden_test.go
@@ -469,17 +469,57 @@ func TestRunWarden_MissingDiscordnameForAdd(t *testing.T) {
 // rejected locally, not forwarded to GuildMembersSearch (which 400s with
 // "Invalid Form Body" and gets captured to Sentry as an error).
 func TestFindGuildMember_OverLengthQueryRejectedBeforeSearch(t *testing.T) {
-	gm := &fakeGuildManager{
-		// Mimic Discord rejecting an over-length query with a 400.
-		MembersSearchErrs: []error{fmt.Errorf(`HTTP 400 Bad Request, {"message": "Invalid Form Body", "code": 50035}`)},
-	}
+	gm := &fakeGuildManager{}
 	longQuery := strings.Repeat("a", 101)
 
 	_, err := findGuildMember(gm, "guild-1", longQuery)
 	if err == nil {
 		t.Fatal("expected an error for an over-length query")
 	}
+	if !strings.Contains(err.Error(), "too long") {
+		t.Fatalf("expected an over-length rejection message, got %q", err.Error())
+	}
 	if gm.countCalls("GuildMembersSearch") != 0 {
 		t.Fatalf("over-length query must be rejected before hitting Discord; got calls %v", gm.Calls())
+	}
+}
+
+// A query at exactly Discord's 100-char limit is valid and must still reach the
+// name search. Pins the boundary so a future >=100 off-by-one is caught.
+func TestFindGuildMember_MaxLengthQueryStillSearches(t *testing.T) {
+	gm := &fakeGuildManager{}
+	maxQuery := strings.Repeat("a", 100)
+
+	_, _ = findGuildMember(gm, "guild-1", maxQuery)
+
+	if gm.countCalls("GuildMembersSearch") != 1 {
+		t.Fatalf("a 100-char query is valid and must reach search; got calls %v", gm.Calls())
+	}
+}
+
+// A multibyte name under 100 runes can exceed 100 bytes. The guard counts runes,
+// so it must reach search. This is the case that justifies utf8.RuneCountInString
+// over len() and would fail if the guard regressed to byte counting.
+func TestFindGuildMember_MultibyteNameUnderLimitStillSearches(t *testing.T) {
+	gm := &fakeGuildManager{}
+	multibyte := strings.Repeat("世", 80) // 80 runes, 240 bytes
+
+	_, _ = findGuildMember(gm, "guild-1", multibyte)
+
+	if gm.countCalls("GuildMembersSearch") != 1 {
+		t.Fatalf("a sub-limit multibyte name must reach search; got calls %v", gm.Calls())
+	}
+}
+
+// The length check runs on the trimmed query, so whitespace padding around a
+// 100-char core must not push it over the limit.
+func TestFindGuildMember_WhitespacePaddedMaxLengthStillSearches(t *testing.T) {
+	gm := &fakeGuildManager{}
+	padded := "  " + strings.Repeat("a", 100) + "  "
+
+	_, _ = findGuildMember(gm, "guild-1", padded)
+
+	if gm.countCalls("GuildMembersSearch") != 1 {
+		t.Fatalf("trimmed 100-char query must reach search; got calls %v", gm.Calls())
 	}
 }


### PR DESCRIPTION
## What

`/warden add` (and `remove`) with a search name longer than 100 characters crashed into a Discord 400 and reported it to Sentry as an error (CAVBOT2-6). Discord caps the member-search `query` param at 1-100 characters; `findGuildMember` only guarded the empty case, so an over-length name fell through to `GuildMembersSearch`.

## Fix

A rune-count length guard alongside the existing empty-query check. The user now gets a short, actionable message and the call never reaches Discord, so it no longer pages Sentry.

## Confirming the bug

Diagnosed against production logs and the Sentry stacktrace. It was a single `/warden add` from one user who pasted an over-length name; they eventually got it working by switching to raw user IDs. Added a regression test at the `findGuildMember` seam that fails without the guard and passes with it.

## Checks

- `golangci-lint run`: clean
- `go test ./...`: green
- `go build`: ok

Smoke test on the test guild still pending (user-facing copy change).

Fixes CAVBOT2-6

> *This was generated by AI*