### PR TITLE
fix(warden): capture genuine GuildChannels faults in runWardenPurge

### DIFF
--- a/commands/warden.go
+++ b/commands/warden.go
@@ -353,7 +353,14 @@ func runWardenPurge(
 
 	guildChannels, err := gm.GuildChannels(guildID)
 	if err != nil {
-		editEphemeral(r, interaction, fmt.Sprintf("❌ Failed to retrieve guild channels: %v", err))
+		// A genuine GuildChannels fault (5xx/transport) is classified and captured
+		// to Sentry; a 4xx stays a non-captured actionable message. The raw Discord
+		// response body is never interpolated into the operator reply (#195).
+		editEphemeral(r, interaction, channelsResolveErrorReply(
+			err,
+			"Failed to retrieve guild channels for warden purge",
+			"command", "warden", "guild", guildID,
+		).Error())
 		return
 	}
 

--- a/commands/warden_channelsresolve_capture_test.go
+++ b/commands/warden_channelsresolve_capture_test.go
@@ -1,0 +1,106 @@
+package commands
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// --- runWardenPurge: GuildChannels fault capture split (#195) ---
+//
+// The GuildChannels lookup inside runWardenPurge must route a genuine system
+// fault (5xx/transport) through the shared classifier and capture it to Sentry
+// (per ADR 0001), while a 4xx stays a non-captured actionable message. The raw
+// Discord response body must never reach the operator-facing message. This
+// mirrors the GuildRoles split #194 closed one call site below.
+
+// purgeChannelsGM builds a guild manager whose warden role resolves cleanly so
+// the purge reaches the GuildChannels lookup, then fails that lookup with err.
+func purgeChannelsGM(err error) *fakeGuildManager {
+	return &fakeGuildManager{
+		roles:        []*discordgo.Role{wardenRole("old-int", wardenRoleBaseName+" Internal")},
+		ChannelsErrs: []error{err},
+	}
+}
+
+// A 5xx from GuildChannels during purge is a genuine Discord-side fault: it must
+// capture to Sentry exactly once, show a body-free message, and never leak the
+// raw Discord response body.
+func TestRunWardenPurge_GuildChannels5xxCaptures(t *testing.T) {
+	noOverwriteDelay(t)
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := purgeChannelsGM(restError(http.StatusInternalServerError, 0, rawBodyMarker))
+	f := &fakeResponder{}
+
+	runWardenPurge(f, gm, wardenInteraction("guild-1"), "guild-1", "internal")
+
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("purge channels 5xx leaked the raw Discord body: %q", got)
+	}
+	if rec.count != 1 {
+		t.Fatalf("a 5xx GuildChannels fault must capture to Sentry exactly once; got %d", rec.count)
+	}
+	if gm.countCalls("GuildRoleCreate") != 0 {
+		t.Fatalf("must not recreate roles when channels are inaccessible; got %v", gm.Calls())
+	}
+	// #195 requires command+guild context on the capture.
+	for key, want := range map[string]string{
+		"command": "warden",
+		"guild":   "guild-1",
+	} {
+		gotV, ok := kvValue(rec.lastKV, key)
+		if !ok {
+			t.Fatalf("capture context missing %q; got kv %v", key, rec.lastKV)
+		}
+		if gotV != want {
+			t.Fatalf("capture context %q = %v, want %q", key, gotV, want)
+		}
+	}
+}
+
+// A transport (non-REST) failure from GuildChannels is also a system fault:
+// capture once, no raw body leak.
+func TestRunWardenPurge_GuildChannelsTransportErrorCaptures(t *testing.T) {
+	noOverwriteDelay(t)
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := purgeChannelsGM(errors.New("dial tcp: connection refused"))
+	f := &fakeResponder{}
+
+	runWardenPurge(f, gm, wardenInteraction("guild-1"), "guild-1", "internal")
+
+	if rec.count != 1 {
+		t.Fatalf("a transport GuildChannels fault must capture to Sentry exactly once; got %d", rec.count)
+	}
+}
+
+// A 4xx from GuildChannels is an operator/config-fixable client fault: it must
+// surface an actionable, body-free message and must NOT capture to Sentry.
+func TestRunWardenPurge_GuildChannels4xxDoesNotCapture(t *testing.T) {
+	noOverwriteDelay(t)
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := purgeChannelsGM(restError(http.StatusForbidden, 50013, rawBodyMarker))
+	f := &fakeResponder{}
+
+	runWardenPurge(f, gm, wardenInteraction("guild-1"), "guild-1", "internal")
+
+	got := lastEditContent(f.Calls())
+	if rec.count != 0 {
+		t.Fatalf("a 4xx GuildChannels fault must NOT capture to Sentry; got %d", rec.count)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("purge channels 4xx leaked the raw Discord body: %q", got)
+	}
+	if !strings.Contains(got, "❌ Failed to retrieve guild channels") {
+		t.Fatalf("expected an actionable guild-channels failure message, got %q", got)
+	}
+	if gm.countCalls("GuildRoleCreate") != 0 {
+		t.Fatalf("must not recreate roles when channels are inaccessible; got %v", gm.Calls())
+	}
+}

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -191,6 +191,23 @@ func roleResolveErrorReply(err error, captureMsg string, kv ...any) error {
 	return fmt.Errorf("❌ Failed to retrieve guild roles (%s)", class.UserDetail)
 }
 
+// channelsResolveErrorReply classifies a GuildChannels lookup failure raised
+// while resolving a guild's channels for a warden purge, captures it to Sentry
+// only for genuine system faults (5xx/transport, per ADR 0001), and returns a
+// body-free, operator-facing error. It mirrors roleResolveErrorReply one call
+// site below, with wording tailored to channels rather than roles. The raw
+// Discord response body (discordgo's "HTTP <status>, <json>") is never
+// interpolated — only a sanitized classifier phrase is shown. captureMsg/kv
+// carry the call site's command/guild context to Sentry.
+func channelsResolveErrorReply(err error, captureMsg string, kv ...any) error {
+	class := classifyDiscordError(err)
+	if class.SystemFault {
+		captureError(captureMsg, err, kv...)
+		return errors.New("❌ Failed to retrieve guild channels (Discord error); please try again shortly")
+	}
+	return fmt.Errorf("❌ Failed to retrieve guild channels (%s)", class.UserDetail)
+}
+
 // roleMutationErrorReply classifies a role add/remove failure, captures it to
 // Sentry only for genuine system faults, and returns a body-free, actionable
 // message. A 403 yields a specific role-hierarchy hint — the common cause is the


### PR DESCRIPTION
## What

When the `GuildChannels` lookup in `runWardenPurge` failed with a real system fault (5xx or transport), the purge path showed the operator the raw Discord error through `%v` and never captured it to Sentry. So an outage during a purge left on-call with no signal and leaked the response body to the operator. This is the same gap #194 closed for `GuildRoles`, one call site below.

## Change

Add `channelsResolveErrorReply` in `commands/warden_errors.go`, a sibling of `roleResolveErrorReply`, and route the `GuildChannels` error branch through it.

- 5xx or transport fault: captured to Sentry with command and guild context through the shared `classifyDiscordError` / `captureError` seam; the operator sees a body-free retry message.
- 4xx: non-captured actionable message built from the sanitized classifier detail, no raw body.

The helper is a per-concern sibling rather than a shared core, matching the file's existing `*ErrorReply` style and keeping the "channels" wording distinct from "roles". The `GuildRoles` path from #194 and its tests are untouched.

## Tests

New `commands/warden_channelsresolve_capture_test.go` drives `runWardenPurge` with a failing `GuildChannels` and asserts the split: a 500 and a non-REST transport error each capture exactly once with command and guild context and no body leak; a 403 captures zero times, leaks no body, and surfaces the actionable message. The #194 role tests all still pass unchanged.

## Verification

Full CI gate green: lint, `go mod tidy` no-op, `go test -race -cover`, coverage floors (commands 88.1%, utils 90.6%), build.

Closes #195

> *This was generated by AI*
