### PR TITLE
fix(commands): capture post-defer edit failures instead of retrying

### DIFF
--- a/commands/afsm.go
+++ b/commands/afsm.go
@@ -175,8 +175,7 @@ func runAFSM(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
 	if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 		Content: &response,
 	}); err != nil {
-		utils.CaptureError("❌ Response edit failed", err)
-		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+		captureDeferredEditFailure(i, "AFSM", err)
 		return
 	}
 	utils.Info("✨ Done!", "command", "AFSM", "department", choice)

--- a/commands/awol.go
+++ b/commands/awol.go
@@ -265,7 +265,7 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 		if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 			Content: &response,
 		}); err != nil {
-			utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+			captureDeferredEditFailure(i, "Awol", err)
 		}
 		return
 	}
@@ -334,7 +334,7 @@ func runAwol(r utils.InteractionResponder, cache loaCacheReader, now time.Time, 
 		Content: nil,
 		Embeds:  &embeds,
 	}); err != nil {
-		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+		captureDeferredEditFailure(i, "Awol", err)
 		return
 	}
 
@@ -444,6 +444,6 @@ func sendAwolFile(r utils.InteractionResponder, i *discordgo.InteractionCreate, 
 		Content: stringPtr(prefix),
 		Files:   []*discordgo.File{file},
 	}); err != nil {
-		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to send file: %v", err))
+		captureDeferredEditFailure(i, "Awol", err)
 	}
 }

--- a/commands/gamertag_search.go
+++ b/commands/gamertag_search.go
@@ -65,7 +65,7 @@ func runGamertagSearch(r utils.InteractionResponder, i *discordgo.InteractionCre
 	response := fmt.Sprintf("Found user for gamertag `%s`: [%s %s](%s)", gamertag, user.Rank.RankShort, user.User.Username, milpacUrl)
 
 	if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &response}); err != nil {
-		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+		captureDeferredEditFailure(i, "GamertagSearch", err)
 		return
 	}
 	utils.Info("✨ Done!", "command", "GamertagSearch")

--- a/commands/interaction_capture.go
+++ b/commands/interaction_capture.go
@@ -1,0 +1,31 @@
+package commands
+
+import "github.com/bwmarrin/discordgo"
+
+// captureDeferredEditFailure handles a failed follow-up edit on an interaction
+// that has ALREADY been acknowledged (an immediate Respond or a defer). Because
+// the interaction is acknowledged, the identical InteractionResponseEdit cannot
+// be retried and a fresh InteractionRespond would only be rejected as
+// already-acknowledged — that is the dead-end loop utils.HandleError walks into
+// on a post-ack edit failure (Respond → already-acknowledged → re-issue the same
+// failing edit). So instead of retrying, we treat the lost reply as a genuine
+// delivery failure and capture it to Sentry with the command name and the guild
+// read off the interaction, so on-call can attribute it even though the command
+// may already have done its work.
+//
+// This is the non-warden sibling of warden.go's captureEditFailure: warden reads
+// its subcommand off the `command` option, whereas these commands each pass their
+// own fixed command name. Both funnel through the same captureError seam and
+// record the same {command, guild_id} context shape.
+func captureDeferredEditFailure(interaction *discordgo.InteractionCreate, command string, err error) {
+	guildID := ""
+	if interaction != nil {
+		guildID = interaction.GuildID
+	}
+	captureError(
+		"Failed to deliver post-acknowledgement interaction edit",
+		err,
+		"command", command,
+		"guild_id", guildID,
+	)
+}

--- a/commands/interaction_capture_test.go
+++ b/commands/interaction_capture_test.go
@@ -1,0 +1,333 @@
+package commands
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+// errEditBoom is the synthetic post-ack edit failure used to drive the migrated
+// edit-failure sites: a plain (non-RESTError) error so the path's only handling
+// is the capture seam, not Discord-error classification.
+var errEditBoom = errors.New("503 service unavailable")
+
+// assertSingleCaptureNoRetry pins the issue-#191 contract for a migrated site:
+// the failing Edit was issued exactly once, the helper did NOT retry through a
+// second Edit or a fresh Respond, and the loss was captured to Sentry exactly
+// once. placeholderResponds is how many legitimate pre-edit Respond calls the
+// command makes (the immediate-ack placeholder = 1).
+func assertSingleCaptureNoRetry(t *testing.T, calls []recordedCall, captures, placeholderResponds int) {
+	t.Helper()
+	if got := countMethod(calls, "Edit"); got != 1 {
+		t.Fatalf("expected exactly 1 Edit (the failing call, no retry), got %d: %v", got, calls)
+	}
+	if got := countMethod(calls, "Respond"); got != placeholderResponds {
+		t.Fatalf("expected exactly %d Respond (placeholder only, no HandleError retry), got %d: %v", placeholderResponds, got, calls)
+	}
+	if captures != 1 {
+		t.Fatalf("expected exactly 1 Sentry capture, got %d", captures)
+	}
+}
+
+// appCommandInteractionWithGuild builds an app-command interaction carrying the
+// given guild id, so a migrated command's edit-failure site can be driven and
+// the captured {command, guild_id} context asserted.
+func appCommandInteractionWithGuild(guildID string, opts ...*discordgo.ApplicationCommandInteractionDataOption) *discordgo.InteractionCreate {
+	i := fakeAppCommandInteraction(opts...)
+	i.GuildID = guildID
+	return i
+}
+
+// captureDeferredEditFailure must capture exactly once with command + guild
+// context read off the interaction, and must NOT touch the responder (no
+// Respond/Edit retry): the helper only reports the already-lost reply.
+func TestCaptureDeferredEditFailure_CapturesOnceWithContext(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	i := appCommandInteractionWithGuild("guild-7")
+
+	captureDeferredEditFailure(i, "Milpac", errors.New("503 service unavailable"))
+
+	if rec.count != 1 {
+		t.Fatalf("expected exactly 1 Sentry capture, got %d", rec.count)
+	}
+	kvMap := kvToMap(rec.lastKV)
+	if kvMap["command"] != "Milpac" {
+		t.Fatalf("expected command=Milpac in capture context, got %v", kvMap["command"])
+	}
+	if kvMap["guild_id"] != "guild-7" {
+		t.Fatalf("expected guild_id=guild-7 in capture context, got %v", kvMap["guild_id"])
+	}
+}
+
+// --- /gamertag_search: final-edit failure ---
+
+func TestRunGamertagSearch_EditFailureCapturesOnceNoRetry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(gamertagProfileJSON))
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	f := &fakeResponder{EditErrs: []error{errEditBoom}}
+	i := appCommandInteractionWithGuild("g-gt", stringOption("gamertag", "SpecOps"))
+
+	runGamertagSearch(f, i)
+
+	assertSingleCaptureNoRetry(t, f.Calls(), rec.count, 1)
+	if kv := kvToMap(rec.lastKV); kv["command"] != "GamertagSearch" || kv["guild_id"] != "g-gt" {
+		t.Fatalf("expected command=GamertagSearch guild_id=g-gt, got %v", kv)
+	}
+}
+
+// --- /milpac: final embed-edit failure ---
+
+func TestRunMilpac_EditFailureCapturesOnceNoRetry(t *testing.T) {
+	serveMilpacByDiscordID(t, milpacProfileWithSecondaries())
+
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	f := &fakeResponder{EditErrs: []error{errEditBoom}}
+	i := appCommandInteractionWithGuild("g-mp", userOption("user", "111"))
+
+	runMilpac(f, i)
+
+	assertSingleCaptureNoRetry(t, f.Calls(), rec.count, 1)
+	if kv := kvToMap(rec.lastKV); kv["command"] != "Milpac" || kv["guild_id"] != "g-mp" {
+		t.Fatalf("expected command=Milpac guild_id=g-mp, got %v", kv)
+	}
+}
+
+// --- /loa: each of the three deferred-edit sites ---
+
+// loaEditInteraction wires the guild id onto a /loa interaction.
+func loaEditInteraction(guildID, position string) *discordgo.InteractionCreate {
+	return appCommandInteractionWithGuild(guildID, stringOption("position", position))
+}
+
+// TestRunLoa_UnavailableEditFailure drives the unhealthy-cache edit site
+// (loa.go:108): the edit of the "cache unavailable" message fails.
+func TestRunLoa_UnavailableEditFailureCapturesOnceNoRetry(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	// Unhealthy cache → the unavailable-message edit site fires; tripwire API
+	// proves we never reach the roster fetch.
+	tripwireAPIServer(t)
+	cache := &fakeLOAView{healthy: false, lastRefresh: loaRefDate}
+	f := &fakeResponder{EditErrs: []error{errEditBoom}}
+
+	runLoa(f, cache, loaRefDate, loaEditInteraction("g-loa1", "1-7"))
+
+	assertSingleCaptureNoRetry(t, f.Calls(), rec.count, 1)
+	if kv := kvToMap(rec.lastKV); kv["command"] != "LOA" || kv["guild_id"] != "g-loa1" {
+		t.Fatalf("expected command=LOA guild_id=g-loa1, got %v", kv)
+	}
+}
+
+// TestRunLoa_NoResultsEditFailure drives the "no active/upcoming" edit site
+// (loa.go:161): roster resolves but no member has an LOA entry.
+func TestRunLoa_NoResultsEditFailureCapturesOnceNoRetry(t *testing.T) {
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": loaMember("Trooper.NoLOA", "100"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	cache := healthyView(map[string]utils.LOAEntry{}) // no entries → no results
+	f := &fakeResponder{EditErrs: []error{errEditBoom}}
+
+	runLoa(f, cache, loaRefDate, loaEditInteraction("g-loa2", "1-7"))
+
+	assertSingleCaptureNoRetry(t, f.Calls(), rec.count, 1)
+	if kv := kvToMap(rec.lastKV); kv["command"] != "LOA" || kv["guild_id"] != "g-loa2" {
+		t.Fatalf("expected command=LOA guild_id=g-loa2, got %v", kv)
+	}
+}
+
+// TestRunLoa_ResultsEmbedEditFailure drives the final embed-edit site
+// (loa.go:220): an active LOA renders, and the embed edit fails.
+func TestRunLoa_ResultsEmbedEditFailureCapturesOnceNoRetry(t *testing.T) {
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": loaMember("Trooper.Active", "100"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	cache := healthyView(map[string]utils.LOAEntry{
+		"trooper.active": {
+			Username:  "Trooper.Active",
+			StartDate: loaRefDate.AddDate(0, 0, -5),
+			EndDate:   loaRefDate.AddDate(0, 0, 5),
+		},
+	})
+	f := &fakeResponder{EditErrs: []error{errEditBoom}}
+
+	runLoa(f, cache, loaRefDate, loaEditInteraction("g-loa3", "1-7"))
+
+	assertSingleCaptureNoRetry(t, f.Calls(), rec.count, 1)
+	if kv := kvToMap(rec.lastKV); kv["command"] != "LOA" || kv["guild_id"] != "g-loa3" {
+		t.Fatalf("expected command=LOA guild_id=g-loa3, got %v", kv)
+	}
+}
+
+// --- /awol: each of the three deferred-edit sites ---
+
+// TestRunAwol_NoResultsEditFailure drives the "no users AWOL" edit site
+// (awol.go:265).
+func TestRunAwol_NoResultsEditFailureCapturesOnceNoRetry(t *testing.T) {
+	// A member whose last forum post is recent → not AWOL → empty result set.
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.Fresh", "100", "2026-05-14 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	f := &fakeResponder{EditErrs: []error{errEditBoom}}
+	i := appCommandInteractionWithGuild("g-awol1", stringOption("position", "1-7"))
+
+	runAwol(f, healthyCache(nil), awolRefDate, i)
+
+	assertSingleCaptureNoRetry(t, f.Calls(), rec.count, 1)
+	if kv := kvToMap(rec.lastKV); kv["command"] != "Awol" || kv["guild_id"] != "g-awol1" {
+		t.Fatalf("expected command=Awol guild_id=g-awol1, got %v", kv)
+	}
+}
+
+// TestRunAwol_EmbedEditFailure drives the embed-edit site (awol.go:333).
+func TestRunAwol_EmbedEditFailureCapturesOnceNoRetry(t *testing.T) {
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	f := &fakeResponder{EditErrs: []error{errEditBoom}}
+	i := appCommandInteractionWithGuild("g-awol2", stringOption("position", "1-7"))
+
+	runAwol(f, healthyCache(nil), awolRefDate, i)
+
+	assertSingleCaptureNoRetry(t, f.Calls(), rec.count, 1)
+	if kv := kvToMap(rec.lastKV); kv["command"] != "Awol" || kv["guild_id"] != "g-awol2" {
+		t.Fatalf("expected command=Awol guild_id=g-awol2, got %v", kv)
+	}
+}
+
+// TestRunAwol_FileSendFailure drives the file-attachment edit site
+// (awol.go:443, sendAwolFile): force_file_output flips rendering to the file
+// path and that follow-up send fails.
+func TestRunAwol_FileSendFailureCapturesOnceNoRetry(t *testing.T) {
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{
+			"100": awolMember("Trooper.A", "100", "2026-03-01 12:00:00"),
+		},
+	}
+	serveAwolRoster(t, roster, http.StatusOK)
+
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	f := &fakeResponder{EditErrs: []error{errEditBoom}}
+	i := appCommandInteractionWithGuild("g-awol3",
+		stringOption("position", "1-7"),
+		boolOption("force_file_output", true),
+	)
+
+	runAwol(f, healthyCache(nil), awolRefDate, i)
+
+	assertSingleCaptureNoRetry(t, f.Calls(), rec.count, 1)
+	if kv := kvToMap(rec.lastKV); kv["command"] != "Awol" || kv["guild_id"] != "g-awol3" {
+		t.Fatalf("expected command=Awol guild_id=g-awol3, got %v", kv)
+	}
+}
+
+// --- /afsm: final-edit failure ---
+
+func TestRunAFSM_EditFailureCapturesOnceNoRetry(t *testing.T) {
+	// Empty department roster is rejected pre-edit (HandleError), so use a
+	// roster with one ineligible member: the command reaches the final edit with
+	// a "no eligible members" body.
+	memberB := utils.LiteProfileResponse{
+		User: utils.User{Username: "Test.B"}, Primary: utils.Position{PositionTitle: "Trooper 3/2/A/1-7"},
+		Secondary:  []utils.Position{{PositionTitle: "S1 Analytics Senior"}},
+		UniformUrl: "https://7cav.us/data/roster_uniforms/0/200.jpg",
+	}
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{"200": memberB},
+	}
+	profiles := map[string]utils.ProfileResponse{
+		"Test.B": {User: memberB.User, UniformUrl: memberB.UniformUrl},
+	}
+	serveRosterAndProfiles(t, roster, http.StatusOK, profiles)
+
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	f := &fakeResponder{EditErrs: []error{errEditBoom}}
+	i := appCommandInteractionWithGuild("g-afsm", stringOption("department", "S6"))
+
+	runAFSM(f, i)
+
+	assertSingleCaptureNoRetry(t, f.Calls(), rec.count, 1)
+	if kv := kvToMap(rec.lastKV); kv["command"] != "AFSM" || kv["guild_id"] != "g-afsm" {
+		t.Fatalf("expected command=AFSM guild_id=g-afsm, got %v", kv)
+	}
+}
+
+// --- /s6-it-check: final-edit failure ---
+
+func TestRunS6ITCheck_EditFailureCapturesOnceNoRetry(t *testing.T) {
+	memberB := utils.LiteProfileResponse{
+		User: utils.User{Username: "Test.B"}, UniformUrl: "https://7cav.us/data/roster_uniforms/0/200.jpg",
+	}
+	roster := utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{"200": memberB},
+	}
+	profiles := map[string]utils.ProfileResponse{
+		"Test.B": {
+			User: memberB.User, UniformUrl: memberB.UniformUrl,
+			Primary:   utils.Position{PositionTitle: "S6 Forums Staff"}, // S6 but no IT
+			Secondary: []utils.Position{{PositionTitle: "S1 Analytics Senior"}},
+		},
+	}
+	serveS6RosterAndProfiles(t, roster, http.StatusOK, profiles)
+
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	f := &fakeResponder{EditErrs: []error{errEditBoom}}
+	i := appCommandInteractionWithGuild("g-s6")
+
+	runS6ITCheck(f, i)
+
+	assertSingleCaptureNoRetry(t, f.Calls(), rec.count, 1)
+	if kv := kvToMap(rec.lastKV); kv["command"] != "S6ITCheck" || kv["guild_id"] != "g-s6" {
+		t.Fatalf("expected command=S6ITCheck guild_id=g-s6, got %v", kv)
+	}
+}

--- a/commands/loa.go
+++ b/commands/loa.go
@@ -106,7 +106,7 @@ func runLoa(r utils.InteractionResponder, cache loaCacheView, now time.Time, i *
 			"staleness", now.Sub(lastRefresh),
 		)
 		if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &msg}); err != nil {
-			utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+			captureDeferredEditFailure(i, "LOA", err)
 		}
 		return
 	}
@@ -161,7 +161,7 @@ func runLoa(r utils.InteractionResponder, cache loaCacheView, now time.Time, i *
 		if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 			Content: &response,
 		}); err != nil {
-			utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+			captureDeferredEditFailure(i, "LOA", err)
 		}
 		return
 	}
@@ -221,7 +221,7 @@ func runLoa(r utils.InteractionResponder, cache loaCacheView, now time.Time, i *
 		Content: stringPtr(""),
 		Embeds:  &embeds,
 	}); err != nil {
-		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+		captureDeferredEditFailure(i, "LOA", err)
 		return
 	}
 

--- a/commands/milpac.go
+++ b/commands/milpac.go
@@ -222,7 +222,7 @@ func runMilpac(r utils.InteractionResponder, i *discordgo.InteractionCreate) {
 		Embeds:  &[]*discordgo.MessageEmbed{embed},
 	})
 	if err != nil {
-		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response with embed: %v", err))
+		captureDeferredEditFailure(i, "Milpac", err)
 	}
 	utils.Info("✨ Done!", "command", "Milpac")
 }

--- a/commands/s6_trackers.go
+++ b/commands/s6_trackers.go
@@ -137,8 +137,7 @@ func runS6ITCheck(r utils.InteractionResponder, i *discordgo.InteractionCreate) 
 	if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 		Content: &response,
 	}); err != nil {
-		utils.CaptureError("❌ Response edit failed", err)
-		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to edit response: %v", err))
+		captureDeferredEditFailure(i, "S6ITCheck", err)
 		return
 	}
 	utils.Info("✨ Done!", "command", "S6ITCheck")


### PR DESCRIPTION
## What

When an interaction has already been deferred and the follow-up `InteractionResponseEdit` fails, routing that edit error through `utils.HandleError` retries a path that cannot succeed: `InteractionRespond` is rejected as already acknowledged, then the same failing edit is reissued. The genuinely lost reply never reaches Sentry, even though the command has often already done its work. Warden fixed this; loa, awol, afsm, s6 trackers, milpac, and gamertag-search still had it.

## Change

Add `captureDeferredEditFailure` in `commands/interaction_capture.go`, a sibling of warden's `captureEditFailure` that records command and guild context through the same package capture seam. Route the ten post-defer edit and follow-up-send failure sites to it:

- gamertag_search final edit, milpac embed edit, s6 trackers final edit, afsm final edit
- loa: cache-unavailable, no-results, and results-embed edits
- awol: no-results edit, embed edit, and the `sendAwolFile` follow-up attachment

Warden keeps its own helper because it reads the subcommand off the interaction option; the rest pass a fixed command name. Pre-defer "Failed to respond" handling and business-error replies (fetch, parse, empty roster) keep using `HandleError`, as intended.

Two redundant double-captures in s6 trackers and afsm are dropped: the same edit error was reported explicitly and then retried, so it now reports exactly once. The per-member, fetch, and empty-roster captures in those commands are untouched.

## Tests

New `commands/interaction_capture_test.go` drives each migrated site with a responder whose edit fails, and asserts for every site: exactly one capture, the `command` and `guild_id` context values, exactly one edit (the failing call, no retry), and one placeholder respond (no `HandleError` retry respond). These fail against the old code (which issues a second `InteractionRespond`) and pass after the change.

## Verification

Full CI gate green: lint, `go mod tidy` no-op, `go test -race -cover`, coverage floors (commands 88.0%, utils 90.6%), build.

Closes #191

> *This was generated by AI*
