### PR TITLE
fix(warden): prevent orphan duplicate role when purge recreation fails

### DIFF
--- a/commands/guild_manager.go
+++ b/commands/guild_manager.go
@@ -16,7 +16,6 @@ import "github.com/bwmarrin/discordgo"
 type GuildManager interface {
 	GuildRoles(guildID string) ([]*discordgo.Role, error)
 	GuildRoleCreate(guildID string, data *discordgo.RoleParams) (*discordgo.Role, error)
-	GuildRoleEdit(guildID, roleID string, data *discordgo.RoleParams) (*discordgo.Role, error)
 	GuildRoleDelete(guildID, roleID string) error
 	GuildChannels(guildID string) ([]*discordgo.Channel, error)
 	ChannelPermissionSet(channelID, targetID string, targetType discordgo.PermissionOverwriteType, allow, deny int64) error
@@ -49,10 +48,6 @@ func (g *sessionGuildManager) GuildRoles(guildID string) ([]*discordgo.Role, err
 
 func (g *sessionGuildManager) GuildRoleCreate(guildID string, data *discordgo.RoleParams) (*discordgo.Role, error) {
 	return g.s.GuildRoleCreate(guildID, data)
-}
-
-func (g *sessionGuildManager) GuildRoleEdit(guildID, roleID string, data *discordgo.RoleParams) (*discordgo.Role, error) {
-	return g.s.GuildRoleEdit(guildID, roleID, data)
 }
 
 func (g *sessionGuildManager) GuildRoleDelete(guildID, roleID string) error {

--- a/commands/warden.go
+++ b/commands/warden.go
@@ -340,15 +340,39 @@ func runWardenPurge(
 		)
 
 		if recreateErr != nil {
-			utils.CaptureError(
+			// Two distinct failure shapes share recreateErr != nil:
+			//
+			//   - newRoleID == "": nothing usable was left behind (the create
+			//     failed, or an overwrite step failed and the new role was cleaned
+			//     up). Tell the operator the role was NOT recreated and they can
+			//     retry.
+			//   - newRoleID != "": the new role was created and configured, but
+			//     deleting the OLD role failed, so a duplicate now lingers. Tell the
+			//     operator the opposite — the recreate happened and the leftover old
+			//     role needs manual cleanup.
+			//
+			// Both route the underlying error through the classifier so no raw
+			// Discord body leaks and only genuine system faults page Sentry (ADR
+			// 0001), via the swappable capture seam.
+			if newRoleID != "" {
+				summaryLines = append(summaryLines, purgePartialDeleteSummary(
+					roleName, newRoleID, roleIDToRecreate, recreateErr,
+					"Warden purge could not delete the old role after recreation",
+					"guild", guildID,
+					"roleName", roleName,
+					"oldRoleID", roleIDToRecreate,
+					"newRoleID", newRoleID,
+				))
+				continue
+			}
+
+			summaryLines = append(summaryLines, purgeRecreateErrorReply(
+				roleName, recreateErr,
 				"Warden purge role recreation failed",
-				recreateErr,
 				"guild", guildID,
 				"roleName", roleName,
 				"roleID", roleIDToRecreate,
-			)
-
-			summaryLines = append(summaryLines, fmt.Sprintf("❌ Failed to recreate '%s': %v", roleName, recreateErr))
+			))
 			continue
 		}
 
@@ -442,6 +466,12 @@ func recreateRoleWithChannelOverwrites(
 
 	channelOverwritesByChannelID := collectRoleOverwritesByChannelID(oldRoleID, guildChannels)
 
+	// GuildRoleCreate's POST sets every field below (name, color, hoist,
+	// mentionable, permissions) in one call, so the role is fully configured the
+	// moment it exists. There is deliberately NO follow-up GuildRoleEdit: a
+	// redundant re-apply of these same fields could fail after the new role
+	// already existed, leaving a duplicate orphan with the old role still in
+	// place (#178). Dropping it removes that failure window entirely.
 	newRole, err := gm.GuildRoleCreate(guildID, &discordgo.RoleParams{
 		Name:        oldRole.Name,
 		Color:       &oldRole.Color,
@@ -454,10 +484,6 @@ func recreateRoleWithChannelOverwrites(
 		return "", 0, fmt.Errorf("create role: %w", err)
 	}
 
-	if err := applyRoleProperties(gm, guildID, newRole.ID, oldRole); err != nil {
-		return "", 0, fmt.Errorf("apply role properties: %w", err)
-	}
-
 	reappliedOverwriteCount, err := reapplyRoleOverwrites(
 		gm,
 		newRole.ID,
@@ -465,14 +491,41 @@ func recreateRoleWithChannelOverwrites(
 	)
 
 	if err != nil {
+		// The new role exists but its overwrites are incomplete and the old role
+		// is still present: that is the orphan-duplicate state #178 is about.
+		// Delete the new role so the guild is left with only the (untouched) old
+		// role, not a half-configured duplicate.
+		cleanupOrphanRole(gm, guildID, newRole.ID)
 		return "", reappliedOverwriteCount, fmt.Errorf("reapply overwrites: %w", err)
 	}
 
 	if err := gm.GuildRoleDelete(guildID, oldRoleID); err != nil {
+		// The new role is fully built and is the intended keeper; only the old
+		// role's deletion failed. Do NOT delete the new role here — that would
+		// throw away the completed recreation. Report the partial state up so the
+		// operator knows the old role lingers and may need a manual delete.
 		return newRole.ID, reappliedOverwriteCount, fmt.Errorf("delete old role: %w", err)
 	}
 
 	return newRole.ID, reappliedOverwriteCount, nil
+}
+
+// cleanupOrphanRole best-effort deletes a role created during a recreation that
+// then failed downstream, so a partial recreate does not leave a duplicate
+// orphan behind. A delete failure here is logged (not returned): the caller is
+// already returning the original downstream error, and the cleanup-delete
+// failing is a secondary fault — surfacing it would mask the real cause. If the
+// delete genuinely fails the role may still linger, which the purge summary's
+// "failed to recreate" line already warns the operator about.
+func cleanupOrphanRole(gm GuildManager, guildID, roleID string) {
+	if err := gm.GuildRoleDelete(guildID, roleID); err != nil {
+		utils.Warn(
+			"failed to clean up orphan role after a failed recreation",
+			"guild", guildID,
+			"roleID", roleID,
+			"error", err,
+		)
+	}
 }
 
 func fetchGuildRoleByID(gm GuildManager, guildID, roleID string) (*discordgo.Role, error) {
@@ -512,22 +565,6 @@ func collectRoleOverwritesByChannelID(
 	}
 
 	return channelOverwritesByChannelID
-}
-
-func applyRoleProperties(
-	gm GuildManager,
-	guildID string,
-	roleID string,
-	sourceRole *discordgo.Role,
-) error {
-	_, err := gm.GuildRoleEdit(guildID, roleID, &discordgo.RoleParams{
-		Name:        sourceRole.Name,
-		Color:       &sourceRole.Color,
-		Hoist:       &sourceRole.Hoist,
-		Mentionable: &sourceRole.Mentionable,
-		Permissions: &sourceRole.Permissions,
-	})
-	return err
 }
 
 func reapplyRoleOverwrites(

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -121,6 +121,59 @@ func searchErrorReply(err error) error {
 	return fmt.Errorf("❌ Member search failed (%s); check the query or try a mention/ID instead", class.UserDetail)
 }
 
+// purgeRecreateErrorReply classifies a purge role-recreation failure where the
+// new role was NOT left behind (the create itself failed, or an overwrite step
+// failed and the new role was cleaned up). It captures to Sentry only for
+// genuine system faults (per ADR 0001) and returns a body-free summary line. The
+// raw Discord response body (discordgo's "HTTP <status>, <json>") is never
+// interpolated: only a sanitized phrase from the classifier is shown. The line
+// names the role and states it was not recreated, so the operator knows nothing
+// new lingers and can retry.
+//
+// The distinct partial-success case (new role created but the OLD role could not
+// be deleted, leaving a duplicate) is handled by purgePartialDeleteSummary, not
+// here — that path must tell the operator the opposite, that a role DOES linger.
+func purgeRecreateErrorReply(roleName string, err error, captureMsg string, kv ...any) string {
+	class := classifyDiscordError(err)
+
+	switch {
+	case class.SystemFault:
+		captureError(captureMsg, err, kv...)
+		return fmt.Sprintf(
+			"❌ Failed to recreate '%s': Discord error, the role was not recreated; please try again shortly.",
+			roleName,
+		)
+	case class.MissingPermissions:
+		return fmt.Sprintf(
+			"❌ Failed to recreate '%s': missing permissions. The bot needs Manage Roles and its own role must sit above '%s'. The role was not recreated.",
+			roleName, roleName,
+		)
+	default:
+		return fmt.Sprintf(
+			"❌ Failed to recreate '%s': Discord rejected the request (%s). The role was not recreated.",
+			roleName, class.UserDetail,
+		)
+	}
+}
+
+// purgePartialDeleteSummary renders the partial-success case: the new role was
+// created and fully configured, but deleting the OLD role failed, so a duplicate
+// now exists in the guild. This is the inverse of purgeRecreateErrorReply — the
+// recreate DID happen, and the operator must be told a role lingers and needs
+// manual cleanup, not that nothing was created. The underlying delete error is
+// routed through the classifier for capture (genuine system faults page Sentry,
+// per ADR 0001) but its raw body is never shown; the summary names both the new
+// and old role IDs so the operator can find and remove the leftover.
+func purgePartialDeleteSummary(roleName, newRoleID, oldRoleID string, err error, captureMsg string, kv ...any) string {
+	if classifyDiscordError(err).SystemFault {
+		captureError(captureMsg, err, kv...)
+	}
+	return fmt.Sprintf(
+		"⚠️ Recreated '%s' (new: `%s`), but the old role (`%s`) could not be deleted and still exists. Delete it manually to remove the duplicate.",
+		roleName, newRoleID, oldRoleID,
+	)
+}
+
 // roleMutationErrorReply classifies a role add/remove failure, captures it to
 // Sentry only for genuine system faults, and returns a body-free, actionable
 // message. A 403 yields a specific role-hierarchy hint — the common cause is the

--- a/commands/warden_purge_orphan_test.go
+++ b/commands/warden_purge_orphan_test.go
@@ -1,0 +1,225 @@
+package commands
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// --- #178: purge recreation must not leave an orphan duplicate role ---
+
+// When the channel-overwrite re-application step fails after the new role has
+// already been created, the function must delete the new role so the guild is
+// not left with a duplicate (new orphan alongside the still-present old role).
+func TestRecreateRole_OverwriteFailureCleansUpNewRole(t *testing.T) {
+	noOverwriteDelay(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("old-int", wardenRoleBaseName+" Internal")},
+		channels: []*discordgo.Channel{
+			{
+				ID: "chan-1",
+				PermissionOverwrites: []*discordgo.PermissionOverwrite{
+					{ID: "old-int", Type: discordgo.PermissionOverwriteTypeRole, Allow: 1, Deny: 0},
+				},
+			},
+		},
+		// The overwrite re-application fails after the new role already exists.
+		ChannelPermSetErrs: []error{restError(http.StatusInternalServerError, 0, "boom")},
+	}
+
+	_, _, err := recreateRoleWithChannelOverwrites(gm, "guild-1", "old-int", gm.channels)
+	if err == nil {
+		t.Fatal("expected an error when the overwrite step fails")
+	}
+
+	// New role was created, then deleted as cleanup. The OLD role must NOT be
+	// deleted (its recreation failed), so exactly one delete -> the new role.
+	if gm.countCalls("GuildRoleCreate") != 1 {
+		t.Fatalf("expected the new role to be created, got %v", gm.Calls())
+	}
+	if gm.countCalls("GuildRoleDelete") != 1 {
+		t.Fatalf("expected exactly 1 delete (the orphan new role), got %d (%v)", gm.countCalls("GuildRoleDelete"), gm.Calls())
+	}
+	// The delete target must be EXACTLY the newly created role id (the fake's
+	// first create returns "new-role-1"), never the old role.
+	if got := gm.lastDeletedRoleID(); got != "new-role-1" {
+		t.Fatalf("cleanup must delete the new role %q, deleted %q", "new-role-1", got)
+	}
+}
+
+// The redundant post-create edit has been dropped: the create already sets every
+// field. Pin the mutation sequence to exactly create-then-delete-old, so a
+// re-edit step (the create->edit failure window #178 closed) cannot reappear.
+func TestRecreateRole_DoesNotReEditAfterCreate(t *testing.T) {
+	noOverwriteDelay(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("old-int", wardenRoleBaseName+" Internal")},
+	}
+
+	_, _, err := recreateRoleWithChannelOverwrites(gm, "guild-1", "old-int", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// With no overwrites to re-apply, the only mutations are: create the new role,
+	// then delete the old one. Any GuildRoleEdit between them would be the dropped
+	// redundant re-apply.
+	wantMutations := []string{"GuildRoleCreate", "GuildRoleDelete"}
+	var gotMutations []string
+	for _, c := range gm.Calls() {
+		if c == "GuildRoleCreate" || c == "GuildRoleEdit" || c == "GuildRoleDelete" {
+			gotMutations = append(gotMutations, c)
+		}
+	}
+	if strings.Join(gotMutations, ",") != strings.Join(wantMutations, ",") {
+		t.Fatalf("expected mutation sequence %v (no redundant edit), got %v", wantMutations, gm.Calls())
+	}
+}
+
+// The purge summary must report a failed recreate clearly and must NEVER include
+// the raw Discord response body. A 5xx recreate failure is routed through the
+// classifier, so the summary carries a sanitized phrase, not "HTTP 500, {json}".
+func TestRunWardenPurge_RecreateFailureSummaryHasNoRawBody(t *testing.T) {
+	noOverwriteDelay(t)
+	captureCount, _ := installCountingCapture(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("old-int", wardenRoleBaseName+" Internal")},
+		// Create fails with a 5xx carrying a raw body that must not leak.
+		RoleCreateErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1")
+
+	runWardenPurge(f, gm, i, "guild-1", "internal")
+
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Failed to recreate 'Verified Warden Internal'") {
+		t.Fatalf("expected a clear failed-recreate line, got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) || strings.Contains(got, "HTTP 500") {
+		t.Fatalf("summary must not contain the raw Discord body, got %q", got)
+	}
+	// A 5xx is a genuine system fault: it must be captured exactly once.
+	if *captureCount != 1 {
+		t.Fatalf("expected the system fault to be captured once, got %d", *captureCount)
+	}
+}
+
+// A 4xx recreate failure (client/config fault, e.g. missing permissions) is
+// reported clearly but must NOT page Sentry and must not leak the body.
+func TestRunWardenPurge_RecreateClientFaultNotCaptured(t *testing.T) {
+	noOverwriteDelay(t)
+	captureCount, _ := installCountingCapture(t)
+	gm := &fakeGuildManager{
+		roles:          []*discordgo.Role{wardenRole("old-int", wardenRoleBaseName+" Internal")},
+		RoleCreateErrs: []error{restError(http.StatusForbidden, 0, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1")
+
+	runWardenPurge(f, gm, i, "guild-1", "internal")
+
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Failed to recreate 'Verified Warden Internal'") {
+		t.Fatalf("expected a clear failed-recreate line, got %q", got)
+	}
+	// A 403 must carry the permission-specific hint, not just the generic prefix.
+	if !strings.Contains(got, "missing permissions") || !strings.Contains(got, "Manage Roles") {
+		t.Fatalf("expected the permission-specific hint for a 403, got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) || strings.Contains(got, "HTTP 403") {
+		t.Fatalf("summary must not contain the raw Discord body, got %q", got)
+	}
+	if *captureCount != 0 {
+		t.Fatalf("a 4xx client fault must not be captured to Sentry, got %d", *captureCount)
+	}
+}
+
+// When create + overwrites succeed but deleting the OLD role fails, the new role
+// was created (a duplicate now exists). The summary must say the recreate
+// happened and the old role lingers / needs manual cleanup — NOT "the role was
+// not recreated", which would be the inverse of the truth.
+func TestRunWardenPurge_OldRoleDeleteFailureReportsLingeringRole(t *testing.T) {
+	noOverwriteDelay(t)
+	captureCount, _ := installCountingCapture(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("old-int", wardenRoleBaseName+" Internal")},
+		// No channels -> no overwrites to re-apply; create succeeds, then the
+		// old-role delete fails with a 5xx carrying a raw body.
+		RoleDeleteErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+	i := wardenInteraction("guild-1")
+
+	runWardenPurge(f, gm, i, "guild-1", "internal")
+
+	got := lastEditContent(f.Calls())
+	// Must report the recreate as having happened, with a lingering old role.
+	if strings.Contains(got, "the role was not recreated") || strings.Contains(got, "The role was not recreated") {
+		t.Fatalf("must NOT claim the role was not recreated (it was); got %q", got)
+	}
+	if !strings.Contains(got, "Recreated 'Verified Warden Internal'") {
+		t.Fatalf("expected the recreate to be reported as done, got %q", got)
+	}
+	if !strings.Contains(got, "could not be deleted") || !strings.Contains(got, "manually") {
+		t.Fatalf("expected a lingering-old-role / manual-cleanup notice, got %q", got)
+	}
+	// The leftover old role id must be named so the operator can find it.
+	if !strings.Contains(got, "old-int") {
+		t.Fatalf("expected the lingering old role id in the summary, got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) || strings.Contains(got, "HTTP 500") {
+		t.Fatalf("summary must not contain the raw Discord body, got %q", got)
+	}
+	// A 5xx delete failure is a genuine system fault: capture it once.
+	if *captureCount != 1 {
+		t.Fatalf("expected the system fault to be captured once, got %d", *captureCount)
+	}
+}
+
+// Edge case: the overwrite step fails (forcing the orphan-cleanup path) AND the
+// cleanup delete of the new role also fails. The function must still return the
+// ORIGINAL "reapply overwrites" error (the cleanup-delete error is logged, not
+// returned, so it can't mask the real cause) and must return normally without a
+// panic.
+func TestRecreateRole_CleanupDeleteAlsoFailsReturnsOriginalError(t *testing.T) {
+	noOverwriteDelay(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("old-int", wardenRoleBaseName+" Internal")},
+		channels: []*discordgo.Channel{
+			{
+				ID: "chan-1",
+				PermissionOverwrites: []*discordgo.PermissionOverwrite{
+					{ID: "old-int", Type: discordgo.PermissionOverwriteTypeRole, Allow: 1, Deny: 0},
+				},
+			},
+		},
+		// Overwrite re-apply fails -> triggers orphan cleanup.
+		ChannelPermSetErrs: []error{restError(http.StatusInternalServerError, 0, "overwrite-boom")},
+		// The cleanup delete of the NEW role then also fails.
+		RoleDeleteErrs: []error{restError(http.StatusInternalServerError, 0, "delete-boom")},
+	}
+
+	newRoleID, _, err := recreateRoleWithChannelOverwrites(gm, "guild-1", "old-int", gm.channels)
+	if err == nil {
+		t.Fatal("expected an error when the overwrite step fails")
+	}
+	// The returned error must be the original overwrite failure, not the
+	// secondary cleanup-delete failure.
+	if !strings.Contains(err.Error(), "reapply overwrites") {
+		t.Fatalf("expected the original 'reapply overwrites' error to surface, got %v", err)
+	}
+	if strings.Contains(err.Error(), "delete-boom") {
+		t.Fatalf("the secondary cleanup-delete error must not mask the original cause, got %v", err)
+	}
+	// On this path nothing usable was left -> newRoleID is empty, so runWardenPurge
+	// reports "not recreated" rather than a lingering-role notice.
+	if newRoleID != "" {
+		t.Fatalf("overwrite-failure path must report no usable new role, got newRoleID %q", newRoleID)
+	}
+	// The cleanup was attempted exactly once (and failed).
+	if gm.countCalls("GuildRoleDelete") != 1 {
+		t.Fatalf("expected exactly one (failed) cleanup delete, got %d (%v)", gm.countCalls("GuildRoleDelete"), gm.Calls())
+	}
+}

--- a/commands/warden_test.go
+++ b/commands/warden_test.go
@@ -31,9 +31,13 @@ type fakeGuildManager struct {
 	// surface) so a test can assert what was delivered, and where.
 	channelMessages []sentChannelMessage
 
+	// deletedRoleIDs records the roleID of every GuildRoleDelete call, so a test
+	// can assert WHICH role a recreate failure cleaned up (the new orphan, not
+	// the old role).
+	deletedRoleIDs []string
+
 	RolesErrs            []error
 	RoleCreateErrs       []error
-	RoleEditErrs         []error
 	RoleDeleteErrs       []error
 	ChannelsErrs         []error
 	ChannelPermSetErrs   []error
@@ -92,17 +96,24 @@ func (g *fakeGuildManager) GuildRoleCreate(_ string, _ *discordgo.RoleParams) (*
 	return &discordgo.Role{ID: fmt.Sprintf("new-role-%d", g.nextCreatedNum)}, nil
 }
 
-func (g *fakeGuildManager) GuildRoleEdit(_, _ string, _ *discordgo.RoleParams) (*discordgo.Role, error) {
-	g.record("GuildRoleEdit")
-	if err := popErr(&g.RoleEditErrs); err != nil {
-		return nil, err
-	}
-	return &discordgo.Role{}, nil
+func (g *fakeGuildManager) GuildRoleDelete(_, roleID string) error {
+	g.record("GuildRoleDelete")
+	g.mu.Lock()
+	g.deletedRoleIDs = append(g.deletedRoleIDs, roleID)
+	g.mu.Unlock()
+	return popErr(&g.RoleDeleteErrs)
 }
 
-func (g *fakeGuildManager) GuildRoleDelete(_, _ string) error {
-	g.record("GuildRoleDelete")
-	return popErr(&g.RoleDeleteErrs)
+// lastDeletedRoleID returns the roleID of the most recent GuildRoleDelete call,
+// or "" if none. Lets a test assert a recreate failure deleted the new orphan
+// role rather than the old role.
+func (g *fakeGuildManager) lastDeletedRoleID() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.deletedRoleIDs) == 0 {
+		return ""
+	}
+	return g.deletedRoleIDs[len(g.deletedRoleIDs)-1]
 }
 
 func (g *fakeGuildManager) GuildChannels(_ string) ([]*discordgo.Channel, error) {
@@ -283,7 +294,8 @@ func TestRunWardenPurge_HappyPath(t *testing.T) {
 
 	runWardenPurge(f, gm, i, "guild-1", "internal")
 
-	// Role recreated: create + edit + one overwrite reapply + delete old.
+	// Role recreated: create + one overwrite reapply + delete old. No redundant
+	// edit (the create sets every field) — see #178.
 	if gm.countCalls("GuildRoleCreate") != 1 {
 		t.Fatalf("expected 1 GuildRoleCreate, got %v", gm.Calls())
 	}


### PR DESCRIPTION
Closes #178.

`recreateRoleWithChannelOverwrites` created a new role with `GuildRoleCreate`, then re-set the same fields with a second `GuildRoleEdit`. If that edit failed, the new role already existed and the old one wasn't deleted yet, so the guild was left with a duplicate orphan role, member overwrites split across two roles, and a summary that showed the raw Discord error.

`GuildRoleCreate` already sets name, color, hoist, mentionable, and permissions in one call, so the second edit was a no-op. Dropping it closes that failure window completely, and the now-unused `GuildRoleEdit` came off the `GuildManager` interface, its adapter, and the fake.

The remaining post-create steps are handled so a failure never leaves an orphan:

- An overwrite re-application failure deletes the freshly created role via `cleanupOrphanRole` before returning. If that cleanup delete itself fails, it logs at WARN and the original overwrite error is still what the caller sees, so the real cause is never masked.
- A failure to delete the OLD role is the one case where the new role is kept, because it is the finished keeper and discarding it would throw away a completed recreate. The summary now says so plainly: the role was recreated, but the old one could not be removed and lingers, so delete it manually. Earlier this read "the role was not recreated," which was the opposite of the truth.

The summary error runs through the #171 classifier, so no raw `HTTP ..., {json}` body reaches the operator and only genuine system faults page Sentry.

Tests cover the overwrite-failure cleanup (new role deleted, old role untouched), the cleanup-delete-also-fails case (original error preserved, no panic), the old-role-delete-failure partial state (summary names the lingering role, not "not recreated"), the no-raw-body property, the 5xx-captures / 4xx-does-not split, the permission-specific 403 hint, and a happy path with no redundant edit.

> *This was generated by AI*