### PR TITLE
fix(warden): guard against nil Member in runWarden entry log via a shared safe-user helper

### DIFF
--- a/commands/interaction_user.go
+++ b/commands/interaction_user.go
@@ -1,0 +1,37 @@
+package commands
+
+import "github.com/bwmarrin/discordgo"
+
+// interactionUser safely extracts the invoking *discordgo.User from an
+// interaction, with no nil dereference for any context.
+//
+// Discord populates interaction.Member (with Member.User) for GUILD interactions
+// and interaction.User for DM interactions; for a guild interaction
+// interaction.User is typically nil and vice versa. So the safe extraction
+// prefers Member.User when present, falls back to interaction.User, and returns
+// nil when neither is available (a malformed or forwarded interaction).
+//
+// Command entry points read username/discord_id off the interaction for their
+// "🚀 Starting ..." log line; doing so directly (interaction.Member.User.…)
+// panics for a member-less interaction. Route those reads through this helper.
+func interactionUser(i *discordgo.InteractionCreate) *discordgo.User {
+	if i == nil || i.Interaction == nil {
+		return nil
+	}
+	if i.Member != nil && i.Member.User != nil {
+		return i.Member.User
+	}
+	return i.User
+}
+
+// interactionUsernameAndID returns the invoking user's username and ID, or empty
+// strings when no user can be resolved. It is the convenience pair for entry-log
+// fields ("username"/"discord_id"), built on interactionUser so the nil-safety
+// lives in one place.
+func interactionUsernameAndID(i *discordgo.InteractionCreate) (username, id string) {
+	user := interactionUser(i)
+	if user == nil {
+		return "", ""
+	}
+	return user.Username, user.ID
+}

--- a/commands/warden.go
+++ b/commands/warden.go
@@ -78,7 +78,22 @@ func runWarden(
 	gm GuildManager,
 	interaction *discordgo.InteractionCreate,
 ) {
-	utils.Info("🚀 Starting Warden", "command", "Warden", "username", interaction.Member.User.Username, "discord_id", interaction.Member.User.ID)
+	// Guild-context guard runs FIRST, before any read of interaction.Member.
+	// Warden requires guild context, and Discord only populates Member for guild
+	// interactions; a DM-shaped or malformed interaction has a nil Member and a
+	// nil GuildID. Rejecting on the empty GuildID here both gives a clear
+	// server-only message and removes the latent nil-deref the entry log would
+	// otherwise hit (#177).
+	guildID := interaction.GuildID
+	if guildID == "" {
+		utils.HandleError(r, interaction, "❌ This command can only be used in a server (guild).")
+		return
+	}
+
+	// Entry log reads the invoking user through the nil-safe helper rather than
+	// interaction.Member.User directly, so it never panics regardless of context.
+	username, discordID := interactionUsernameAndID(interaction)
+	utils.Info("🚀 Starting Warden", "command", "Warden", "username", username, "discord_id", discordID)
 
 	commandData := interaction.ApplicationCommandData()
 
@@ -99,12 +114,6 @@ func runWarden(
 			interaction,
 			"❌ Missing or invalid flag argument; must be 'internal', 'external', or 'both'",
 		)
-		return
-	}
-
-	guildID := interaction.GuildID
-	if guildID == "" {
-		utils.HandleError(r, interaction, "❌ This command can only be used in a server (guild).")
 		return
 	}
 

--- a/commands/warden_test.go
+++ b/commands/warden_test.go
@@ -198,6 +198,17 @@ func lastEditContent(calls []recordedCall) string {
 	return "<none>"
 }
 
+// lastResponseContent returns the Content of the last immediate Respond call
+// (the surface utils.HandleError uses for an un-deferred rejection), or "<none>".
+func lastResponseContent(calls []recordedCall) string {
+	for idx := len(calls) - 1; idx >= 0; idx-- {
+		if calls[idx].Method == "Respond" && calls[idx].Response != nil && calls[idx].Response.Data != nil {
+			return calls[idx].Response.Data.Content
+		}
+	}
+	return "<none>"
+}
+
 // --- runWarden routing / deferred-ephemeral acknowledge path ---
 
 func TestRunWarden_AddDeferredEphemeralAcknowledge(t *testing.T) {
@@ -271,6 +282,127 @@ func TestRunWarden_MissingGuildIDRejected(t *testing.T) {
 
 	if len(gm.Calls()) != 0 {
 		t.Fatalf("DM-context must not touch guild; got %v", gm.Calls())
+	}
+}
+
+// A DM-shaped interaction has a nil Member (Discord populates interaction.User
+// instead). The entry-log read of Member.User must not panic, and the
+// guild-context guard must reject it with a clear server-only message before any
+// guild call. Regression for #177.
+func TestRunWarden_NilMemberDMContextRejectedWithoutPanic(t *testing.T) {
+	gm := &fakeGuildManager{}
+	f := &fakeResponder{}
+	// DM context: no Member, no GuildID, User set instead.
+	i := fakeAppCommandInteraction(
+		stringOption("command", "add"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "x"),
+	)
+	i.Member = nil
+	i.User = &discordgo.User{ID: "555", Username: "dmuser"}
+
+	runWarden(f, gm, i) // must not panic on the entry-log Member deref
+
+	if len(gm.Calls()) != 0 {
+		t.Fatalf("nil-Member DM context must not touch guild; got %v", gm.Calls())
+	}
+	if got := lastResponseContent(f.Calls()); !strings.Contains(got, "can only be used in a server") {
+		t.Fatalf("expected a clear server-only rejection, got %q", got)
+	}
+}
+
+// The fully malformed case: both Member and User are nil (e.g. a forwarded or
+// crafted interaction). The entry log must still not panic, and the command must
+// reject rather than mutate anything. Regression for #177.
+func TestRunWarden_NilMemberAndUserDoesNotPanic(t *testing.T) {
+	gm := &fakeGuildManager{}
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(
+		stringOption("command", "add"),
+		stringOption("flag", "internal"),
+		stringOption("discordname", "x"),
+	)
+	i.Member = nil
+	i.User = nil
+
+	runWarden(f, gm, i) // must not panic with both nil
+
+	if len(gm.Calls()) != 0 {
+		t.Fatalf("malformed interaction must not touch guild; got %v", gm.Calls())
+	}
+	if got := lastResponseContent(f.Calls()); !strings.Contains(got, "can only be used in a server") {
+		t.Fatalf("expected a clear server-only rejection, not a silent/empty response, got %q", got)
+	}
+}
+
+func TestInteractionUser(t *testing.T) {
+	member := &discordgo.User{ID: "1", Username: "guildy"}
+	dm := &discordgo.User{ID: "2", Username: "dmy"}
+
+	tests := []struct {
+		name     string
+		i        *discordgo.InteractionCreate
+		wantUser *discordgo.User
+	}{
+		{
+			name:     "guild interaction prefers Member.User",
+			i:        &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{Member: &discordgo.Member{User: member}, User: dm}},
+			wantUser: member,
+		},
+		{
+			name:     "DM interaction falls back to User",
+			i:        &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{User: dm}},
+			wantUser: dm,
+		},
+		{
+			name:     "Member present but its User nil falls back to User",
+			i:        &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{Member: &discordgo.Member{}, User: dm}},
+			wantUser: dm,
+		},
+		{
+			name:     "both nil yields nil",
+			i:        &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{}},
+			wantUser: nil,
+		},
+		{
+			name:     "nil interaction yields nil",
+			i:        nil,
+			wantUser: nil,
+		},
+		{
+			name:     "nil inner Interaction yields nil",
+			i:        &discordgo.InteractionCreate{},
+			wantUser: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := interactionUser(tc.i); got != tc.wantUser {
+				t.Fatalf("interactionUser = %v, want %v", got, tc.wantUser)
+			}
+		})
+	}
+}
+
+func TestInteractionUsernameAndID(t *testing.T) {
+	guild := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Member: &discordgo.Member{User: &discordgo.User{ID: "1", Username: "guildy"}},
+	}}
+	if name, id := interactionUsernameAndID(guild); name != "guildy" || id != "1" {
+		t.Fatalf("guild: got (%q, %q), want (guildy, 1)", name, id)
+	}
+
+	dm := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		User: &discordgo.User{ID: "2", Username: "dmy"},
+	}}
+	if name, id := interactionUsernameAndID(dm); name != "dmy" || id != "2" {
+		t.Fatalf("dm: got (%q, %q), want (dmy, 2)", name, id)
+	}
+
+	none := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{}}
+	if name, id := interactionUsernameAndID(none); name != "" || id != "" {
+		t.Fatalf("none: got (%q, %q), want empty strings", name, id)
 	}
 }
 


### PR DESCRIPTION
Closes #177.

`runWarden`'s first statement read `interaction.Member.User.Username` and `.ID` for the "Starting Warden" log line, and the guild-context guard ran after it. Warden is registered guild-scoped today, so Discord always populates `Member` and this never fired, but a DM-context or malformed interaction with a nil `Member` would have panicked before the guard. The dispatcher's `RecoverPanic` would have caught it one layer up, so the operator got a Sentry page and no reply instead of a clear message.

Two changes:

- The existing `GuildID == ""` guard now runs first, so a member-less interaction is rejected with the existing "can only be used in a server" ephemeral message before anything reads `Member`. On a real guild interaction the guard is a no-op, so the path is unchanged.
- A new `commands/interaction_user.go` adds `interactionUser(i) *discordgo.User` (prefers `Member.User`, falls back to `i.User`, nil-safe at every level including a nil inner `Interaction`) and `interactionUsernameAndID(i) (string, string)`. The entry log uses the helper, so even a guild interaction that somehow arrived with a nil `Member` logs blank fields rather than crashing.

The helper is the shared seam the issue describes; the other commands with the same raw `i.Member.User` entry-log read are left for a separate change.

Tests drive the nil-Member DM case and the both-nil malformed case through `runWarden` (no panic, the server-only rejection is surfaced, no guild calls), unit-test the helper across every nil branch, and keep the guild happy path as the regression guard.

> *This was generated by AI*