### PR TITLE
fix(warden): make findGuildRoleIDByName not-found result explicit

### DIFF
--- a/commands/warden.go
+++ b/commands/warden.go
@@ -638,11 +638,11 @@ func resolveWardenRoleIDs(
 
 	for _, roleName := range roleNames {
 		roleID, findErr := findGuildRoleIDByName(gm, guildID, roleName)
+		if errors.Is(findErr, errRoleNotFound) {
+			return nil, nil, fmt.Errorf("❌ '%s' role not found in guild", roleName)
+		}
 		if findErr != nil {
 			return nil, nil, fmt.Errorf("❌ Failed to retrieve guild roles: %v", findErr)
-		}
-		if roleID == "" {
-			return nil, nil, fmt.Errorf("❌ '%s' role not found in guild", roleName)
 		}
 		roleIDs = append(roleIDs, roleID)
 	}
@@ -847,6 +847,15 @@ func resolveMemberByID(gm GuildManager, guildID, userID string) (*discordgo.Memb
 	return member, nil
 }
 
+// errRoleNotFound is the sentinel findGuildRoleIDByName returns when no guild
+// role matches the requested name. It makes the not-found case explicit and
+// checkable (errors.Is) so a caller cannot misread it as success, and keeps it
+// distinct from a genuine GuildRoles API failure (which surfaces as a different,
+// wrapped error). See ADR 0002 / the "empty vs failure" invariant: ("",
+// errRoleNotFound) means definitively absent; ("", someOtherErr) means upstream
+// failure; (id, nil) means found.
+var errRoleNotFound = errors.New("role not found")
+
 func findGuildRoleIDByName(gm GuildManager, guildID, roleName string) (string, error) {
 	roles, err := gm.GuildRoles(guildID)
 	if err != nil {
@@ -859,7 +868,7 @@ func findGuildRoleIDByName(gm GuildManager, guildID, roleName string) (string, e
 		}
 	}
 
-	return "", nil
+	return "", fmt.Errorf("%q: %w", roleName, errRoleNotFound)
 }
 
 func splitCommaSeparated(value string) []string {

--- a/commands/warden_rolelookup_test.go
+++ b/commands/warden_rolelookup_test.go
@@ -1,0 +1,120 @@
+package commands
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// --- findGuildRoleIDByName: explicit not-found contract (#180) ---
+
+// A matching role returns its id, no error, and the not-found sentinel is NOT
+// reported. This is the "found" branch.
+func TestFindGuildRoleIDByName_Found(t *testing.T) {
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("role-abc", "Verified Warden Internal")},
+	}
+
+	id, err := findGuildRoleIDByName(gm, "guild-1", "Verified Warden Internal")
+	if err != nil {
+		t.Fatalf("found role should not error, got %v", err)
+	}
+	if id != "role-abc" {
+		t.Fatalf("expected id %q, got %q", "role-abc", id)
+	}
+}
+
+// No matching role returns the explicit errRoleNotFound sentinel — NOT a bare
+// empty-string-with-nil-error. This is the contract change #180 is about: a
+// missing role must be a distinct, checkable signal a caller cannot misread as
+// success.
+func TestFindGuildRoleIDByName_NotFoundIsExplicit(t *testing.T) {
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("other", "Some Other Role")},
+	}
+
+	id, err := findGuildRoleIDByName(gm, "guild-1", "Verified Warden Internal")
+	if !errors.Is(err, errRoleNotFound) {
+		t.Fatalf("not-found must return errRoleNotFound sentinel, got err=%v id=%q", err, id)
+	}
+}
+
+// A genuine GuildRoles API failure returns a real error that is distinguishable
+// from not-found: it must NOT satisfy errors.Is(err, errRoleNotFound), so a
+// caller cannot mistake an upstream fault for "role absent". The underlying
+// error is wrapped/passed through unchanged for capture.
+func TestFindGuildRoleIDByName_APIErrorIsNotNotFound(t *testing.T) {
+	apiErr := errors.New("boom: guild roles unavailable")
+	gm := &fakeGuildManager{RolesErrs: []error{apiErr}}
+
+	_, err := findGuildRoleIDByName(gm, "guild-1", "Verified Warden Internal")
+	if err == nil {
+		t.Fatal("API failure must return a non-nil error")
+	}
+	if errors.Is(err, errRoleNotFound) {
+		t.Fatal("API failure must NOT be classified as errRoleNotFound")
+	}
+	if !errors.Is(err, apiErr) {
+		t.Fatalf("API failure must surface the underlying error, got %v", err)
+	}
+}
+
+// --- resolveWardenRoleIDs: each user-facing outcome unchanged (#180) ---
+
+// Found: resolveWardenRoleIDs returns the resolved ids and names, no error.
+func TestResolveWardenRoleIDs_Found(t *testing.T) {
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+	}
+
+	ids, names, err := resolveWardenRoleIDs(gm, "guild-1", "internal")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "r-int" {
+		t.Fatalf("expected [r-int], got %v", ids)
+	}
+	if len(names) != 1 || names[0] != wardenRoleBaseName+" Internal" {
+		t.Fatalf("unexpected names %v", names)
+	}
+}
+
+// Not-found: resolveWardenRoleIDs surfaces the same distinct "role not found in
+// guild" message as before, naming the missing role.
+func TestResolveWardenRoleIDs_NotFoundMessageUnchanged(t *testing.T) {
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("other", "Some Other Role")},
+	}
+
+	_, _, err := resolveWardenRoleIDs(gm, "guild-1", "internal")
+	if err == nil {
+		t.Fatal("expected role-not-found error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "role not found in guild") {
+		t.Fatalf("expected role-not-found message, got %q", got)
+	}
+	if !strings.Contains(got, wardenRoleBaseName+" Internal") {
+		t.Fatalf("not-found message must name the missing role, got %q", got)
+	}
+}
+
+// API error: a genuine GuildRoles failure surfaces the distinct "Failed to
+// retrieve guild roles" message — it is NOT silently treated as not-found.
+func TestResolveWardenRoleIDs_APIErrorMessageUnchanged(t *testing.T) {
+	gm := &fakeGuildManager{RolesErrs: []error{errors.New("boom")}}
+
+	_, _, err := resolveWardenRoleIDs(gm, "guild-1", "internal")
+	if err == nil {
+		t.Fatal("expected guild-roles API error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "Failed to retrieve guild roles") {
+		t.Fatalf("expected API-failure message, got %q", got)
+	}
+	if strings.Contains(got, "role not found") {
+		t.Fatalf("API failure must not be reported as not-found, got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #180.

`findGuildRoleIDByName` signaled "no role matched" by returning an empty string with a nil error, so the caller had to remember to check for the empty string. The current caller does check, so behavior was correct, but the contract is the empty-vs-failure footgun this codebase has been bitten by before: a future caller that forgets the check would read a missing role as success.

Not-found is now an explicit, checkable sentinel. The helper keeps its `(string, error)` shape and returns a wrapped `errRoleNotFound` when no role matches, while a genuine `GuildRoles` API failure is still returned as its own unwrapped error. `resolveWardenRoleIDs` checks `errors.Is(err, errRoleNotFound)` first for its existing "role not found in guild" message, falls through to the existing "Failed to retrieve guild roles" message for any other error, and otherwise appends the id. The three user-facing outcomes are unchanged, and an API fault can no longer be mistaken for a missing role.

Tests cover found, not-found (asserting the sentinel, not a bare empty-and-nil), and a genuine API failure (asserting it is NOT the not-found sentinel), at both the helper and the `resolveWardenRoleIDs` layer.

> *This was generated by AI*