### PR TITLE
fix(warden): treat mention/ID member lookups as authoritative instead of falling through to name search

### DIFF
--- a/commands/warden.go
+++ b/commands/warden.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -636,24 +637,19 @@ func findGuildMember(gm GuildManager, guildID, query string) (*discordgo.Member,
 		return nil, fmt.Errorf("❌ Query too long (max 100 characters); use a mention/ID instead")
 	}
 
-	// Mentions: <@123>, <@!123>
-	if strings.HasPrefix(trimmedQuery, "<@") && strings.HasSuffix(trimmedQuery, ">") {
-		userID := strings.TrimSuffix(strings.TrimPrefix(trimmedQuery, "<@"), ">")
-		userID = strings.TrimPrefix(userID, "!")
-		if userID != "" {
-			member, err := gm.GuildMember(guildID, userID)
-			if err == nil && member != nil {
-				return member, nil
-			}
-		}
+	// Mentions: <@123>, <@!123>. A mention unambiguously names one user, so the
+	// targeted GuildMember lookup is authoritative — we never fall through to a
+	// name search of the raw "<@...>" string (which can't match a display name
+	// and would report a misleading "no member found" even for a transient API
+	// fault). A 404 means the user really isn't here; any other failure is
+	// surfaced (and captured if it's a genuine system fault).
+	if userID, ok := mentionUserID(trimmedQuery); ok {
+		return resolveMemberByID(gm, guildID, userID)
 	}
 
-	// Raw snowflake ID
+	// Raw snowflake ID: same authoritative treatment as a mention.
 	if isSnowflakeID(trimmedQuery) {
-		member, err := gm.GuildMember(guildID, trimmedQuery)
-		if err == nil && member != nil {
-			return member, nil
-		}
+		return resolveMemberByID(gm, guildID, trimmedQuery)
 	}
 
 	// Name search
@@ -670,6 +666,46 @@ func findGuildMember(gm GuildManager, guildID, query string) (*discordgo.Member,
 	default:
 		return nil, fmt.Errorf("❌ Too many matches for '%s' (be more specific, or use a mention/ID)", query)
 	}
+}
+
+// mentionUserID extracts the user snowflake from a Discord mention
+// (<@123> or <@!123>). It returns ("", false) for anything that isn't a
+// non-empty mention, so callers can branch on whether the input was a mention.
+func mentionUserID(query string) (string, bool) {
+	if !strings.HasPrefix(query, "<@") || !strings.HasSuffix(query, ">") {
+		return "", false
+	}
+	userID := strings.TrimSuffix(strings.TrimPrefix(query, "<@"), ">")
+	userID = strings.TrimPrefix(userID, "!")
+	if userID == "" {
+		return "", false
+	}
+	return userID, true
+}
+
+// resolveMemberByID performs the authoritative targeted member lookup used for
+// mentions and raw snowflakes. The result is trusted: it never falls through to
+// a name search. A 404 yields a clear "not in this server" message; any other
+// failure is routed through the shared classifier so a genuine system fault is
+// captured to Sentry and the raw Discord body never reaches the reply.
+func resolveMemberByID(gm GuildManager, guildID, userID string) (*discordgo.Member, error) {
+	member, err := gm.GuildMember(guildID, userID)
+	if err != nil {
+		class := classifyDiscordError(err)
+		switch {
+		case class.NotFound:
+			return nil, fmt.Errorf("❌ <@%s> is not in this server", userID)
+		case class.SystemFault:
+			captureError("Failed to look up guild member by ID", err, "user_id", userID)
+			return nil, errors.New("❌ Member lookup is temporarily unavailable (Discord error); please try again shortly")
+		default:
+			return nil, fmt.Errorf("❌ Could not look up <@%s> (%s)", userID, class.UserDetail)
+		}
+	}
+	if member == nil {
+		return nil, fmt.Errorf("❌ <@%s> is not in this server", userID)
+	}
+	return member, nil
 }
 
 func findGuildRoleIDByName(gm GuildManager, guildID, roleName string) (string, error) {

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -29,6 +29,11 @@ type discordErrorClass struct {
 	// bot lacks Manage Roles or the target role sits above the bot's own role.
 	// Callers use it to render a specific, actionable hierarchy hint.
 	MissingPermissions bool
+	// NotFound is true for a 404. On a targeted member-by-ID/mention lookup this
+	// means the user is genuinely absent from the guild — a clear, non-system
+	// condition the caller renders as "not in this server" rather than capturing
+	// or downgrading into a name search.
+	NotFound bool
 	// UserDetail is a short, body-free phrase safe to show an operator. It never
 	// contains the raw Discord error body.
 	UserDetail string
@@ -57,6 +62,11 @@ func classifyDiscordError(err error) discordErrorClass {
 		return discordErrorClass{
 			MissingPermissions: true,
 			UserDetail:         "missing permissions",
+		}
+	case status == http.StatusNotFound:
+		return discordErrorClass{
+			NotFound:   true,
+			UserDetail: "not found",
 		}
 	case status >= 400 && status < 500:
 		return discordErrorClass{

--- a/commands/warden_resterror_test.go
+++ b/commands/warden_resterror_test.go
@@ -82,6 +82,169 @@ func TestClassifyDiscordError_RESTErrorNilResponseIsSystemFault(t *testing.T) {
 	}
 }
 
+// A 404 is a distinct, non-system client fault: the targeted member-by-ID
+// lookup proved the user is absent. It must set NotFound (so findGuildMember can
+// render a clear "not in this server" message) without setting SystemFault or
+// MissingPermissions, and never leak the raw body.
+func TestClassifyDiscordError_404IsNotFound(t *testing.T) {
+	err := restError(http.StatusNotFound, 10007, rawBodyMarker)
+	c := classifyDiscordError(err)
+	if c.SystemFault {
+		t.Fatalf("a 404 must not be a system fault")
+	}
+	if !c.NotFound {
+		t.Fatalf("a 404 must set NotFound so callers can show a clear absent-member message")
+	}
+	if strings.Contains(c.UserDetail, rawBodyMarker) {
+		t.Fatalf("classifier leaked the raw Discord body: %q", c.UserDetail)
+	}
+}
+
+// --- mention/ID lookup: authoritative, never falls through to name search ---
+
+// A valid mention for a present member resolves via the targeted GuildMember
+// lookup and never reaches GuildMembersSearch.
+func TestFindGuildMember_MentionSuccessResolvesAuthoritatively(t *testing.T) {
+	gm := &fakeGuildManager{
+		membersByID: map[string]*discordgo.Member{"123456789012345678": {User: &discordgo.User{ID: "123456789012345678", Username: "trooper"}}},
+	}
+
+	member, err := findGuildMember(gm, "guild-1", "<@123456789012345678>")
+	if err != nil {
+		t.Fatalf("expected the mention to resolve, got error %v", err)
+	}
+	if member == nil || member.User == nil || member.User.ID != "123456789012345678" {
+		t.Fatalf("expected the targeted member, got %+v", member)
+	}
+	if gm.countCalls("GuildMembersSearch") != 0 {
+		t.Fatalf("a resolved mention must not fall through to name search; got calls %v", gm.Calls())
+	}
+}
+
+// A mention whose targeted lookup 404s must yield a clear "not in this server"
+// message — never a name search of the raw "<@...>" string, and never a Sentry
+// capture (a 404 is an ordinary, non-system condition).
+func TestFindGuildMember_Mention404ClearMessageNoSearchNoCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{MemberErrs: []error{restError(http.StatusNotFound, 10007, rawBodyMarker)}}
+
+	_, err := findGuildMember(gm, "guild-1", "<@123456789012345678>")
+	if err == nil {
+		t.Fatal("expected an error when the mentioned member is absent")
+	}
+	if strings.Contains(err.Error(), rawBodyMarker) {
+		t.Fatalf("mention 404 leaked the raw Discord body: %q", err.Error())
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "not in this server") {
+		t.Fatalf("expected a clear absent-member message, got %q", err.Error())
+	}
+	if gm.countCalls("GuildMembersSearch") != 0 {
+		t.Fatalf("a 404 mention must NOT fall through to name search; got calls %v", gm.Calls())
+	}
+	if rec.count != 0 {
+		t.Fatalf("a 404 mention must NOT capture to Sentry; got %d", rec.count)
+	}
+}
+
+// A transient (non-404) failure on a mention lookup is a genuine system fault:
+// it must surface an error, capture to Sentry once, and must NOT downgrade into
+// a name search of the raw mention string (which would report a misleading
+// "no member found").
+func TestFindGuildMember_MentionTransientFaultSurfacedAndCaptured(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{MemberErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)}}
+
+	_, err := findGuildMember(gm, "guild-1", "<@123456789012345678>")
+	if err == nil {
+		t.Fatal("expected an error from a transient mention-lookup failure")
+	}
+	if strings.Contains(err.Error(), rawBodyMarker) {
+		t.Fatalf("mention transient fault leaked the raw Discord body: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "No member found") {
+		t.Fatalf("a transient fault must not be reported as 'no member found': %q", err.Error())
+	}
+	if gm.countCalls("GuildMembersSearch") != 0 {
+		t.Fatalf("a transient mention fault must NOT fall through to name search; got calls %v", gm.Calls())
+	}
+	if rec.count != 1 {
+		t.Fatalf("a transient (5xx) mention fault must capture to Sentry once; got %d", rec.count)
+	}
+}
+
+// A raw snowflake ID whose targeted lookup 404s is treated identically to a
+// mention: a clear absent-member message, no name search of the raw ID.
+func TestFindGuildMember_Snowflake404ClearMessageNoSearch(t *testing.T) {
+	gm := &fakeGuildManager{MemberErrs: []error{restError(http.StatusNotFound, 10007, rawBodyMarker)}}
+
+	_, err := findGuildMember(gm, "guild-1", "123456789012345678")
+	if err == nil {
+		t.Fatal("expected an error when the snowflake member is absent")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "not in this server") {
+		t.Fatalf("expected a clear absent-member message, got %q", err.Error())
+	}
+	if gm.countCalls("GuildMembersSearch") != 0 {
+		t.Fatalf("a 404 snowflake must NOT fall through to name search; got calls %v", gm.Calls())
+	}
+}
+
+// The raw-snowflake form must reach the same system-fault capture arm as the
+// mention form on a transient (non-404) failure: surface an error, capture once,
+// no name search, no misleading "no member found". Snowflakes were otherwise
+// only covered for 404, so this pins the two input forms to identical handling.
+func TestFindGuildMember_SnowflakeTransientFaultSurfacedAndCaptured(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{MemberErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)}}
+
+	_, err := findGuildMember(gm, "guild-1", "123456789012345678")
+	if err == nil {
+		t.Fatal("expected an error from a transient snowflake-lookup failure")
+	}
+	if strings.Contains(err.Error(), rawBodyMarker) {
+		t.Fatalf("snowflake transient fault leaked the raw Discord body: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "No member found") {
+		t.Fatalf("a transient fault must not be reported as 'no member found': %q", err.Error())
+	}
+	if gm.countCalls("GuildMembersSearch") != 0 {
+		t.Fatalf("a transient snowflake fault must NOT fall through to name search; got calls %v", gm.Calls())
+	}
+	if rec.count != 1 {
+		t.Fatalf("a transient (5xx) snowflake fault must capture to Sentry once; got %d", rec.count)
+	}
+}
+
+// A non-404 4xx (here a 400) on a targeted mention/ID lookup is an
+// operator/config-fixable client fault: it shows the generic "Discord rejected
+// the request" wording, never captures to Sentry, and never leaks the raw body.
+// Covers the default arm of resolveMemberByID.
+func TestFindGuildMember_MentionGeneric4xxNoCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{MemberErrs: []error{restError(http.StatusBadRequest, 50035, rawBodyMarker)}}
+
+	_, err := findGuildMember(gm, "guild-1", "<@123456789012345678>")
+	if err == nil {
+		t.Fatal("expected an error from a 400 mention lookup")
+	}
+	if strings.Contains(err.Error(), rawBodyMarker) {
+		t.Fatalf("mention generic 4xx leaked the raw Discord body: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "Discord rejected the request") {
+		t.Fatalf("expected the generic 4xx rejection wording, got %q", err.Error())
+	}
+	if gm.countCalls("GuildMembersSearch") != 0 {
+		t.Fatalf("a generic 4xx mention fault must NOT fall through to name search; got calls %v", gm.Calls())
+	}
+	if rec.count != 0 {
+		t.Fatalf("a generic 4xx mention fault must NOT capture to Sentry; got %d", rec.count)
+	}
+}
+
 // captureRecorder swaps the package-level captureError seam for the duration of
 // a test and counts how many times it fires, so a test can assert the
 // 4xx-vs-5xx Sentry split without a live Sentry client.


### PR DESCRIPTION
Closes #172.

`findGuildMember` resolved a mention (`<@123>`) or raw snowflake through `GuildMember`, but on any error it fell through to a `GuildMembersSearch` of the literal input. A display-name search never matches `<@123>`, so a transient API fault came back as "No member found matching '<@123>'" and the real error never reached Sentry.

The mention and snowflake branches now treat the targeted lookup as authoritative. The result is classified with the #171 helper, extended here with a `NotFound` (404) case:

- 404: a clear "that user is not in this server" message, no Sentry capture.
- 5xx or transport: captured per ADR 0001, with a generic retry message.
- Other 4xx: a short sanitized message, no capture.

Neither branch falls through to a name search of the raw mention string anymore, and no raw Discord body reaches the reply. The plain-name path is unchanged. The empty `<@>` case keeps its old fall-through, which is intentional.

Tests use the existing GuildManager fake (the `MemberErrs` injection) and the capture recorder seam to cover mention success, mention/snowflake 404, mention/snowflake transient fault, and a generic 4xx, asserting the search-call count stays at zero, the capture count matches, and no raw body leaks.

> *This was generated by AI*