### PR TITLE
chore: gitignore the cavbot2 build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 WARP.md
 .claude/
 docs/superpowers/
+
+# build artifact from `go build -o cavbot2`
+/cavbot2


### PR DESCRIPTION
## What

`go build -o cavbot2` writes the binary to the repo root, where it was not gitignored. A routine `git add -A` could stage it by accident.

This adds a root-anchored `/cavbot2` to `.gitignore` so the build artifact stays out of git.

## Why the anchor

The leading slash matches only the root binary. A nested file named `cavbot2` or a `cavbot2/` directory is left alone, and no currently tracked file becomes ignored.

## Verification

- `go build -o cavbot2`, then `git status` is clean (binary ignored).
- `git ls-files -ci --exclude-standard` reports nothing, so no tracked file is newly ignored.
- Full CI gate green: lint, `go mod tidy` no-op, `go test -race`, coverage floors, build.

Closes #192

> *This was generated by AI*
