### PR TITLE
fix(warden): capture genuine GuildRoles faults in resolveWardenRoleIDs

### DIFF
--- a/commands/warden.go
+++ b/commands/warden.go
@@ -663,7 +663,14 @@ func resolveWardenRoleIDs(
 			return nil, nil, fmt.Errorf("❌ '%s' role not found in guild", roleName)
 		}
 		if findErr != nil {
-			return nil, nil, fmt.Errorf("❌ Failed to retrieve guild roles: %v", findErr)
+			// A genuine GuildRoles fault (5xx/transport) is classified and captured
+			// to Sentry; a 4xx stays a non-captured actionable message. The not-found
+			// branch above is handled first, so it never reaches here (#194).
+			return nil, nil, roleResolveErrorReply(
+				findErr,
+				"Failed to retrieve guild roles for warden role resolution",
+				"command", "warden", "guild", guildID, "role", roleName,
+			)
 		}
 		roleIDs = append(roleIDs, roleID)
 	}

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -174,6 +174,23 @@ func purgePartialDeleteSummary(roleName, newRoleID, oldRoleID string, err error,
 	)
 }
 
+// roleResolveErrorReply classifies a GuildRoles lookup failure raised while
+// resolving a warden role by name, captures it to Sentry only for genuine system
+// faults (5xx/transport, per ADR 0001), and returns a body-free, operator-facing
+// error. The explicit not-found result is handled by the caller before this is
+// reached and is deliberately never routed here, so it stays non-captured. The
+// raw Discord response body (discordgo's "HTTP <status>, <json>") is never
+// interpolated — only a sanitized classifier phrase is shown. captureMsg/kv carry
+// the call site's command/guild context to Sentry.
+func roleResolveErrorReply(err error, captureMsg string, kv ...any) error {
+	class := classifyDiscordError(err)
+	if class.SystemFault {
+		captureError(captureMsg, err, kv...)
+		return errors.New("❌ Failed to retrieve guild roles (Discord error); please try again shortly")
+	}
+	return fmt.Errorf("❌ Failed to retrieve guild roles (%s)", class.UserDetail)
+}
+
 // roleMutationErrorReply classifies a role add/remove failure, captures it to
 // Sentry only for genuine system faults, and returns a body-free, actionable
 // message. A 403 yields a specific role-hierarchy hint — the common cause is the

--- a/commands/warden_resterror_test.go
+++ b/commands/warden_resterror_test.go
@@ -247,16 +247,33 @@ func TestFindGuildMember_MentionGeneric4xxNoCapture(t *testing.T) {
 
 // captureRecorder swaps the package-level captureError seam for the duration of
 // a test and counts how many times it fires, so a test can assert the
-// 4xx-vs-5xx Sentry split without a live Sentry client.
+// 4xx-vs-5xx Sentry split without a live Sentry client. lastKV holds the kv
+// varargs from the most recent capture, so a test can also pin the context
+// fields (command/guild/role) a site is required to forward.
 type captureRecorder struct {
-	count int
+	count  int
+	lastKV []any
 }
 
 func (c *captureRecorder) install(t *testing.T) {
 	t.Helper()
 	prev := captureError
-	captureError = func(msg string, err error, kv ...any) { c.count++ }
+	captureError = func(msg string, err error, kv ...any) {
+		c.count++
+		c.lastKV = kv
+	}
 	t.Cleanup(func() { captureError = prev })
+}
+
+// kvValue returns the value paired with key in a sequential key/value vararg
+// slice (k0, v0, k1, v1, ...), and whether it was present.
+func kvValue(kv []any, key string) (any, bool) {
+	for i := 0; i+1 < len(kv); i += 2 {
+		if k, ok := kv[i].(string); ok && k == key {
+			return kv[i+1], true
+		}
+	}
+	return nil, false
 }
 
 // --- search path: 4xx vs 5xx split ---

--- a/commands/warden_roleresolve_capture_test.go
+++ b/commands/warden_roleresolve_capture_test.go
@@ -1,0 +1,108 @@
+package commands
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// --- resolveWardenRoleIDs: GuildRoles fault capture split (#194) ---
+//
+// The GuildRoles lookup inside resolveWardenRoleIDs must route a genuine system
+// fault (5xx/transport) through the shared classifier and capture it to Sentry
+// (per ADR 0001), while a 4xx stays a non-captured actionable message and the
+// explicit not-found result remains non-captured. The raw Discord body must
+// never reach the operator-facing message.
+
+// A 5xx from GuildRoles during role resolution is a genuine Discord-side fault:
+// it must capture to Sentry exactly once, show a body-free generic retry
+// message, and never leak the raw Discord response body.
+func TestResolveWardenRoleIDs_GuildRoles5xxCaptures(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{RolesErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)}}
+
+	_, _, err := resolveWardenRoleIDs(gm, "guild-1", "internal")
+	if err == nil {
+		t.Fatal("expected an error from a 5xx GuildRoles lookup")
+	}
+	if rec.count != 1 {
+		t.Fatalf("a 5xx GuildRoles fault must capture to Sentry exactly once; got %d", rec.count)
+	}
+	if strings.Contains(err.Error(), rawBodyMarker) {
+		t.Fatalf("role resolution leaked the raw Discord body: %q", err.Error())
+	}
+	// #194 requires command+guild context on the capture; pin those plus role.
+	for key, want := range map[string]string{
+		"command": "warden",
+		"guild":   "guild-1",
+		"role":    wardenRoleBaseName + " Internal",
+	} {
+		got, ok := kvValue(rec.lastKV, key)
+		if !ok {
+			t.Fatalf("capture context missing %q; got kv %v", key, rec.lastKV)
+		}
+		if got != want {
+			t.Fatalf("capture context %q = %v, want %q", key, got, want)
+		}
+	}
+}
+
+// A transport (non-REST) failure from GuildRoles is also a system fault: capture
+// once, no raw body leak.
+func TestResolveWardenRoleIDs_GuildRolesTransportErrorCaptures(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{RolesErrs: []error{errors.New("dial tcp: connection refused")}}
+
+	_, _, err := resolveWardenRoleIDs(gm, "guild-1", "internal")
+	if err == nil {
+		t.Fatal("expected an error from a transport GuildRoles failure")
+	}
+	if rec.count != 1 {
+		t.Fatalf("a transport GuildRoles fault must capture to Sentry exactly once; got %d", rec.count)
+	}
+}
+
+// A 4xx from GuildRoles is an operator/config-fixable client fault: it must
+// surface an actionable, body-free message and must NOT capture to Sentry.
+func TestResolveWardenRoleIDs_GuildRoles4xxDoesNotCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{RolesErrs: []error{restError(http.StatusBadRequest, 50035, rawBodyMarker)}}
+
+	_, _, err := resolveWardenRoleIDs(gm, "guild-1", "internal")
+	if err == nil {
+		t.Fatal("expected an error from a 4xx GuildRoles lookup")
+	}
+	if rec.count != 0 {
+		t.Fatalf("a 4xx GuildRoles fault must NOT capture to Sentry; got %d", rec.count)
+	}
+	if strings.Contains(err.Error(), rawBodyMarker) {
+		t.Fatalf("role resolution leaked the raw Discord body: %q", err.Error())
+	}
+}
+
+// The explicit not-found result (the role simply isn't in the guild) is not a
+// fault and must NOT capture to Sentry; the not-found message is preserved.
+func TestResolveWardenRoleIDs_NotFoundDoesNotCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("other", "Some Other Role")},
+	}
+
+	_, _, err := resolveWardenRoleIDs(gm, "guild-1", "internal")
+	if err == nil {
+		t.Fatal("expected a role-not-found error")
+	}
+	if rec.count != 0 {
+		t.Fatalf("an explicit not-found result must NOT capture to Sentry; got %d", rec.count)
+	}
+	if !strings.Contains(err.Error(), "role not found in guild") {
+		t.Fatalf("expected the not-found message, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
## What

`resolveWardenRoleIDs` resolves warden role IDs by name. When the underlying `GuildRoles` call failed with a genuine system fault (5xx or transport), it showed the operator a generic message but never classified the error or captured it to Sentry, so a real Discord outage during role resolution left on-call with no signal. It also interpolated the raw error into the operator message with `%v`, leaking the Discord response body.

## Change

The failing branch now routes through the existing `classifyDiscordError` / `captureError` seam via a new `roleResolveErrorReply` helper, matching the sibling warden sites (member search, role add/remove).

- 5xx or transport fault: captured to Sentry with command, guild, and role context; the operator sees a body-free retry message.
- 4xx: non-captured actionable message built from the sanitized classifier detail, no raw body.
- not-found: unchanged, stays non-captured (intercepted before the new branch).

This follows ADR 0001, which scopes manual Sentry capture to genuine system faults.

## Tests

New `commands/warden_roleresolve_capture_test.go` covers the split:

- 5xx captures exactly once, with command/guild/role context asserted and no body leak.
- transport error captures exactly once.
- 4xx does not capture, no body leak.
- not-found does not capture, message preserved.

## Verification

Full CI gate green: lint, `go mod tidy` no-op, `go test -race -cover`, coverage floors (commands 86.3%, utils 90.6%), build.

Follow-up #195 tracks the same pattern at the sibling `GuildChannels` call in `runWardenPurge`.

Closes #194

> *This was generated by AI*
