### PR TITLE
fix(warden): classify Discord REST errors to stop leaking raw bodies and false Sentry pages

### DIFF
--- a/commands/warden.go
+++ b/commands/warden.go
@@ -158,15 +158,12 @@ func handleWardenAdd(r utils.InteractionResponder, gm GuildManager, interaction 
 	for index, roleID := range roleIDs {
 		roleName := roleNames[index]
 		if err := gm.GuildMemberRoleAdd(guildID, member.User.ID, roleID); err != nil {
-			utils.CaptureError("Failed to add warden role", err, "user", member.User.ID, "role", roleName)
 			editEphemeral(
 				r,
 				interaction,
-				fmt.Sprintf(
-					"❌ Failed to add '%s' role to %s: %v",
-					roleName,
-					formatUser(member),
-					err,
+				roleMutationErrorReply(
+					"add", roleName, formatUser(member), err,
+					"Failed to add warden role", "user", member.User.ID, "role", roleName,
 				),
 			)
 			return
@@ -213,8 +210,10 @@ func handleWardenRemove(
 	for index, roleID := range roleIDs {
 		roleName := roleNames[index]
 		if err := gm.GuildMemberRoleRemove(guildID, member.User.ID, roleID); err != nil {
-			utils.CaptureError("Failed to remove warden role", err, "user", member.User.ID, "role", roleName)
-			editEphemeral(r, interaction, fmt.Sprintf("❌ Failed to remove '%s' role from %s: %v", roleName, formatUser(member), err))
+			editEphemeral(r, interaction, roleMutationErrorReply(
+				"remove", roleName, formatUser(member), err,
+				"Failed to remove warden role", "user", member.User.ID, "role", roleName,
+			))
 			return
 		}
 	}
@@ -261,8 +260,10 @@ func handleWardenBulkAdd(
 		for index, roleID := range roleIDs {
 			roleName := roleNames[index]
 			if err := gm.GuildMemberRoleAdd(guildID, member.User.ID, roleID); err != nil {
-				utils.CaptureError("Failed to add warden role in bulk", err, "user", member.User.ID, "role", roleName)
-				failures = append(failures, fmt.Sprintf("❌ Failed to add '%s' role to %s: %v", roleName, formatUser(member), err))
+				failures = append(failures, roleMutationErrorReply(
+					"add", roleName, formatUser(member), err,
+					"Failed to add warden role in bulk", "user", member.User.ID, "role", roleName,
+				))
 				allOK = false
 			}
 		}
@@ -658,8 +659,7 @@ func findGuildMember(gm GuildManager, guildID, query string) (*discordgo.Member,
 	// Name search
 	members, err := gm.GuildMembersSearch(guildID, trimmedQuery, 10)
 	if err != nil {
-		utils.CaptureError("Failed to search members", err)
-		return nil, fmt.Errorf("❌ Failed to search members: %v", err)
+		return nil, searchErrorReply(err)
 	}
 
 	switch len(members) {

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+// captureError is the Sentry-capture seam used by /warden's error-handling
+// paths. It points at utils.CaptureError in production; tests swap it to assert
+// that only genuine system faults (5xx/transport) page Sentry, per ADR 0001.
+var captureError = utils.CaptureError
+
+// discordErrorClass is the result of classifying an error returned by a Discord
+// REST call. It separates operator/config-fixable client faults (4xx) from
+// genuine system faults (5xx and transport errors), and never carries the raw
+// Discord response body — discordgo's RESTError.Error() returns
+// "HTTP <status>, <full JSON body>", which we must keep out of user-facing
+// replies (ADR 0001: CaptureError is for genuine internal failures only).
+type discordErrorClass struct {
+	// SystemFault is true for 5xx responses and transport errors. Only these
+	// should be sent to Sentry via utils.CaptureError; 4xx client/config faults
+	// must not page on-call for an ordinary, fixable condition.
+	SystemFault bool
+	// MissingPermissions is true for a 403 Forbidden, the common case where the
+	// bot lacks Manage Roles or the target role sits above the bot's own role.
+	// Callers use it to render a specific, actionable hierarchy hint.
+	MissingPermissions bool
+	// UserDetail is a short, body-free phrase safe to show an operator. It never
+	// contains the raw Discord error body.
+	UserDetail string
+}
+
+// classifyDiscordError inspects err for a *discordgo.RESTError and branches on
+// its HTTP status class. Anything without a RESTError (transport/connection
+// errors, context cancellation) is treated as a system fault. The returned
+// UserDetail is always a fixed, sanitized phrase — the raw response body is
+// deliberately discarded so it can never reach a user-facing reply.
+func classifyDiscordError(err error) discordErrorClass {
+	var restErr *discordgo.RESTError
+	if !errors.As(err, &restErr) || restErr.Response == nil {
+		// No structured HTTP response: transport/connection failure or an
+		// unexpected error shape. Treat as a system fault and capture.
+		return discordErrorClass{
+			SystemFault: true,
+			UserDetail:  "could not reach Discord",
+		}
+	}
+
+	status := restErr.Response.StatusCode
+
+	switch {
+	case status == http.StatusForbidden:
+		return discordErrorClass{
+			MissingPermissions: true,
+			UserDetail:         "missing permissions",
+		}
+	case status >= 400 && status < 500:
+		return discordErrorClass{
+			UserDetail: "Discord rejected the request",
+		}
+	default:
+		// 5xx (and any unexpected >=500) is a Discord-side system fault.
+		return discordErrorClass{
+			SystemFault: true,
+			UserDetail:  "Discord returned a server error",
+		}
+	}
+}
+
+// searchErrorReply classifies a GuildMembersSearch failure, captures it to
+// Sentry only when it is a genuine system fault, and returns a body-free,
+// operator-facing error. The raw Discord response body is never interpolated.
+func searchErrorReply(err error) error {
+	class := classifyDiscordError(err)
+	if class.SystemFault {
+		captureError("Failed to search members", err)
+		return errors.New("❌ Member search is temporarily unavailable (Discord error); please try again shortly")
+	}
+	return fmt.Errorf("❌ Member search failed (%s); check the query or try a mention/ID instead", class.UserDetail)
+}
+
+// roleMutationErrorReply classifies a role add/remove failure, captures it to
+// Sentry only for genuine system faults, and returns a body-free, actionable
+// message. A 403 yields a specific role-hierarchy hint — the common cause is the
+// target role sitting above the bot's own role, or the bot missing Manage Roles.
+// captureMsg/kv are forwarded to captureError so each site keeps its own log
+// context (action, user, role).
+func roleMutationErrorReply(action, roleName, userLabel string, err error, captureMsg string, kv ...any) string {
+	class := classifyDiscordError(err)
+
+	switch {
+	case class.SystemFault:
+		captureError(captureMsg, err, kv...)
+		return fmt.Sprintf("❌ Could not %s '%s' for %s: Discord error, please try again shortly.", action, roleName, userLabel)
+	case class.MissingPermissions:
+		return fmt.Sprintf(
+			"❌ Could not %s '%s' for %s: missing permissions — the bot needs Manage Roles and its own role must be positioned above '%s'.",
+			action, roleName, userLabel, roleName,
+		)
+	default:
+		return fmt.Sprintf("❌ Could not %s '%s' for %s: Discord rejected the request.", action, roleName, userLabel)
+	}
+}

--- a/commands/warden_resterror_test.go
+++ b/commands/warden_resterror_test.go
@@ -1,0 +1,337 @@
+package commands
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// restError builds a *discordgo.RESTError carrying the given HTTP status and a
+// raw JSON body, mirroring how discordgo wraps a failed API call. The body is
+// the exact string that RESTError.Error() leaks ("HTTP <status>, <body>") — our
+// classifier must never surface it in a user-facing reply.
+func restError(statusCode int, code int, apiMessage string) *discordgo.RESTError {
+	body := fmt.Sprintf(`{"message": %q, "code": %d}`, apiMessage, code)
+	return &discordgo.RESTError{
+		Response:     &http.Response{StatusCode: statusCode, Status: fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode))},
+		ResponseBody: []byte(body),
+		Message:      &discordgo.APIErrorMessage{Code: code, Message: apiMessage},
+	}
+}
+
+// rawBody is the literal leak the classifier must keep out of user-facing text:
+// a substring guaranteed to appear only if RESTError.Error() was interpolated.
+const rawBodyMarker = "secret-internal-detail"
+
+// --- classifier unit tests ---
+
+func TestClassifyDiscordError_4xxIsClientFault(t *testing.T) {
+	err := restError(http.StatusBadRequest, 50035, rawBodyMarker)
+	c := classifyDiscordError(err)
+	if c.SystemFault {
+		t.Fatalf("a 400 must be classified as a client/config fault, not a system fault")
+	}
+	if strings.Contains(c.UserDetail, rawBodyMarker) {
+		t.Fatalf("classifier leaked the raw Discord body: %q", c.UserDetail)
+	}
+}
+
+func TestClassifyDiscordError_5xxIsSystemFault(t *testing.T) {
+	err := restError(http.StatusInternalServerError, 0, rawBodyMarker)
+	c := classifyDiscordError(err)
+	if !c.SystemFault {
+		t.Fatalf("a 500 must be classified as a system fault")
+	}
+	if strings.Contains(c.UserDetail, rawBodyMarker) {
+		t.Fatalf("classifier leaked the raw Discord body: %q", c.UserDetail)
+	}
+}
+
+func TestClassifyDiscordError_TransportErrorIsSystemFault(t *testing.T) {
+	// A non-REST transport error (no HTTP response) is a system fault.
+	err := fmt.Errorf("dial tcp: connection refused")
+	c := classifyDiscordError(err)
+	if !c.SystemFault {
+		t.Fatalf("a transport error must be classified as a system fault")
+	}
+}
+
+func TestClassifyDiscordError_403RoleHierarchyMessage(t *testing.T) {
+	err := restError(http.StatusForbidden, 50013, rawBodyMarker)
+	c := classifyDiscordError(err)
+	if c.SystemFault {
+		t.Fatalf("a 403 must not be a system fault")
+	}
+	if !c.MissingPermissions {
+		t.Fatalf("a 403 must set MissingPermissions so callers can show the hierarchy hint")
+	}
+}
+
+// A *discordgo.RESTError can carry a nil Response (e.g. an error built before
+// any HTTP exchange completes). With no status code to read, the classifier
+// can't prove it's a client fault, so it must take the system-fault guard
+// rather than dereference the nil Response.
+func TestClassifyDiscordError_RESTErrorNilResponseIsSystemFault(t *testing.T) {
+	err := &discordgo.RESTError{Response: nil}
+	c := classifyDiscordError(err)
+	if !c.SystemFault {
+		t.Fatalf("a RESTError with a nil Response must be classified as a system fault")
+	}
+}
+
+// captureRecorder swaps the package-level captureError seam for the duration of
+// a test and counts how many times it fires, so a test can assert the
+// 4xx-vs-5xx Sentry split without a live Sentry client.
+type captureRecorder struct {
+	count int
+}
+
+func (c *captureRecorder) install(t *testing.T) {
+	t.Helper()
+	prev := captureError
+	captureError = func(msg string, err error, kv ...any) { c.count++ }
+	t.Cleanup(func() { captureError = prev })
+}
+
+// --- search path: 4xx vs 5xx split ---
+
+func TestFindGuildMember_Search4xxDoesNotCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{MembersSearchErrs: []error{restError(http.StatusBadRequest, 50035, rawBodyMarker)}}
+
+	_, err := findGuildMember(gm, "guild-1", "somename")
+	if err == nil {
+		t.Fatal("expected an error from a 400 search")
+	}
+	if rec.count != 0 {
+		t.Fatalf("a 4xx search must NOT capture to Sentry; got %d captures", rec.count)
+	}
+	if strings.Contains(err.Error(), rawBodyMarker) {
+		t.Fatalf("search reply leaked the raw Discord body: %q", err.Error())
+	}
+}
+
+func TestFindGuildMember_Search5xxCaptures(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{MembersSearchErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)}}
+
+	_, err := findGuildMember(gm, "guild-1", "somename")
+	if err == nil {
+		t.Fatal("expected an error from a 500 search")
+	}
+	if rec.count != 1 {
+		t.Fatalf("a 5xx search must capture to Sentry exactly once; got %d", rec.count)
+	}
+	if strings.Contains(err.Error(), rawBodyMarker) {
+		t.Fatalf("search reply leaked the raw Discord body: %q", err.Error())
+	}
+}
+
+func TestFindGuildMember_SearchTransportErrorCaptures(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{MembersSearchErrs: []error{fmt.Errorf("dial tcp: connection refused")}}
+
+	_, err := findGuildMember(gm, "guild-1", "somename")
+	if err == nil {
+		t.Fatal("expected an error from a transport failure")
+	}
+	if rec.count != 1 {
+		t.Fatalf("a transport error must capture to Sentry exactly once; got %d", rec.count)
+	}
+}
+
+// --- role add/remove paths: 4xx vs 5xx split + 403 hierarchy hint ---
+
+func wardenAddInteraction() *discordgo.InteractionCreate {
+	return wardenInteraction("guild-1",
+		stringOption("command", "add"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "123456789012345678"),
+	)
+}
+
+func wardenRemoveInteraction() *discordgo.InteractionCreate {
+	return wardenInteraction("guild-1",
+		stringOption("command", "remove"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "123456789012345678"),
+	)
+}
+
+func wardenRoleAddGM(addErr error) *fakeGuildManager {
+	return &fakeGuildManager{
+		roles:             []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		membersByID:       map[string]*discordgo.Member{"123456789012345678": {User: &discordgo.User{ID: "123456789012345678", Username: "trooper"}}},
+		MemberRoleAddErrs: []error{addErr},
+	}
+}
+
+func TestRunWardenAdd_RoleAdd403ShowsHierarchyHintNoCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := wardenRoleAddGM(restError(http.StatusForbidden, 50013, rawBodyMarker))
+	f := &fakeResponder{}
+
+	runWarden(f, gm, wardenAddInteraction())
+
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("role-add 403 leaked the raw Discord body: %q", got)
+	}
+	if !strings.Contains(strings.ToLower(got), "above") || !strings.Contains(strings.ToLower(got), "role") {
+		t.Fatalf("expected a role-hierarchy hint mentioning the role is above the bot's, got %q", got)
+	}
+	if rec.count != 0 {
+		t.Fatalf("a 403 role add must NOT capture to Sentry; got %d", rec.count)
+	}
+}
+
+func TestRunWardenAdd_RoleAdd5xxCapturesGenericRetry(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := wardenRoleAddGM(restError(http.StatusInternalServerError, 0, rawBodyMarker))
+	f := &fakeResponder{}
+
+	runWarden(f, gm, wardenAddInteraction())
+
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("role-add 5xx leaked the raw Discord body: %q", got)
+	}
+	if rec.count != 1 {
+		t.Fatalf("a 5xx role add must capture to Sentry once; got %d", rec.count)
+	}
+}
+
+// A non-403 4xx (here a 404) is still an operator/config-fixable client fault:
+// it must show the generic "Discord rejected the request" wording, never the
+// raw body, and never capture to Sentry. Covers the default arm of
+// roleMutationErrorReply, which no other mutation-site test exercises.
+func TestRunWardenAdd_RoleAddGeneric4xxNoCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := wardenRoleAddGM(restError(http.StatusNotFound, 10011, rawBodyMarker))
+	f := &fakeResponder{}
+
+	runWarden(f, gm, wardenAddInteraction())
+
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("role-add generic 4xx leaked the raw Discord body: %q", got)
+	}
+	if !strings.Contains(got, "Discord rejected the request") {
+		t.Fatalf("expected the generic 4xx rejection wording, got %q", got)
+	}
+	if rec.count != 0 {
+		t.Fatalf("a generic 4xx role add must NOT capture to Sentry; got %d", rec.count)
+	}
+}
+
+func TestRunWardenRemove_RoleRemove403ShowsHierarchyHintNoCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{
+		roles:                []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		membersByID:          map[string]*discordgo.Member{"123456789012345678": {User: &discordgo.User{ID: "123456789012345678", Username: "trooper"}}},
+		MemberRoleRemoveErrs: []error{restError(http.StatusForbidden, 50013, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, wardenRemoveInteraction())
+
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("role-remove 403 leaked the raw Discord body: %q", got)
+	}
+	if !strings.Contains(strings.ToLower(got), "above") {
+		t.Fatalf("expected a role-hierarchy hint, got %q", got)
+	}
+	if rec.count != 0 {
+		t.Fatalf("a 403 role remove must NOT capture to Sentry; got %d", rec.count)
+	}
+}
+
+func TestRunWardenRemove_RoleRemove5xxCaptures(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{
+		roles:                []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		membersByID:          map[string]*discordgo.Member{"123456789012345678": {User: &discordgo.User{ID: "123456789012345678", Username: "trooper"}}},
+		MemberRoleRemoveErrs: []error{restError(http.StatusBadGateway, 0, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, wardenRemoveInteraction())
+
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("role-remove 5xx leaked the raw Discord body: %q", got)
+	}
+	if rec.count != 1 {
+		t.Fatalf("a 5xx role remove must capture to Sentry once; got %d", rec.count)
+	}
+}
+
+// --- bulkadd: 4xx role-add failure must not capture but still report ---
+
+func TestRunWardenBulkAdd_RoleAdd403NoCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		searchResults: map[string][]*discordgo.Member{
+			"good": {{User: &discordgo.User{ID: "111", Username: "good"}}},
+		},
+		MemberRoleAddErrs: []error{restError(http.StatusForbidden, 50013, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1",
+		stringOption("command", "bulkadd"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "good"),
+	)
+
+	runWarden(f, gm, i)
+
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("bulkadd 403 leaked the raw Discord body: %q", got)
+	}
+	if rec.count != 0 {
+		t.Fatalf("a 403 bulk role add must NOT capture to Sentry; got %d", rec.count)
+	}
+}
+
+func TestRunWardenBulkAdd_RoleAdd5xxCaptures(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		searchResults: map[string][]*discordgo.Member{
+			"good": {{User: &discordgo.User{ID: "111", Username: "good"}}},
+		},
+		MemberRoleAddErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1",
+		stringOption("command", "bulkadd"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "good"),
+	)
+
+	runWarden(f, gm, i)
+
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("bulkadd 5xx leaked the raw Discord body: %q", got)
+	}
+	if rec.count != 1 {
+		t.Fatalf("a 5xx bulk role add must capture to Sentry once; got %d", rec.count)
+	}
+}

--- a/commands/warden_test.go
+++ b/commands/warden_test.go
@@ -416,8 +416,14 @@ func TestRunWarden_AddRoleAddFailureSurfaces(t *testing.T) {
 
 	runWarden(f, gm, i)
 
-	if got := lastEditContent(f.Calls()); !strings.Contains(got, "❌ Failed to add 'Verified Warden Internal' role") {
+	// A plain (non-REST) error is a transport-class fault: the reply names the
+	// role and surfaces the failure, but never the raw error text.
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Could not add 'Verified Warden Internal'") {
 		t.Fatalf("expected role-add failure surfaced, got %q", got)
+	}
+	if strings.Contains(got, "forbidden") {
+		t.Fatalf("reply must not leak the raw error text, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Closes #171.

When a discordgo call failed in the warden stack, the raw `HTTP <status>, <json body>` was shown to the operator and every failure was sent to Sentry, including ordinary 4xx conditions caused by operator input or guild config. That's the same root cause as the fixed CAVBOT2-6 issue.

This adds a small warden-local classifier over `discordgo.RESTError` (via `errors.As`) that splits errors by status class:

- 4xx (operator/config): short actionable reply, no `CaptureError`. A 403 on role add/remove now names the role and explains the bot needs Manage Roles positioned above the target role.
- 5xx and transport/unclassifiable: `CaptureError` plus a generic retry message, per ADR 0001.

The raw Discord body is discarded inside the classifier, so it can't reach a reply. Applied at the four sites the audit flagged: the `GuildMembersSearch` path in `findGuildMember`, and the role add/remove paths in the add, remove, and bulkadd handlers.

Tests use the existing GuildManager fake and a planted marker string to assert the 4xx-vs-5xx split (capture vs no-capture) and that no raw body leaks, across search and all three mutation sites. The purge path is left as-is (out of scope; its failures are genuine system faults).

> *This was generated by AI*