### PR TITLE
fix(warden): deliver purge summary via fallback surface when the interaction token expires

### DIFF
--- a/commands/guild_manager.go
+++ b/commands/guild_manager.go
@@ -3,9 +3,11 @@ package commands
 import "github.com/bwmarrin/discordgo"
 
 // GuildManager is the subset of *discordgo.Session that /warden uses to read
-// and mutate guild roles, members, and channel permission overwrites. Command
-// code depends on this interface so tests can substitute a fake that records
-// calls and injects per-call errors without touching the live Discord gateway.
+// and mutate guild roles, members, and channel permission overwrites, plus send
+// a plain channel message as the purge summary's token-independent fallback
+// surface. Command code depends on this interface so tests can substitute a fake
+// that records calls and injects per-call errors without touching the live
+// Discord gateway.
 //
 // Following the InteractionResponder precedent (utils/discord_responder.go),
 // the production wrapper is a thin pass-through; the variadic
@@ -22,6 +24,11 @@ type GuildManager interface {
 	GuildMembersSearch(guildID, query string, limit int) ([]*discordgo.Member, error)
 	GuildMemberRoleAdd(guildID, userID, roleID string) error
 	GuildMemberRoleRemove(guildID, userID, roleID string) error
+	// ChannelMessageSend posts a plain message to a channel. Unlike the
+	// interaction-response surfaces, it does not depend on the (15-minute)
+	// interaction token, so it is the fallback surface a long purge uses to
+	// deliver its summary once the deferred edit can no longer be delivered.
+	ChannelMessageSend(channelID, content string) error
 }
 
 // sessionGuildManager adapts *discordgo.Session to GuildManager. Each method is
@@ -74,4 +81,9 @@ func (g *sessionGuildManager) GuildMemberRoleAdd(guildID, userID, roleID string)
 
 func (g *sessionGuildManager) GuildMemberRoleRemove(guildID, userID, roleID string) error {
 	return g.s.GuildMemberRoleRemove(guildID, userID, roleID)
+}
+
+func (g *sessionGuildManager) ChannelMessageSend(channelID, content string) error {
+	_, err := g.s.ChannelMessageSend(channelID, content)
+	return err
 }

--- a/commands/warden.go
+++ b/commands/warden.go
@@ -364,7 +364,69 @@ func runWardenPurge(
 		)
 	}
 
-	editEphemeral(r, interaction, joinOrFallback(summaryLines, "✅ Purge complete."))
+	deliverPurgeSummary(r, gm, interaction, joinOrFallback(summaryLines, "✅ Purge complete."))
+}
+
+// deliverPurgeSummary delivers the purge summary, with a token-expiry fallback.
+// A purge re-applies channel overwrites with a per-channel throttle, so across
+// many channels it can outlive Discord's 15-minute interaction token. Once that
+// window closes the deferred-ephemeral edit can no longer be delivered, and the
+// operator would otherwise be left with a spinner that never resolves on a
+// destructive op — an unanswerable "did it finish?" that risks a re-run.
+//
+// On a successful edit nothing else happens (the normal ephemeral reply). When
+// the edit fails:
+//   - token expiry → post the summary to the invoking channel. This surface
+//     does not depend on the interaction token, so it reaches the operator even
+//     after the window. Trade-off: the channel message is NOT ephemeral, unlike
+//     the normal reply, but a "your destructive op finished" notice is an
+//     acceptable thing to leave visible.
+//   - any other (unexpected) failure → capture to Sentry with context via the
+//     shared seam, the same as the non-purge edit helpers.
+func deliverPurgeSummary(
+	r utils.InteractionResponder,
+	gm GuildManager,
+	interaction *discordgo.InteractionCreate,
+	summary string,
+) {
+	editErr := r.InteractionResponseEdit(interaction.Interaction, &discordgo.WebhookEdit{
+		Content: &summary,
+	})
+	if editErr == nil {
+		return
+	}
+
+	if isInteractionTokenExpired(editErr) {
+		if sendErr := gm.ChannelMessageSend(interaction.ChannelID, summary); sendErr != nil {
+			// Both surfaces failed: the operator can't be reached. This is a
+			// genuine delivery fault worth paging on. Carry the original edit
+			// error too, so on-call sees the full chain — the edit expired AND
+			// the channel send failed — not just the second failure.
+			captureError(
+				"Failed to deliver purge summary via channel fallback after token expiry",
+				sendErr,
+				"command", wardenSubcommandOf(interaction),
+				"guild_id", interaction.GuildID,
+				"channel_id", interaction.ChannelID,
+				"edit_error", editErr,
+			)
+			return
+		}
+		// Recovery, not a fault: the deferred edit expired but the channel
+		// fallback reached the operator. Log (don't capture, per ADR 0001) so
+		// "did the long purge ever surface its result?" is answerable from logs.
+		utils.Info(
+			"purge summary delivered via channel fallback after interaction token expired",
+			"command", wardenSubcommandOf(interaction),
+			"guild_id", interaction.GuildID,
+			"channel_id", interaction.ChannelID,
+		)
+		return
+	}
+
+	// Unexpected (non-expiry) edit failure: capture with context, same seam the
+	// other edit helpers funnel through.
+	captureEditFailure(interaction, editErr)
 }
 
 func recreateRoleWithChannelOverwrites(

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -81,6 +81,34 @@ func classifyDiscordError(err error) discordErrorClass {
 	}
 }
 
+// isInteractionTokenExpired reports whether err is Discord's signal that the
+// interaction's 15-minute token window has closed, so the deferred-ephemeral
+// edit can no longer be delivered. It is deliberately narrow: only the specific
+// application error codes Discord returns once the webhook token is gone count
+// as expiry — a 5xx or a transport error is an unexpected fault, not expiry,
+// and must take the capture-to-Sentry path instead. A precise predicate keeps a
+// long purge from silently swallowing a genuine delivery fault as "just
+// expired".
+//
+//   - 50027 Invalid Webhook Token — the interaction-followup webhook token is no
+//     longer valid (the canonical post-window signal).
+//   - 10015 Unknown Webhook / 10062 Unknown Interaction — the webhook/interaction
+//     backing the deferred response is gone, the same end-of-window condition.
+func isInteractionTokenExpired(err error) bool {
+	var restErr *discordgo.RESTError
+	if !errors.As(err, &restErr) || restErr.Message == nil {
+		return false
+	}
+	switch restErr.Message.Code {
+	case discordgo.ErrCodeInvalidWebhookTokenProvided,
+		discordgo.ErrCodeUnknownWebhook,
+		discordgo.ErrCodeUnknownInteraction:
+		return true
+	default:
+		return false
+	}
+}
+
 // searchErrorReply classifies a GuildMembersSearch failure, captures it to
 // Sentry only when it is a genuine system fault, and returns a body-free,
 // operator-facing error. The raw Discord response body is never interpolated.

--- a/commands/warden_purge_fallback_test.go
+++ b/commands/warden_purge_fallback_test.go
@@ -1,0 +1,248 @@
+package commands
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// tokenExpiredRESTError builds the *discordgo.RESTError Discord returns on the
+// deferred-interaction webhook edit once the 15-minute token window has passed:
+// a 401 carrying the "Invalid Webhook Token" application error code (50027).
+func tokenExpiredRESTError() *discordgo.RESTError {
+	return restError(http.StatusUnauthorized, discordgo.ErrCodeInvalidWebhookTokenProvided, "Invalid Webhook Token")
+}
+
+// purgeInteractionWithChannel builds a deferred purge interaction carrying both
+// a guild id and the invoking channel id, so the channel-message fallback has a
+// destination to post to.
+func purgeInteractionWithChannel(guildID, channelID string) *discordgo.InteractionCreate {
+	i := wardenInteraction(guildID, stringOption("command", "purge"))
+	i.ChannelID = channelID
+	return i
+}
+
+// installCountingCapture swaps the captureError seam to both count how many
+// times it fires and record the kv from the most recent call, so a test can
+// assert exactly-one-capture and the context fields on the same install.
+func installCountingCapture(t *testing.T) (*int, *[]any) {
+	t.Helper()
+	var count int
+	var gotKV []any
+	prev := captureError
+	captureError = func(_ string, _ error, kv ...any) {
+		count++
+		gotKV = kv
+	}
+	t.Cleanup(func() { captureError = prev })
+	return &count, &gotKV
+}
+
+// lastChannelMessage returns the content of the last ChannelMessageSend
+// recorded by the fake, or "<none>".
+func (g *fakeGuildManager) lastChannelMessage() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.channelMessages) == 0 {
+		return "<none>"
+	}
+	return g.channelMessages[len(g.channelMessages)-1].content
+}
+
+// --- token-expiry classifier ---
+
+func TestIsInteractionTokenExpired_50027IsExpiry(t *testing.T) {
+	if !isInteractionTokenExpired(tokenExpiredRESTError()) {
+		t.Fatal("an Invalid Webhook Token (50027) error must be treated as token expiry")
+	}
+}
+
+func TestIsInteractionTokenExpired_UnknownWebhookIsExpiry(t *testing.T) {
+	err := restError(http.StatusNotFound, discordgo.ErrCodeUnknownWebhook, "Unknown Webhook")
+	if !isInteractionTokenExpired(err) {
+		t.Fatal("an Unknown Webhook (10015) error must be treated as token expiry")
+	}
+}
+
+func TestIsInteractionTokenExpired_UnknownInteractionIsExpiry(t *testing.T) {
+	err := restError(http.StatusNotFound, discordgo.ErrCodeUnknownInteraction, "Unknown Interaction")
+	if !isInteractionTokenExpired(err) {
+		t.Fatal("an Unknown Interaction (10062) error must be treated as token expiry")
+	}
+}
+
+func TestIsInteractionTokenExpired_5xxIsNotExpiry(t *testing.T) {
+	err := restError(http.StatusInternalServerError, 0, "boom")
+	if isInteractionTokenExpired(err) {
+		t.Fatal("a 5xx must NOT be misclassified as token expiry — it is an unexpected fault")
+	}
+}
+
+func TestIsInteractionTokenExpired_TransportErrorIsNotExpiry(t *testing.T) {
+	if isInteractionTokenExpired(errors.New("dial tcp: connection refused")) {
+		t.Fatal("a transport error must NOT be classified as token expiry")
+	}
+}
+
+// --- deliverPurgeSummary: happy path ---
+
+// On a successful edit, the summary is delivered ephemerally and the fallback
+// channel surface is never touched, and nothing is captured to Sentry.
+func TestDeliverPurgeSummary_HappyPathEditsNoFallback(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	f := &fakeResponder{} // edit succeeds
+	gm := &fakeGuildManager{}
+	i := purgeInteractionWithChannel("guild-1", "chan-9")
+
+	deliverPurgeSummary(f, gm, i, "✅ Purge complete.")
+
+	if got := countMethod(f.Calls(), "Edit"); got != 1 {
+		t.Fatalf("expected exactly 1 Edit on the happy path, got %d", got)
+	}
+	if got := gm.countCalls("ChannelMessageSend"); got != 0 {
+		t.Fatalf("happy path must NOT use the channel fallback; got %d ChannelMessageSend", got)
+	}
+	if rec.count != 0 {
+		t.Fatalf("happy path must not capture to Sentry; got %d", rec.count)
+	}
+}
+
+// --- deliverPurgeSummary: token-expiry fallback ---
+
+// When the deferred edit fails with a token-expiry error, the summary must be
+// delivered through the channel-message fallback carrying the same summary.
+func TestDeliverPurgeSummary_TokenExpiryFallsBackToChannel(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	f := &fakeResponder{EditErrs: []error{tokenExpiredRESTError()}}
+	gm := &fakeGuildManager{}
+	i := purgeInteractionWithChannel("guild-1", "chan-9")
+	summary := "✅ Recreated 'Verified Warden Internal'."
+
+	deliverPurgeSummary(f, gm, i, summary)
+
+	if got := gm.countCalls("ChannelMessageSend"); got != 1 {
+		t.Fatalf("a token-expired edit must fall back to one ChannelMessageSend; got %d (%v)", got, gm.Calls())
+	}
+	if got := gm.lastChannelMessage(); !strings.Contains(got, "Recreated 'Verified Warden Internal'") {
+		t.Fatalf("fallback channel message must carry the purge summary, got %q", got)
+	}
+	// Token expiry is an expected end-of-window condition, not a system fault:
+	// the operator was reached via the fallback, so it must NOT page Sentry.
+	if rec.count != 0 {
+		t.Fatalf("a token-expiry fallback delivery must NOT capture to Sentry; got %d", rec.count)
+	}
+}
+
+// The fallback channel message must be addressed to the invoking channel.
+func TestDeliverPurgeSummary_TokenExpiryFallbackTargetsInvokingChannel(t *testing.T) {
+	f := &fakeResponder{EditErrs: []error{tokenExpiredRESTError()}}
+	gm := &fakeGuildManager{}
+	i := purgeInteractionWithChannel("guild-1", "chan-target")
+
+	deliverPurgeSummary(f, gm, i, "summary")
+
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+	if len(gm.channelMessages) != 1 {
+		t.Fatalf("expected exactly 1 channel message, got %d", len(gm.channelMessages))
+	}
+	if gm.channelMessages[0].channelID != "chan-target" {
+		t.Fatalf("fallback must target the invoking channel id, got %q", gm.channelMessages[0].channelID)
+	}
+}
+
+// --- deliverPurgeSummary: unexpected (non-expiry) edit failure ---
+
+// A non-expiry edit failure (e.g. a 5xx) is an unexpected fault: it must be
+// captured to Sentry with context and must NOT be delivered as if expiry.
+func TestDeliverPurgeSummary_UnexpectedFailureCapturedNotFallback(t *testing.T) {
+	captures, gotKV := installCountingCapture(t)
+
+	f := &fakeResponder{EditErrs: []error{restError(http.StatusInternalServerError, 0, "boom")}}
+	gm := &fakeGuildManager{}
+	i := purgeInteractionWithChannel("guild-7", "chan-9")
+
+	deliverPurgeSummary(f, gm, i, "summary")
+
+	// The edit is attempted exactly once: an unexpected failure captures, it does
+	// not retry the already-acknowledged edit.
+	if got := countMethod(f.Calls(), "Edit"); got != 1 {
+		t.Fatalf("expected exactly 1 Edit (the failing call, no retry), got %d", got)
+	}
+	if got := gm.countCalls("ChannelMessageSend"); got != 0 {
+		t.Fatalf("an unexpected (non-expiry) edit failure must NOT use the channel fallback; got %d", got)
+	}
+	if *captures != 1 {
+		t.Fatalf("expected exactly 1 Sentry capture on an unexpected failure, got %d", *captures)
+	}
+	kvMap := kvToMap(*gotKV)
+	if kvMap["command"] != "purge" {
+		t.Fatalf("expected command=purge in capture context, got %v", kvMap["command"])
+	}
+	if kvMap["guild_id"] != "guild-7" {
+		t.Fatalf("expected guild_id=guild-7 in capture context, got %v", kvMap["guild_id"])
+	}
+}
+
+// When the edit expires AND the channel fallback also fails, the operator
+// cannot be reached at all — that is a genuine delivery fault, so it must be
+// captured to Sentry with command + guild context.
+func TestDeliverPurgeSummary_BothSurfacesFailCaptures(t *testing.T) {
+	captures, gotKV := installCountingCapture(t)
+
+	editErr := tokenExpiredRESTError()
+	f := &fakeResponder{EditErrs: []error{editErr}}
+	gm := &fakeGuildManager{ChannelMessageErrs: []error{errors.New("missing access")}}
+	i := purgeInteractionWithChannel("guild-3", "chan-9")
+
+	deliverPurgeSummary(f, gm, i, "summary")
+
+	if got := gm.countCalls("ChannelMessageSend"); got != 1 {
+		t.Fatalf("expected the fallback to be attempted once, got %d", got)
+	}
+	if *captures != 1 {
+		t.Fatalf("expected exactly 1 Sentry capture when both surfaces fail, got %d", *captures)
+	}
+	kvMap := kvToMap(*gotKV)
+	if kvMap["command"] != "purge" {
+		t.Fatalf("expected command=purge in capture context, got %v", kvMap["command"])
+	}
+	if kvMap["guild_id"] != "guild-3" {
+		t.Fatalf("expected guild_id=guild-3 in capture context, got %v", kvMap["guild_id"])
+	}
+	// The capture must carry the original token-expiry edit error too, so on-call
+	// sees the full failure chain (edit expired AND channel send failed).
+	if kvMap["edit_error"] != error(editErr) {
+		t.Fatalf("expected the original edit error in capture context, got %v", kvMap["edit_error"])
+	}
+}
+
+// --- runWardenPurge wires the summary through deliverPurgeSummary ---
+
+// The end-to-end purge path must reach the channel fallback when its deferred
+// edit expires, so a long purge that finished server-side still reaches the
+// operator. Drives runWardenPurge directly (synchronous, no goroutine).
+func TestRunWardenPurge_TokenExpiryReachesChannelFallback(t *testing.T) {
+	noOverwriteDelay(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("old-int", wardenRoleBaseName+" Internal")},
+	}
+	f := &fakeResponder{EditErrs: []error{tokenExpiredRESTError()}}
+	i := purgeInteractionWithChannel("guild-1", "chan-9")
+
+	runWardenPurge(f, gm, i, "guild-1", "internal")
+
+	if got := gm.countCalls("ChannelMessageSend"); got != 1 {
+		t.Fatalf("a token-expired purge edit must reach the channel fallback once; got %d (%v)", got, gm.Calls())
+	}
+	if got := gm.lastChannelMessage(); !strings.Contains(got, "Recreated 'Verified Warden Internal'") {
+		t.Fatalf("fallback message must carry the recreated-role summary, got %q", got)
+	}
+}

--- a/commands/warden_test.go
+++ b/commands/warden_test.go
@@ -27,6 +27,10 @@ type fakeGuildManager struct {
 	createdRole    *discordgo.Role // returned by GuildRoleCreate
 	nextCreatedNum int
 
+	// channelMessages records every ChannelMessageSend (the purge fallback
+	// surface) so a test can assert what was delivered, and where.
+	channelMessages []sentChannelMessage
+
 	RolesErrs            []error
 	RoleCreateErrs       []error
 	RoleEditErrs         []error
@@ -37,6 +41,13 @@ type fakeGuildManager struct {
 	MembersSearchErrs    []error
 	MemberRoleAddErrs    []error
 	MemberRoleRemoveErrs []error
+	ChannelMessageErrs   []error
+}
+
+// sentChannelMessage is one recorded ChannelMessageSend call.
+type sentChannelMessage struct {
+	channelID string
+	content   string
 }
 
 func (g *fakeGuildManager) record(name string) {
@@ -134,6 +145,14 @@ func (g *fakeGuildManager) GuildMemberRoleAdd(_, _, _ string) error {
 func (g *fakeGuildManager) GuildMemberRoleRemove(_, _, _ string) error {
 	g.record("GuildMemberRoleRemove")
 	return popErr(&g.MemberRoleRemoveErrs)
+}
+
+func (g *fakeGuildManager) ChannelMessageSend(channelID, content string) error {
+	g.record("ChannelMessageSend")
+	g.mu.Lock()
+	g.channelMessages = append(g.channelMessages, sentChannelMessage{channelID: channelID, content: content})
+	g.mu.Unlock()
+	return popErr(&g.ChannelMessageErrs)
 }
 
 // wardenInteraction builds an *InteractionCreate carrying the given option


### PR DESCRIPTION
Closes #175.

`handleWardenPurge` defers, then runs `runWardenPurge` in a goroutine that re-applies channel overwrites with a per-channel throttle. A purge across many channels can outlast Discord's 15-minute interaction token, after which the deferred `editEphemeral` summary fails and there is no other surface. The operator is left watching a spinner that never resolves on a destructive role-recreate, which invites a re-run.

The final summary delivery now goes through a synchronous `deliverPurgeSummary`:

- Edit succeeds: nothing else happens (happy path unchanged).
- Token expired: post the summary to the invoking channel via a new `GuildManager.ChannelMessageSend`. This message is public rather than ephemeral, which is a fair trade for a "your destructive op finished" notice and far better than a hung spinner.
- Any other edit failure: capture to Sentry through the #174 `captureEditFailure` seam.
- Edit expired and the channel send also failed: capture both errors with the command, guild, and channel context so an on-call responder can see why the operator became unreachable.

Token expiry is detected by `isInteractionTokenExpired`, which matches the discordgo error codes Discord returns on a stale webhook edit (50027, 10015, 10062) and deliberately excludes 5xx and transport errors so a real fault still pages instead of posting to a channel. The expiry path also logs an info line on successful fallback so the delivery is greppable.

`GuildManager`, its session adapter, and the test fake all gained `ChannelMessageSend`. The purge goroutine keeps its panic recovery; the deliverable logic was pulled into the synchronous `deliverPurgeSummary` so tests drive it directly with no goroutine race. Tests cover happy path, each expiry code, 5xx and transport non-expiry, the channel fallback content and target, the capture-once non-expiry path, and the both-surfaces-fail capture.

> *This was generated by AI*