### PR TITLE
docs(adr): correct ADR 0004 to match warden's actual interaction-response pattern

### DIFF
--- a/docs/adr/0004-interaction-responder-and-placeholder.md
+++ b/docs/adr/0004-interaction-responder-and-placeholder.md
@@ -1,4 +1,4 @@
-# ADR 0004: `InteractionResponder` interface + placeholder-vs-Defer convention
+# ADR 0004: `InteractionResponder` interface + interaction-response conventions
 
 ## Status
 
@@ -11,28 +11,51 @@ directly. The interface exposes only the 3 hot-path methods actually used
 (`InteractionRespond`, `InteractionResponseEdit`, `FollowupMessageCreate`)
 and drops the universally-ignored `*Message` return values.
 
-Two response patterns coexist:
+Four response patterns coexist:
 
 - **Placeholder** (most commands) — `InteractionRespond` immediately with
   `"Fetching X for Y..."`, then `InteractionResponseEdit` to replace.
-- **Defer** (`s3aar`, `warden`) — `Defer` then `FollowupMessageCreate`.
+- **Deferred edit** (`warden`) — defer an *ephemeral* response
+  (`InteractionResponseDeferredChannelMessageWithSource` +
+  `MessageFlagsEphemeral`), then fill it in with `InteractionResponseEdit`.
+  The `deferEphemeral` / `editEphemeral` / `editEphemeralWithEmbed` helpers in
+  `commands/warden.go` wrap this. Warden does **not** use
+  `FollowupMessageCreate`.
+- **Deferred followup** (`s3aar`) — defer a public response, then post the
+  result with `FollowupMessageCreate`. One run can fire several followups
+  (debug output, per-step errors), which is why it follows up rather than
+  editing a single deferred reply.
+- **Button confirmation** (`/apps_beta_deploy`) — does not defer at all. The
+  slash command replies immediately and ephemerally
+  (`InteractionResponseChannelMessageWithSource` + `MessageFlagsEphemeral`)
+  with Confirm/Cancel buttons. The button click swaps that message via
+  `InteractionResponseUpdateMessage`, and once the deploy fires the result goes
+  out as a *public* `FollowupMessageCreate` (no flags) so the channel can see
+  it.
 
 The placeholder pattern is a deliberate UX choice: echo back the parsed
 argument inside ~200ms so typos are visible before the long upstream call
 returns.
 
+For the deferred patterns, defer when there's no argument worth echoing back.
+An edit replaces the single deferred message in place; a followup posts a new
+message. `warden` has one result to show, so it edits; `s3aar` may emit
+several, so it follows up.
+
 ## Why
 
 The interface keeps test plumbing minimal and forces deliberate choice of
-dependencies. The placeholder/Defer split is documented because tests must
-pin `InteractionResponse.Type` faithfully — a placeholder-vs-Defer regression
-shouldn't slip past.
+dependencies. The patterns are documented because tests must pin
+`InteractionResponse.Type` faithfully — if a command quietly switches between,
+say, a placeholder and a defer, the test should catch it.
 
 ## How to apply
 
 - New command → take `InteractionResponder`, not `*discordgo.Session`.
-- Default to the placeholder pattern; pick Defer only when there's no
-  argument worth echoing back (or the work is sub-200ms).
+- Default to the placeholder pattern; defer only when there's no argument
+  worth echoing back (or the work is sub-200ms). Once deferred, either edit
+  the deferred reply (`InteractionResponseEdit`) or post a `FollowupMessageCreate`.
+  Edit when there's one result message; follow up when you may emit several.
 - Use `errors.As` with `*discordgo.RESTError` code 40060 to detect
   "interaction already acknowledged" (wording-proof rather than matching the
   error string).


### PR DESCRIPTION
Closes #176.

ADR 0004 listed `/warden` as an example of "Defer then `FollowupMessageCreate`", but warden defers an ephemeral response and fills it with `InteractionResponseEdit` (the `deferEphemeral` / `editEphemeral` helpers). It never calls `FollowupMessageCreate`. That's the doc drift ADR 0006 warns about.

While reconciling it I spot-checked every command the ADR names and found it was conflating distinct shapes, so the ADR now documents the four patterns the commands actually use:

- Placeholder: immediate "Fetching..." response then edit (milpac, loa, awol, and most commands).
- Deferred edit: ephemeral defer then `InteractionResponseEdit` (warden).
- Deferred followup: public defer then `FollowupMessageCreate` (s3aar, the one genuine defer-then-followup command).
- Button confirmation: immediate ephemeral ack with buttons, `InteractionResponseUpdateMessage` on click, then a public `FollowupMessageCreate` (`/apps_beta_deploy`).

Retitled away from "placeholder-vs-Defer" since it now covers four shapes. Docs only; no command behavior changes.

> *This was generated by AI*