### PR TITLE
feat(commands): add /warden-bulkadd-internal for validated unit rosters

### DIFF
--- a/commands/registry.go
+++ b/commands/registry.go
@@ -11,6 +11,7 @@ func NewRegistry() *Registry {
 	r.RegisterCommands(
 		Milpac(),
 		Warden(),
+		WardenBulkAddInternal(),
 		AppsBetaDeploy(),
 		Zulu(),
 		S6ITCheck(),

--- a/commands/warden_bulkadd_internal.go
+++ b/commands/warden_bulkadd_internal.go
@@ -1,0 +1,319 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+// wardenInternalRosterTimeout bounds the single milpac roster fetch. The
+// per-trooper role-adds that follow are plain Discord calls inside the
+// interaction's 15-minute window, so only the roster lookup needs a deadline.
+const wardenInternalRosterTimeout = 30 * time.Second
+
+// wardenInternalUnit is one row of the unit registry behind the
+// /warden-bulkadd-internal picker. value is what the operator's choice emits and
+// what fingerprints captures; label is shown in the dropdown and the report;
+// query is the author-controlled milpac position-group search verified to
+// isolate exactly that unit's roster.
+//
+// The registry is both the extension seam and the safety boundary (ADR 0009):
+// adding a unit later is one new row with no logic change, and the operator can
+// only ever emit a value the registry already contains.
+type wardenInternalUnit struct {
+	value string
+	label string
+	query string
+}
+
+// wardenInternalUnits is the unit registry. Each query is verified to
+// substring-match only its own position group's titles before being added here.
+// D/ACD is the one validated internal unit today; the next is one more row.
+var wardenInternalUnits = []wardenInternalUnit{
+	{value: "D/ACD", label: "D/ACD", query: "D/ACD"},
+}
+
+// lookupWardenInternalUnit resolves a picker value to its registry row. The
+// boolean is the safety check: an unregistered value never resolves, so no query
+// outside the registry can ever reach the milpac API.
+func lookupWardenInternalUnit(value string) (wardenInternalUnit, bool) {
+	for _, unit := range wardenInternalUnits {
+		if unit.value == value {
+			return unit, true
+		}
+	}
+	return wardenInternalUnit{}, false
+}
+
+// wardenInternalUnitChoices builds the dropdown choices from the registry, so a
+// new registry row automatically becomes a new picker option with no edit here.
+func wardenInternalUnitChoices() []*discordgo.ApplicationCommandOptionChoice {
+	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0, len(wardenInternalUnits))
+	for _, unit := range wardenInternalUnits {
+		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
+			Name:  unit.label,
+			Value: unit.value,
+		})
+	}
+	return choices
+}
+
+func WardenBulkAddInternal() Command {
+	return Command{
+		Definition: &discordgo.ApplicationCommand{
+			Name:        "warden-bulkadd-internal",
+			Description: "Add a validated unit's roster to Verified Warden Internal",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "unit",
+					Description: "Validated unit whose roster is added to Verified Warden Internal",
+					Required:    true,
+					Choices:     wardenInternalUnitChoices(),
+				},
+			},
+		},
+		Handler: handleWardenBulkAddInternal,
+	}
+}
+
+func handleWardenBulkAddInternal(session *discordgo.Session, interaction *discordgo.InteractionCreate) {
+	runWardenBulkAddInternal(utils.NewSessionResponder(session), NewSessionGuildManager(session), interaction)
+}
+
+func runWardenBulkAddInternal(
+	r utils.InteractionResponder,
+	gm GuildManager,
+	interaction *discordgo.InteractionCreate,
+) {
+	// Guild-context guard first, before any read of interaction.Member: warden
+	// commands require guild context, and rejecting on an empty GuildID here both
+	// gives a clear server-only message and removes a latent nil-deref.
+	guildID := interaction.GuildID
+	if guildID == "" {
+		utils.HandleError(r, interaction, "❌ This command can only be used in a server (guild).")
+		return
+	}
+
+	username, discordID := interactionUsernameAndID(interaction)
+	utils.Info("🚀 Starting Warden Bulk Add Internal", "command", "warden-bulkadd-internal", "username", username, "discord_id", discordID)
+
+	commandData := interaction.ApplicationCommandData()
+	unitValue, ok := getOptionString(commandData, "unit")
+	if !ok {
+		utils.HandleError(r, interaction, "❌ Missing unit argument.")
+		return
+	}
+	// The picker only ever emits a registered value, but validate against the
+	// registry anyway: it is the safety boundary, and a crafted interaction must
+	// not be able to express a query the registry never authorized.
+	unit, ok := lookupWardenInternalUnit(unitValue)
+	if !ok {
+		utils.HandleError(r, interaction, fmt.Sprintf("❌ Unknown unit %q; pick one from the list.", unitValue))
+		return
+	}
+
+	if err := deferEphemeral(r, interaction); err != nil {
+		utils.HandleError(r, interaction, fmt.Sprintf("❌ Failed to acknowledge: %v", err))
+		return
+	}
+
+	roleName := resolveWardenRoleNames("internal")[0]
+	roleID, err := findGuildRoleIDByName(gm, guildID, roleName)
+	if errors.Is(err, errRoleNotFound) {
+		editEphemeral(r, interaction, fmt.Sprintf("❌ '%s' role not found in guild", roleName))
+		return
+	}
+	if err != nil {
+		// A genuine GuildRoles fault (5xx/transport) captures to Sentry; a 4xx
+		// stays a non-captured actionable message. The raw Discord body is never
+		// interpolated into the reply.
+		editEphemeral(r, interaction, roleResolveErrorReply(
+			err,
+			"Failed to retrieve guild roles for warden internal bulk add",
+			"command", "warden-bulkadd-internal", "guild", guildID, "role", roleName,
+		).Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), wardenInternalRosterTimeout)
+	defer cancel()
+
+	roster, err := utils.GetRosterByFuzzyPositionSearch(ctx, unit.query)
+	if err != nil {
+		// A roster fetch failure on fixed input is a genuine milpac fault, not a
+		// user-input miss: capture it (tagged with the unit value) and surface a
+		// retry message.
+		captureError(
+			"Failed to fetch warden internal unit roster",
+			err,
+			"command", "warden-bulkadd-internal", "guild", guildID, "unit", unit.value,
+		)
+		editEphemeral(r, interaction, fmt.Sprintf(
+			"❌ Failed to fetch the %s roster (milpac error); please try again shortly.",
+			unit.label,
+		))
+		return
+	}
+
+	// Empty vs failure, per ADR 0002. The picker -> registry -> fixed query makes
+	// this fixed input, so an empty result is structurally a bug, not "the unit is
+	// empty". Change nothing, report it (tagged with the unit value so each
+	// registry entry fingerprints separately), and tell the operator it shouldn't
+	// have happened — never a silent "added 0".
+	if len(roster.LiteProfiles) == 0 {
+		captureError(
+			"Warden internal bulk add roster lookup returned zero members",
+			fmt.Errorf("empty roster for unit %q", unit.value),
+			"command", "warden-bulkadd-internal", "guild", guildID, "unit", unit.value,
+		)
+		editEphemeral(r, interaction, fmt.Sprintf(
+			"⚠️ The %s roster came back empty. That shouldn't happen for a validated unit, so nothing was changed and the issue has been reported.",
+			unit.label,
+		))
+		return
+	}
+
+	var added []*discordgo.Member
+	var notInDiscord []string
+	var noDiscordLinked []string
+	var faults []string
+	for _, profile := range roster.LiteProfiles {
+		memberDiscordID := strings.TrimSpace(profile.DiscordID)
+		if memberDiscordID == "" {
+			// No Discord connection on the milpac: nothing to add, and a mention
+			// would render as a dead raw ID. List by forum username instead.
+			noDiscordLinked = append(noDiscordLinked, profile.User.Username)
+			continue
+		}
+
+		err := gm.GuildMemberRoleAdd(guildID, memberDiscordID, roleID)
+		if err == nil {
+			// Idempotent PUT: a fresh add and a re-add of an existing member both
+			// land here, so this is "added or confirmed".
+			added = append(added, &discordgo.Member{
+				User: &discordgo.User{ID: memberDiscordID, Username: profile.User.Username},
+			})
+			continue
+		}
+
+		class := classifyDiscordError(err)
+		if class.NotFound {
+			// 404 Unknown Member: the trooper has a linked Discord but isn't in this
+			// server. List by forum username (a mention would be a dead raw ID); not
+			// a fault, so no capture, and the run continues.
+			notInDiscord = append(notInDiscord, profile.User.Username)
+			continue
+		}
+		if class.SystemFault {
+			// Genuine fault (5xx/transport): capture to Sentry tagged with the unit
+			// value so each registry entry fingerprints separately, list the member,
+			// and continue past it. The raw Discord body never reaches the reply.
+			captureError(
+				"Failed to add warden internal role in bulk",
+				err,
+				"command", "warden-bulkadd-internal", "guild", guildID, "user", memberDiscordID, "unit", unit.value,
+			)
+			faults = append(faults, profile.User.Username)
+			continue
+		}
+
+		// A non-404 client fault (e.g. 403 missing Manage Roles, or the role above
+		// the bot) is operator-fixable: surface it so it is never silently dropped,
+		// but do not capture (ADR 0001). Typically this hits every member at once,
+		// which is itself the signal the bot's permissions need fixing.
+		faults = append(faults, profile.User.Username)
+	}
+
+	slices.SortFunc(added, func(a, b *discordgo.Member) int {
+		return strings.Compare(a.User.Username, b.User.Username)
+	})
+	slices.Sort(notInDiscord)
+	slices.Sort(noDiscordLinked)
+	slices.Sort(faults)
+
+	content := buildWardenInternalBulkAddSummary(unit.label, roleName, len(added), notInDiscord, noDiscordLinked, faults)
+	var embed *discordgo.MessageEmbed
+	if len(added) > 0 {
+		embed = buildAddedMembersEmbed(added)
+	}
+	editEphemeralWithEmbed(r, interaction, content, embed)
+
+	utils.Info("✨ Done!", "command", "warden-bulkadd-internal", "unit", unit.value, "added", len(added))
+}
+
+// buildWardenInternalBulkAddSummary composes the ephemeral report. The
+// added-or-confirmed count always leads (the command never silently reports
+// nothing); the not-in-Discord, no-Discord-linked, and could-not-be-added
+// buckets are listed by forum username only when non-empty.
+func buildWardenInternalBulkAddSummary(
+	unitLabel, roleName string,
+	addedCount int,
+	notInDiscord, noDiscordLinked, faults []string,
+) string {
+	sections := []string{
+		fmt.Sprintf("✅ Added or confirmed %d %s member(s) in %s.", addedCount, unitLabel, roleName),
+	}
+	if section := formatWardenInternalSection("Not in this Discord", notInDiscord); section != "" {
+		sections = append(sections, section)
+	}
+	if section := formatWardenInternalSection("No Discord linked", noDiscordLinked); section != "" {
+		sections = append(sections, section)
+	}
+	if section := formatWardenInternalSection("Could not be added", faults); section != "" {
+		sections = append(sections, section)
+	}
+	return clampToDiscordMessageLimit(strings.Join(sections, "\n\n"))
+}
+
+// wardenInternalSummaryMaxLen is Discord's per-message character ceiling. The
+// success count is collapsed into one line and the added members ride in the
+// embed, so the content only grows with the by-username buckets; for a curated
+// company-sized unit this stays well under the limit, but clamp anyway so a
+// pathologically large bucket can never make the edit itself fail.
+const wardenInternalSummaryMaxLen = 2000
+
+// clampToDiscordMessageLimit keeps as many whole lines as fit under the limit,
+// then appends a truncation marker. The lead summary line is short and comes
+// first, so it always survives.
+func clampToDiscordMessageLimit(message string) string {
+	if len(message) <= wardenInternalSummaryMaxLen {
+		return message
+	}
+	const marker = "... (truncated)"
+	lines := strings.Split(message, "\n")
+	var kept []string
+	used := 0
+	for _, line := range lines {
+		addition := len(line) + 1 // +1 for the newline join
+		if used+addition+len(marker)+1 > wardenInternalSummaryMaxLen {
+			break
+		}
+		kept = append(kept, line)
+		used += addition
+	}
+	kept = append(kept, marker)
+	return strings.Join(kept, "\n")
+}
+
+// formatWardenInternalSection renders a labelled, count-headed list of forum
+// usernames, or "" when the bucket is empty. The count lives in the header so a
+// test can pin the section size deterministically even though the underlying
+// roster iterates in map order.
+func formatWardenInternalSection(title string, usernames []string) string {
+	if len(usernames) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s (%d):", title, len(usernames))
+	for _, username := range usernames {
+		fmt.Fprintf(&sb, "\n- %s", username)
+	}
+	return sb.String()
+}

--- a/commands/warden_bulkadd_internal.go
+++ b/commands/warden_bulkadd_internal.go
@@ -92,9 +92,9 @@ func runWardenBulkAddInternal(
 	gm GuildManager,
 	interaction *discordgo.InteractionCreate,
 ) {
-	// Guild-context guard first, before any read of interaction.Member: warden
-	// commands require guild context, and rejecting on an empty GuildID here both
-	// gives a clear server-only message and removes a latent nil-deref.
+	// Guild-context guard first: warden commands require guild context. Rejecting
+	// on an empty GuildID here gives a clear server-only message and guarantees a
+	// non-empty guildID for every downstream Discord role call.
 	guildID := interaction.GuildID
 	if guildID == "" {
 		utils.HandleError(r, interaction, "❌ This command can only be used in a server (guild).")
@@ -184,6 +184,7 @@ func runWardenBulkAddInternal(
 	var notInDiscord []string
 	var noDiscordLinked []string
 	var faults []string
+	var sawMissingPermissions bool
 	for _, profile := range roster.LiteProfiles {
 		memberDiscordID := strings.TrimSpace(profile.DiscordID)
 		if memberDiscordID == "" {
@@ -227,7 +228,12 @@ func runWardenBulkAddInternal(
 		// A non-404 client fault (e.g. 403 missing Manage Roles, or the role above
 		// the bot) is operator-fixable: surface it so it is never silently dropped,
 		// but do not capture (ADR 0001). Typically this hits every member at once,
-		// which is itself the signal the bot's permissions need fixing.
+		// which is itself the signal the bot's permissions need fixing. Remember a
+		// 403 so the summary can add an actionable hint instead of leaving the
+		// operator with only an opaque "Could not be added" list.
+		if class.MissingPermissions {
+			sawMissingPermissions = true
+		}
 		faults = append(faults, profile.User.Username)
 	}
 
@@ -238,7 +244,7 @@ func runWardenBulkAddInternal(
 	slices.Sort(noDiscordLinked)
 	slices.Sort(faults)
 
-	content := buildWardenInternalBulkAddSummary(unit.label, roleName, len(added), notInDiscord, noDiscordLinked, faults)
+	content := buildWardenInternalBulkAddSummary(unit.label, roleName, len(added), notInDiscord, noDiscordLinked, faults, sawMissingPermissions)
 	var embed *discordgo.MessageEmbed
 	if len(added) > 0 {
 		embed = buildAddedMembersEmbed(added)
@@ -251,11 +257,14 @@ func runWardenBulkAddInternal(
 // buildWardenInternalBulkAddSummary composes the ephemeral report. The
 // added-or-confirmed count always leads (the command never silently reports
 // nothing); the not-in-Discord, no-Discord-linked, and could-not-be-added
-// buckets are listed by forum username only when non-empty.
+// buckets are listed by forum username only when non-empty. When any fault was a
+// 403, a permissions hint trails the buckets so a misconfigured bot reads as an
+// actionable fix rather than an opaque list of failures.
 func buildWardenInternalBulkAddSummary(
 	unitLabel, roleName string,
 	addedCount int,
 	notInDiscord, noDiscordLinked, faults []string,
+	missingPermissions bool,
 ) string {
 	sections := []string{
 		fmt.Sprintf("✅ Added or confirmed %d %s member(s) in %s.", addedCount, unitLabel, roleName),
@@ -269,14 +278,31 @@ func buildWardenInternalBulkAddSummary(
 	if section := formatWardenInternalSection("Could not be added", faults); section != "" {
 		sections = append(sections, section)
 	}
+	if missingPermissions {
+		sections = append(sections, wardenInternalPermissionsHint(roleName))
+	}
 	return clampToDiscordMessageLimit(strings.Join(sections, "\n\n"))
 }
 
-// wardenInternalSummaryMaxLen is Discord's per-message character ceiling. The
-// success count is collapsed into one line and the added members ride in the
-// embed, so the content only grows with the by-username buckets; for a curated
-// company-sized unit this stays well under the limit, but clamp anyway so a
-// pathologically large bucket can never make the edit itself fail.
+// wardenInternalPermissionsHint is the actionable line appended when a per-member
+// add failed on a 403. It reuses the substance of roleMutationErrorReply's
+// missing-permissions branch (Manage Roles plus the role-hierarchy requirement)
+// without interpolating any raw Discord body.
+func wardenInternalPermissionsHint(roleName string) string {
+	return fmt.Sprintf(
+		"⚠️ Some members couldn't be added because the bot is missing permissions. It needs Manage Roles, and its own role must sit above '%s'.",
+		roleName,
+	)
+}
+
+// wardenInternalSummaryMaxLen is Discord's per-message limit. The success count
+// is collapsed into one line and the added members ride in the embed, so the
+// content only grows with the by-username buckets; for a curated company-sized
+// unit this stays well under the limit, but clamp anyway so a pathologically
+// large bucket can never make the edit itself fail. clampToDiscordMessageLimit
+// measures bytes (len), not runes: that is deliberate, since byte length >= rune
+// count it is a safe over-estimate of Discord's UTF-8 code-point limit, so don't
+// "fix" it into a rune count and weaken the margin.
 const wardenInternalSummaryMaxLen = 2000
 
 // clampToDiscordMessageLimit keeps as many whole lines as fit under the limit,
@@ -303,9 +329,10 @@ func clampToDiscordMessageLimit(message string) string {
 }
 
 // formatWardenInternalSection renders a labelled, count-headed list of forum
-// usernames, or "" when the bucket is empty. The count lives in the header so a
-// test can pin the section size deterministically even though the underlying
-// roster iterates in map order.
+// usernames, or "" when the bucket is empty. The slices.Sort calls at the call
+// site make the within-bucket username order deterministic; the header count is
+// what keeps the bucket *size* stable in a test even when which member lands in
+// the bucket is map-order-dependent.
 func formatWardenInternalSection(title string, usernames []string) string {
 	if len(usernames) == 0 {
 		return ""

--- a/commands/warden_bulkadd_internal_test.go
+++ b/commands/warden_bulkadd_internal_test.go
@@ -134,10 +134,13 @@ func TestLookupWardenInternalUnit(t *testing.T) {
 }
 
 // Every registry row must carry a non-empty value, query, and label, and values
-// must be unique. An empty value would shadow getOptionString's "" miss return,
-// and a duplicate value would let the first matching row silently shadow a later
-// one — both invisible to "add a row, no logic change". This pins the invariant
-// so a careless new row fails loudly here.
+// must be unique. A genuine miss returns ("", false) from getOptionString and the
+// caller rejects it on the boolean before any lookup, but a present-but-empty
+// option (unit="") returns ("", true), so the guard passes and an empty-value
+// registry row would resolve that input instead of it being rejected as "Unknown
+// unit". A duplicate value would let the first matching row silently shadow a
+// later one. Both are invisible to "add a row, no logic change", so this pins the
+// invariant to fail loudly here.
 func TestWardenInternalUnits_RegistryRowsValidAndUnique(t *testing.T) {
 	seen := map[string]bool{}
 	for i, unit := range wardenInternalUnits {
@@ -420,6 +423,50 @@ func TestRunWardenBulkAddInternal_PerMemberFaultCapturedAndRunContinues(t *testi
 	}
 	if embed := lastEditEmbed(f.Calls()); embed == nil || !strings.Contains(embed.Title, "1") {
 		t.Fatal("expected the one successful add reported in the success embed")
+	}
+}
+
+// A generic non-403/404 4xx on an add (here a 400 with a non-permission code) is
+// the classifier's fall-through client fault. Like the 403 it is listed and not
+// captured, but unlike the 403 it carries no missing-permissions signal, so the
+// summary must NOT append the Manage Roles hint. The clean member still lands in
+// added/confirmed so the run is realistic.
+func TestRunWardenBulkAddInternal_PerMemberGeneric4xxListedNotCapturedNoHint(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	serveRosterAndProfiles(t, liteRoster(
+		liteMember("Ok.A", "111111111111111111"),
+		liteMember("Reject.B", "222222222222222222"),
+	), http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	// One add 400s with a non-permission code (50035 Invalid Form Body), hitting the
+	// classifier's generic 4xx arm — not NotFound, not SystemFault, not
+	// MissingPermissions. Map order randomizes which member draws it, so assert on
+	// counts rather than which member lands in the bucket.
+	gm.MemberRoleAddErrs = []error{nil, restError(http.StatusBadRequest, 50035, rawBodyMarker)}
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	got := lastEditContent(f.Calls())
+	// The clean member is added/confirmed; the 400 lands in the fault bucket.
+	if !strings.Contains(got, "Added or confirmed 1") {
+		t.Fatalf("expected the one clean add reported as added-or-confirmed, got %q", got)
+	}
+	if !strings.Contains(got, "Could not be added (1)") {
+		t.Fatalf("a generic 4xx fault must still be listed, not silently dropped; got %q", got)
+	}
+	// A generic 4xx is a client fault, not a system fault: it must not page Sentry.
+	if rec.count != 0 {
+		t.Fatalf("a generic 4xx client fault must NOT capture to Sentry; got %d", rec.count)
+	}
+	// It is not a 403 either, so no missing-permissions hint may be appended.
+	if strings.Contains(got, "Manage Roles") {
+		t.Fatalf("a non-403 4xx must not surface the missing-permissions hint; got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
 	}
 }
 

--- a/commands/warden_bulkadd_internal_test.go
+++ b/commands/warden_bulkadd_internal_test.go
@@ -133,11 +133,37 @@ func TestLookupWardenInternalUnit(t *testing.T) {
 	}
 }
 
+// Every registry row must carry a non-empty value, query, and label, and values
+// must be unique. An empty value would shadow getOptionString's "" miss return,
+// and a duplicate value would let the first matching row silently shadow a later
+// one — both invisible to "add a row, no logic change". This pins the invariant
+// so a careless new row fails loudly here.
+func TestWardenInternalUnits_RegistryRowsValidAndUnique(t *testing.T) {
+	seen := map[string]bool{}
+	for i, unit := range wardenInternalUnits {
+		if unit.value == "" {
+			t.Fatalf("registry row %d has an empty value", i)
+		}
+		if unit.query == "" {
+			t.Fatalf("registry row %d (%q) has an empty query", i, unit.value)
+		}
+		if unit.label == "" {
+			t.Fatalf("registry row %d (%q) has an empty label", i, unit.value)
+		}
+		if seen[unit.value] {
+			t.Fatalf("registry row %d has a duplicate value %q; the first match would shadow it", i, unit.value)
+		}
+		seen[unit.value] = true
+	}
+}
+
 // Happy path: every roster member has a linked, in-guild Discord. Each one is
 // added straight to Verified Warden Internal by ID (no member search), the run
 // is acknowledged with a deferred ephemeral, and the report carries the
 // added-or-confirmed count plus the success mention embed.
 func TestRunWardenBulkAddInternal_HappyPathAddsAllAndReportsCount(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
 	serveRosterAndProfiles(t, liteRoster(
 		liteMember("Trooper.A", "111111111111111111"),
 		liteMember("Trooper.B", "222222222222222222"),
@@ -156,6 +182,26 @@ func TestRunWardenBulkAddInternal_HappyPathAddsAllAndReportsCount(t *testing.T) 
 		t.Fatalf("expected 2 role adds, got %d (%v)", gm.countCalls("GuildMemberRoleAdd"), gm.Calls())
 	}
 
+	// The right IDs reach the right role: every add carries the run's guild and
+	// the resolved internal role id (r-int), and the user ids are exactly the
+	// roster members' Discord ids (map order is nondeterministic, so compare as a
+	// set).
+	gotUserIDs := map[string]bool{}
+	for _, add := range gm.roleAddCalls() {
+		if add.guildID != "guild-1" {
+			t.Fatalf("add must carry the run guild; got %q", add.guildID)
+		}
+		if add.roleID != "r-int" {
+			t.Fatalf("add must target the resolved internal role id r-int; got %q", add.roleID)
+		}
+		gotUserIDs[add.userID] = true
+	}
+	for _, want := range []string{"111111111111111111", "222222222222222222"} {
+		if !gotUserIDs[want] {
+			t.Fatalf("expected roster member %s to be added by Discord id; got adds %+v", want, gm.roleAddCalls())
+		}
+	}
+
 	calls := f.Calls()
 	if len(calls) == 0 {
 		t.Fatal("expected responder calls")
@@ -169,16 +215,55 @@ func TestRunWardenBulkAddInternal_HappyPathAddsAllAndReportsCount(t *testing.T) 
 	}
 
 	got := lastEditContent(calls)
-	if !strings.Contains(got, "2") {
-		t.Fatalf("expected the added-or-confirmed count in the summary, got %q", got)
+	if !strings.Contains(got, "Added or confirmed 2") {
+		t.Fatalf("expected the exact added-or-confirmed lead phrase, got %q", got)
+	}
+	// A clean run is not a permissions problem: no hint.
+	if strings.Contains(got, "Manage Roles") {
+		t.Fatalf("a clean run must not surface the missing-permissions hint; got %q", got)
 	}
 
 	embed := lastEditEmbed(calls)
 	if embed == nil {
 		t.Fatal("expected a success mention embed")
 	}
-	if !strings.Contains(embed.Title, "2") {
-		t.Fatalf("embed should report 2 users, got %q", embed.Title)
+	if embed.Title != "Added 2 user(s)" {
+		t.Fatalf("embed should report exactly 2 users, got %q", embed.Title)
+	}
+
+	// A clean run must never page Sentry.
+	if rec.count != 0 {
+		t.Fatalf("a clean happy-path run must not capture to Sentry; got %d", rec.count)
+	}
+}
+
+// Idempotency: re-adding a member who already holds the role is a no-op on
+// Discord's side (the role-add PUT returns success), so the fake returns nil and
+// the member must land in added/confirmed, not in any failure bucket. This is the
+// contract behind the "added or confirmed" wording — a nil error means the member
+// has the role whether or not this call is what put it there.
+func TestRunWardenBulkAddInternal_IdempotentReAddCountsAsConfirmed(t *testing.T) {
+	serveRosterAndProfiles(t, liteRoster(
+		liteMember("Already.In", "111111111111111111"),
+	), http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	// No queued error: the add of an already-present member succeeds (nil), exactly
+	// as Discord's idempotent role-add PUT behaves.
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Added or confirmed 1") {
+		t.Fatalf("an idempotent re-add must count as confirmed, got %q", got)
+	}
+	if strings.Contains(got, "Could not be added") {
+		t.Fatalf("an idempotent re-add must not be reported as a failure, got %q", got)
+	}
+	embed := lastEditEmbed(f.Calls())
+	if embed == nil || !strings.Contains(embed.Description, "111111111111111111") {
+		t.Fatalf("the re-added member must appear in the success embed, got %+v", embed)
 	}
 }
 
@@ -201,6 +286,9 @@ func TestRunWardenBulkAddInternal_NoDiscordLinkedListedNotAdded(t *testing.T) {
 		t.Fatalf("expected exactly 1 role add (the linked member), got %d (%v)", gm.countCalls("GuildMemberRoleAdd"), gm.Calls())
 	}
 	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Added or confirmed 1") {
+		t.Fatalf("expected the exact added-or-confirmed lead phrase for the one linked member, got %q", got)
+	}
 	if !strings.Contains(got, "No Discord linked") {
 		t.Fatalf("expected a 'No Discord linked' section, got %q", got)
 	}
@@ -237,6 +325,9 @@ func TestRunWardenBulkAddInternal_NotInGuild404ListedNotAddedNoCapture(t *testin
 		t.Fatalf("expected both members attempted, got %d (%v)", gm.countCalls("GuildMemberRoleAdd"), gm.Calls())
 	}
 	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Added or confirmed 1") {
+		t.Fatalf("expected the exact added-or-confirmed lead phrase for the one present member, got %q", got)
+	}
 	if !strings.Contains(got, "Not in this Discord (1)") {
 		t.Fatalf("expected one member in the 'Not in this Discord' section, got %q", got)
 	}
@@ -280,6 +371,12 @@ func TestRunWardenBulkAddInternal_PerMemberClientFaultListedNotCaptured(t *testi
 	if strings.Contains(got, rawBodyMarker) {
 		t.Fatalf("must not leak the raw Discord body, got %q", got)
 	}
+	// A 403 is a missing-permissions fault: the summary must carry an actionable
+	// hint (Manage Roles + role position) so the operator isn't left with only an
+	// opaque "Could not be added" list and a misleading "added 0" lead.
+	if !strings.Contains(got, "Manage Roles") {
+		t.Fatalf("a missing-permissions fault must surface a 'Manage Roles' hierarchy hint; got %q", got)
+	}
 }
 
 // A genuine per-member fault (5xx) is listed, sent to Sentry tagged with the
@@ -316,8 +413,62 @@ func TestRunWardenBulkAddInternal_PerMemberFaultCapturedAndRunContinues(t *testi
 	if strings.Contains(got, rawBodyMarker) {
 		t.Fatalf("must not leak the raw Discord body, got %q", got)
 	}
+	// A pure-5xx fault is not a permissions problem, so the missing-permissions
+	// hint must NOT be appended.
+	if strings.Contains(got, "Manage Roles") {
+		t.Fatalf("a 5xx fault must not surface the missing-permissions hint; got %q", got)
+	}
 	if embed := lastEditEmbed(f.Calls()); embed == nil || !strings.Contains(embed.Title, "1") {
 		t.Fatal("expected the one successful add reported in the success embed")
+	}
+}
+
+// All four outcome buckets at once: one clean add, one linked-but-absent (404),
+// one with no Discord link, and one genuine fault (5xx). The lead count must
+// coexist with every section, and the sections must appear in a stable order
+// (lead, not-in-Discord, no-Discord-linked, could-not-be-added). Map iteration
+// order randomizes WHICH linked member draws which error, but the multiset of
+// outcomes — and therefore every bucket size — is fixed.
+func TestRunWardenBulkAddInternal_AllBucketsCoexistWithStableOrdering(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	serveRosterAndProfiles(t, liteRoster(
+		liteMember("Added.A", "111111111111111111"),
+		liteMember("Absent.B", "222222222222222222"),
+		liteMember("Linkless.C", ""),
+		liteMember("Boom.D", "333333333333333333"),
+	), http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	// Three linked members draw these three outcomes (one each) in map order: a
+	// success, a 404 (not in this Discord), and a 5xx (a genuine fault).
+	gm.MemberRoleAddErrs = []error{
+		nil,
+		restError(http.StatusNotFound, 10007, rawBodyMarker),
+		restError(http.StatusInternalServerError, 0, rawBodyMarker),
+	}
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	got := lastEditContent(f.Calls())
+	leadIdx := strings.Index(got, "Added or confirmed 1")
+	notInIdx := strings.Index(got, "Not in this Discord (1)")
+	noLinkIdx := strings.Index(got, "No Discord linked (1)")
+	faultIdx := strings.Index(got, "Could not be added (1)")
+	if leadIdx < 0 || notInIdx < 0 || noLinkIdx < 0 || faultIdx < 0 {
+		t.Fatalf("expected the lead count and all three buckets present, got %q", got)
+	}
+	ordered := leadIdx < notInIdx && notInIdx < noLinkIdx && noLinkIdx < faultIdx
+	if !ordered {
+		t.Fatalf("sections must keep a stable order (lead, not-in-Discord, no-link, could-not-be-added); got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+	// Only the 5xx is a genuine fault; it captures exactly once.
+	if rec.count != 1 {
+		t.Fatalf("only the 5xx fault should capture to Sentry; got %d", rec.count)
 	}
 }
 
@@ -504,7 +655,7 @@ func TestBuildWardenInternalBulkAddSummary_ClampsToDiscordLimit(t *testing.T) {
 		many[i] = "Trooper.Placeholder.Name"
 	}
 
-	got := buildWardenInternalBulkAddSummary("D/ACD", wardenInternalRoleName, 0, nil, nil, many)
+	got := buildWardenInternalBulkAddSummary("D/ACD", wardenInternalRoleName, 0, nil, nil, many, false)
 
 	if len(got) > 2000 {
 		t.Fatalf("summary must stay within Discord's 2000-char limit, got %d", len(got))

--- a/commands/warden_bulkadd_internal_test.go
+++ b/commands/warden_bulkadd_internal_test.go
@@ -1,0 +1,534 @@
+package commands
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+const wardenInternalRoleName = wardenRoleBaseName + " Internal"
+
+// wardenBulkAddInternalInteraction builds a guild-context interaction carrying
+// the chosen unit value, mirroring what the Choices-backed picker emits.
+func wardenBulkAddInternalInteraction(unit string) *discordgo.InteractionCreate {
+	i := fakeAppCommandInteraction(stringOption("unit", unit))
+	i.GuildID = "guild-1"
+	return i
+}
+
+// internalRoleGM is a fake guild that already has the Verified Warden Internal
+// role, the precondition every successful run needs.
+func internalRoleGM() *fakeGuildManager {
+	return &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenInternalRoleName)},
+	}
+}
+
+// liteMember is a roster entry constructor: a forum username plus its linked
+// Discord ID (empty means no Discord connection on the milpac).
+func liteMember(username, discordID string) utils.LiteProfileResponse {
+	return utils.LiteProfileResponse{
+		User:      utils.User{Username: username},
+		DiscordID: discordID,
+	}
+}
+
+func liteRoster(members ...utils.LiteProfileResponse) utils.LiteRosterResponse {
+	profiles := make(map[string]utils.LiteProfileResponse, len(members))
+	for idx, m := range members {
+		profiles[strconvI(idx)] = m
+	}
+	return utils.LiteRosterResponse{LiteProfiles: profiles}
+}
+
+func strconvI(i int) string {
+	return string(rune('a' + i))
+}
+
+// lastEditEmbed returns the first embed on the last Edit call, or nil.
+func lastEditEmbed(calls []recordedCall) *discordgo.MessageEmbed {
+	for idx := len(calls) - 1; idx >= 0; idx-- {
+		c := calls[idx]
+		if c.Method == "Edit" && c.Edit != nil && c.Edit.Embeds != nil && len(*c.Edit.Embeds) > 0 {
+			return (*c.Edit.Embeds)[0]
+		}
+	}
+	return nil
+}
+
+// The unit input is a validated, Choices-backed dropdown derived from the unit
+// registry — never free text. This is the safety decision the whole command
+// hangs on (see ADR 0009): the operator can only ever emit a value the registry
+// already contains, so a one-character slip can't substring-match the regiment.
+func TestWardenBulkAddInternalDefinition_SingleUnitPickerFromRegistry(t *testing.T) {
+	cmd := WardenBulkAddInternal()
+
+	if cmd.Definition.Name != "warden-bulkadd-internal" {
+		t.Fatalf("command name = %q, want warden-bulkadd-internal", cmd.Definition.Name)
+	}
+	if cmd.Handler == nil {
+		t.Fatal("command must have a handler")
+	}
+
+	// Exactly one option: the unit picker. A one-field surface is the point.
+	if len(cmd.Definition.Options) != 1 {
+		t.Fatalf("expected exactly one option (unit), got %d", len(cmd.Definition.Options))
+	}
+	unitOpt := cmd.Definition.Options[0]
+	if unitOpt.Name != "unit" {
+		t.Fatalf("option name = %q, want unit", unitOpt.Name)
+	}
+	if !unitOpt.Required {
+		t.Fatal("the unit option must be required")
+	}
+	// Choices-backed dropdown, not free text.
+	if len(unitOpt.Choices) == 0 {
+		t.Fatal("the unit option must carry Choices (validated dropdown), not be free text")
+	}
+	// The choices are derived from the registry, so adding a unit later is one new
+	// registry row with no command-definition change.
+	if len(unitOpt.Choices) != len(wardenInternalUnits) {
+		t.Fatalf("choices (%d) must be derived 1:1 from the registry (%d)", len(unitOpt.Choices), len(wardenInternalUnits))
+	}
+	foundDACD := false
+	for _, choice := range unitOpt.Choices {
+		if choice.Value == "D/ACD" {
+			foundDACD = true
+		}
+	}
+	if !foundDACD {
+		t.Fatalf("expected a D/ACD choice derived from the registry, got %+v", unitOpt.Choices)
+	}
+
+	// No DefaultMemberPermissions in code: access is governed by Discord's
+	// server-side command-permission override, matching the warden convention.
+	if cmd.Definition.DefaultMemberPermissions != nil {
+		t.Fatal("must not set DefaultMemberPermissions in code (warden convention)")
+	}
+}
+
+// The registry is both the extension seam and the safety boundary: a lookup
+// resolves a known unit to its author-controlled query, and rejects anything
+// that isn't a registered value.
+func TestLookupWardenInternalUnit(t *testing.T) {
+	unit, ok := lookupWardenInternalUnit("D/ACD")
+	if !ok {
+		t.Fatal("expected D/ACD to resolve from the registry")
+	}
+	if unit.query != "D/ACD" {
+		t.Fatalf("query = %q, want D/ACD", unit.query)
+	}
+	if unit.label == "" {
+		t.Fatal("a registered unit must carry a human label")
+	}
+
+	if _, ok := lookupWardenInternalUnit("7"); ok {
+		t.Fatal("an unregistered value must not resolve (the safety boundary)")
+	}
+	if _, ok := lookupWardenInternalUnit(""); ok {
+		t.Fatal("an empty value must not resolve")
+	}
+}
+
+// Happy path: every roster member has a linked, in-guild Discord. Each one is
+// added straight to Verified Warden Internal by ID (no member search), the run
+// is acknowledged with a deferred ephemeral, and the report carries the
+// added-or-confirmed count plus the success mention embed.
+func TestRunWardenBulkAddInternal_HappyPathAddsAllAndReportsCount(t *testing.T) {
+	serveRosterAndProfiles(t, liteRoster(
+		liteMember("Trooper.A", "111111111111111111"),
+		liteMember("Trooper.B", "222222222222222222"),
+	), http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	// IDs come from the milpac, so the command adds directly and never searches.
+	if gm.countCalls("GuildMembersSearch") != 0 {
+		t.Fatalf("must add by Discord ID directly, never searching; got %v", gm.Calls())
+	}
+	if gm.countCalls("GuildMemberRoleAdd") != 2 {
+		t.Fatalf("expected 2 role adds, got %d (%v)", gm.countCalls("GuildMemberRoleAdd"), gm.Calls())
+	}
+
+	calls := f.Calls()
+	if len(calls) == 0 {
+		t.Fatal("expected responder calls")
+	}
+	first := calls[0]
+	if first.Method != "Respond" || first.Response.Type != discordgo.InteractionResponseDeferredChannelMessageWithSource {
+		t.Fatalf("expected a deferred response first, got %+v", first)
+	}
+	if first.Response.Data == nil || first.Response.Data.Flags&discordgo.MessageFlagsEphemeral == 0 {
+		t.Fatal("the defer must be ephemeral")
+	}
+
+	got := lastEditContent(calls)
+	if !strings.Contains(got, "2") {
+		t.Fatalf("expected the added-or-confirmed count in the summary, got %q", got)
+	}
+
+	embed := lastEditEmbed(calls)
+	if embed == nil {
+		t.Fatal("expected a success mention embed")
+	}
+	if !strings.Contains(embed.Title, "2") {
+		t.Fatalf("embed should report 2 users, got %q", embed.Title)
+	}
+}
+
+// A member whose milpac carries no Discord connection (empty discordId) is
+// listed by forum username and never sent to Discord — a mention would render as
+// a dead raw ID, and there is nothing to add.
+func TestRunWardenBulkAddInternal_NoDiscordLinkedListedNotAdded(t *testing.T) {
+	serveRosterAndProfiles(t, liteRoster(
+		liteMember("Trooper.A", "111111111111111111"),
+		liteMember("Linkless.B", ""),
+	), http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	// Only the linked member reaches Discord; the link-less one is skipped.
+	if gm.countCalls("GuildMemberRoleAdd") != 1 {
+		t.Fatalf("expected exactly 1 role add (the linked member), got %d (%v)", gm.countCalls("GuildMemberRoleAdd"), gm.Calls())
+	}
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "No Discord linked") {
+		t.Fatalf("expected a 'No Discord linked' section, got %q", got)
+	}
+	if !strings.Contains(got, "Linkless.B") {
+		t.Fatalf("expected the link-less member listed by forum username, got %q", got)
+	}
+	// The link-less member must not appear as a mention in the success embed.
+	if embed := lastEditEmbed(f.Calls()); embed != nil && strings.Contains(embed.Description, "Linkless.B") {
+		t.Fatalf("link-less member must not be in the success embed, got %q", embed.Description)
+	}
+}
+
+// A member with a linked Discord whose add returns 404 (Unknown Member) is "not
+// in this server": listed by forum username, not added, the run continues past
+// it, and a 404 never captures to Sentry.
+func TestRunWardenBulkAddInternal_NotInGuild404ListedNotAddedNoCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	serveRosterAndProfiles(t, liteRoster(
+		liteMember("Present.A", "111111111111111111"),
+		liteMember("Absent.B", "222222222222222222"),
+	), http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	// One of the two adds 404s. Map iteration order is nondeterministic, so assert
+	// on counts rather than which member lands in the bucket.
+	gm.MemberRoleAddErrs = []error{nil, restError(http.StatusNotFound, 10007, rawBodyMarker)}
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	// Both members were attempted: the run continued past the 404.
+	if gm.countCalls("GuildMemberRoleAdd") != 2 {
+		t.Fatalf("expected both members attempted, got %d (%v)", gm.countCalls("GuildMemberRoleAdd"), gm.Calls())
+	}
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Not in this Discord (1)") {
+		t.Fatalf("expected one member in the 'Not in this Discord' section, got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+	if rec.count != 0 {
+		t.Fatalf("a 404 (not in server) must NOT capture to Sentry; got %d", rec.count)
+	}
+	if embed := lastEditEmbed(f.Calls()); embed == nil || !strings.Contains(embed.Title, "1") {
+		t.Fatal("expected the one successful add reported in the success embed")
+	}
+}
+
+// A non-404 client fault on an add (here a 403 — bot lacks Manage Roles or the
+// role sits above it) is still surfaced, never silently dropped, but it is an
+// operator-fixable condition so it must NOT capture to Sentry.
+func TestRunWardenBulkAddInternal_PerMemberClientFaultListedNotCaptured(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	serveRosterAndProfiles(t, liteRoster(
+		liteMember("Forbidden.A", "111111111111111111"),
+	), http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	gm.MemberRoleAddErrs = []error{restError(http.StatusForbidden, 50013, rawBodyMarker)}
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Could not be added (1)") {
+		t.Fatalf("a non-404 client fault must still be listed, not silently dropped; got %q", got)
+	}
+	if !strings.Contains(got, "Forbidden.A") {
+		t.Fatalf("expected the member listed by forum username, got %q", got)
+	}
+	if rec.count != 0 {
+		t.Fatalf("a 4xx client fault must NOT capture to Sentry; got %d", rec.count)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}
+
+// A genuine per-member fault (5xx) is listed, sent to Sentry tagged with the
+// unit value, and the run continues past it so the other members still get
+// processed.
+func TestRunWardenBulkAddInternal_PerMemberFaultCapturedAndRunContinues(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	serveRosterAndProfiles(t, liteRoster(
+		liteMember("Ok.A", "111111111111111111"),
+		liteMember("Boom.B", "222222222222222222"),
+	), http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	gm.MemberRoleAddErrs = []error{nil, restError(http.StatusInternalServerError, 0, rawBodyMarker)}
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	// Both attempted: the run continued past the per-member 5xx.
+	if gm.countCalls("GuildMemberRoleAdd") != 2 {
+		t.Fatalf("expected both members attempted, got %d (%v)", gm.countCalls("GuildMemberRoleAdd"), gm.Calls())
+	}
+	if rec.count != 1 {
+		t.Fatalf("a 5xx per-member fault must capture to Sentry exactly once; got %d", rec.count)
+	}
+	if unitVal, ok := kvValue(rec.lastKV, "unit"); !ok || unitVal != "D/ACD" {
+		t.Fatalf("the capture must be tagged with the unit value; got kv %v", rec.lastKV)
+	}
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Could not be added (1)") {
+		t.Fatalf("expected a 'Could not be added' section listing the faulted member, got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+	if embed := lastEditEmbed(f.Calls()); embed == nil || !strings.Contains(embed.Title, "1") {
+		t.Fatal("expected the one successful add reported in the success embed")
+	}
+}
+
+// The picker feeding a registry feeding a fixed query makes this fixed input, so
+// an empty roster is structurally a bug, not "the unit is empty" (ADR 0002). It
+// must change nothing, tell the operator it shouldn't happen and was reported,
+// and capture tagged with the unit value — never a silent "added 0".
+func TestRunWardenBulkAddInternal_EmptyRosterCapturedNothingChanged(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	serveRosterAndProfiles(t, utils.LiteRosterResponse{
+		LiteProfiles: map[string]utils.LiteProfileResponse{},
+	}, http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	if gm.countCalls("GuildMemberRoleAdd") != 0 {
+		t.Fatalf("an empty roster must change nothing; got adds %v", gm.Calls())
+	}
+	if rec.count != 1 {
+		t.Fatalf("an empty roster from a validated unit must capture exactly once; got %d", rec.count)
+	}
+	if unitVal, ok := kvValue(rec.lastKV, "unit"); !ok || unitVal != "D/ACD" {
+		t.Fatalf("the empty-roster capture must be tagged with the unit value; got kv %v", rec.lastKV)
+	}
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, "Added or confirmed 0") {
+		t.Fatalf("empty roster must not be reported as a normal 'added 0' summary; got %q", got)
+	}
+	if !strings.Contains(strings.ToLower(got), "shouldn't happen") {
+		t.Fatalf("expected an ADR-0002 'shouldn't happen, reported' message, got %q", got)
+	}
+	// No success embed for a non-result.
+	if embed := lastEditEmbed(f.Calls()); embed != nil {
+		t.Fatalf("an empty roster must not produce a success embed; got %+v", embed)
+	}
+}
+
+// A failed roster fetch is a genuine milpac fault on fixed input: it must be
+// captured (tagged with the unit value), surfaced to the operator, and add
+// nobody.
+func TestRunWardenBulkAddInternal_RosterFetchFaultCapturedNoAdds(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	serveRosterAndProfiles(t, utils.LiteRosterResponse{}, http.StatusInternalServerError, nil)
+
+	gm := internalRoleGM()
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	if gm.countCalls("GuildMemberRoleAdd") != 0 {
+		t.Fatalf("a failed roster fetch must not add anyone; got %v", gm.Calls())
+	}
+	if rec.count != 1 {
+		t.Fatalf("a genuine milpac fault must capture exactly once; got %d", rec.count)
+	}
+	if unitVal, ok := kvValue(rec.lastKV, "unit"); !ok || unitVal != "D/ACD" {
+		t.Fatalf("the roster-fetch capture must be tagged with the unit value; got kv %v", rec.lastKV)
+	}
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "Failed to fetch") {
+		t.Fatalf("expected a roster-fetch failure message, got %q", got)
+	}
+}
+
+// A DM-shaped interaction (no GuildID) is rejected with a clear server-only
+// message before any defer, guild call, or roster fetch.
+func TestRunWardenBulkAddInternal_MissingGuildRejectedBeforeAnything(t *testing.T) {
+	tripwireAPIServer(t)
+	gm := &fakeGuildManager{}
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction(stringOption("unit", "D/ACD")) // no GuildID
+
+	runWardenBulkAddInternal(f, gm, i)
+
+	if len(gm.Calls()) != 0 {
+		t.Fatalf("DM-context must not touch the guild; got %v", gm.Calls())
+	}
+	if got := lastResponseContent(f.Calls()); !strings.Contains(got, "can only be used in a server") {
+		t.Fatalf("expected a server-only rejection, got %q", got)
+	}
+}
+
+// A crafted interaction carrying a value absent from the registry is rejected
+// before any guild call or roster fetch — the registry is the safety boundary.
+func TestRunWardenBulkAddInternal_UnknownUnitRejectedBeforeAnything(t *testing.T) {
+	tripwireAPIServer(t)
+	gm := internalRoleGM()
+	f := &fakeResponder{}
+	i := wardenBulkAddInternalInteraction("7") // a one-character slip, not in the registry
+
+	runWardenBulkAddInternal(f, gm, i)
+
+	if len(gm.Calls()) != 0 {
+		t.Fatalf("an unregistered unit must be rejected before any guild call; got %v", gm.Calls())
+	}
+	if got := lastResponseContent(f.Calls()); !strings.Contains(got, "Unknown unit") {
+		t.Fatalf("expected an unknown-unit rejection, got %q", got)
+	}
+}
+
+// A (malformed) interaction with no unit option is rejected before any guild
+// call or roster fetch.
+func TestRunWardenBulkAddInternal_MissingUnitOptionRejected(t *testing.T) {
+	tripwireAPIServer(t)
+	gm := internalRoleGM()
+	f := &fakeResponder{}
+	i := fakeAppCommandInteraction() // no unit option
+	i.GuildID = "guild-1"
+
+	runWardenBulkAddInternal(f, gm, i)
+
+	if len(gm.Calls()) != 0 {
+		t.Fatalf("a missing unit must short-circuit before any guild call; got %v", gm.Calls())
+	}
+	if got := lastResponseContent(f.Calls()); !strings.Contains(got, "Missing unit") {
+		t.Fatalf("expected a missing-unit rejection, got %q", got)
+	}
+}
+
+// When the deferred-ephemeral acknowledge fails, the run bails before resolving
+// roles or fetching the roster, rather than pressing on with no live response.
+func TestRunWardenBulkAddInternal_DeferFailureBailsBeforeWork(t *testing.T) {
+	tripwireAPIServer(t)
+	gm := internalRoleGM()
+	f := &fakeResponder{RespondErrs: []error{errFirstRespond}}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	if gm.countCalls("GuildRoles") != 0 {
+		t.Fatalf("a failed defer must bail before role resolution; got %v", gm.Calls())
+	}
+	if gm.countCalls("GuildMemberRoleAdd") != 0 {
+		t.Fatalf("a failed defer must add nobody; got %v", gm.Calls())
+	}
+}
+
+// When the Verified Warden Internal role is absent from the guild, the run says
+// so and never fetches the roster or adds anyone.
+func TestRunWardenBulkAddInternal_InternalRoleMissingSurfacedNoFetch(t *testing.T) {
+	tripwireAPIServer(t)
+	gm := &fakeGuildManager{roles: []*discordgo.Role{wardenRole("x", "Some Other Role")}}
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	if gm.countCalls("GuildMemberRoleAdd") != 0 {
+		t.Fatalf("must not add anyone when the role is missing; got %v", gm.Calls())
+	}
+	if got := lastEditContent(f.Calls()); !strings.Contains(got, "role not found in guild") {
+		t.Fatalf("expected a role-not-found message, got %q", got)
+	}
+}
+
+// A 5xx from GuildRoles during role resolution is a genuine Discord fault: it
+// captures once, shows a body-free retry message, and never fetches the roster.
+func TestRunWardenBulkAddInternal_RoleResolve5xxCapturedNoFetch(t *testing.T) {
+	tripwireAPIServer(t)
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{RolesErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)}}
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	if rec.count != 1 {
+		t.Fatalf("a 5xx GuildRoles fault must capture exactly once; got %d", rec.count)
+	}
+	if got := lastEditContent(f.Calls()); strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}
+
+// A very large bucket would otherwise push the summary past Discord's 2000-char
+// message limit and fail the edit. The summary must clamp to the limit while
+// keeping the always-present lead line.
+func TestBuildWardenInternalBulkAddSummary_ClampsToDiscordLimit(t *testing.T) {
+	many := make([]string, 400)
+	for i := range many {
+		many[i] = "Trooper.Placeholder.Name"
+	}
+
+	got := buildWardenInternalBulkAddSummary("D/ACD", wardenInternalRoleName, 0, nil, nil, many)
+
+	if len(got) > 2000 {
+		t.Fatalf("summary must stay within Discord's 2000-char limit, got %d", len(got))
+	}
+	if !strings.Contains(got, "Added or confirmed 0") {
+		t.Fatalf("the lead summary line must survive truncation, got %q", got)
+	}
+}
+
+// The command is wired into the registry so Discord registers it and routes its
+// interactions to the handler.
+func TestRegistry_RegistersWardenBulkAddInternal(t *testing.T) {
+	reg := NewRegistry()
+
+	registered := false
+	for _, def := range reg.GetCommands() {
+		if def.Name == "warden-bulkadd-internal" {
+			registered = true
+		}
+	}
+	if !registered {
+		t.Fatal("warden-bulkadd-internal must be registered in the command registry")
+	}
+	if _, ok := reg.GetHandler("warden-bulkadd-internal"); !ok {
+		t.Fatal("warden-bulkadd-internal must resolve a handler from the registry")
+	}
+}

--- a/commands/warden_bulkadd_internal_test.go
+++ b/commands/warden_bulkadd_internal_test.go
@@ -62,7 +62,7 @@ func lastEditEmbed(calls []recordedCall) *discordgo.MessageEmbed {
 // The unit input is a validated, Choices-backed dropdown derived from the unit
 // registry — never free text. This is the safety decision the whole command
 // hangs on (see ADR 0009): the operator can only ever emit a value the registry
-// already contains, so a one-character slip can't substring-match the regiment.
+// already contains, so a careless short query can't substring-match the regiment.
 func TestWardenBulkAddInternalDefinition_SingleUnitPickerFromRegistry(t *testing.T) {
 	cmd := WardenBulkAddInternal()
 
@@ -562,7 +562,7 @@ func TestRunWardenBulkAddInternal_UnknownUnitRejectedBeforeAnything(t *testing.T
 	tripwireAPIServer(t)
 	gm := internalRoleGM()
 	f := &fakeResponder{}
-	i := wardenBulkAddInternalInteraction("7") // a one-character slip, not in the registry
+	i := wardenBulkAddInternalInteraction("7") // a careless short query, not in the registry
 
 	runWardenBulkAddInternal(f, gm, i)
 

--- a/commands/warden_test.go
+++ b/commands/warden_test.go
@@ -36,6 +36,11 @@ type fakeGuildManager struct {
 	// the old role).
 	deletedRoleIDs []string
 
+	// roleAdds records the full argument tuple of every GuildMemberRoleAdd call,
+	// so a test can prove the right Discord IDs reached the right role (the bare
+	// Calls() log only keeps the method name).
+	roleAdds []roleAddCall
+
 	RolesErrs            []error
 	RoleCreateErrs       []error
 	RoleDeleteErrs       []error
@@ -52,6 +57,15 @@ type fakeGuildManager struct {
 type sentChannelMessage struct {
 	channelID string
 	content   string
+}
+
+// roleAddCall is one recorded GuildMemberRoleAdd call with every argument kept,
+// so a test can assert the exact (guildID, userID, roleID) tuples a command
+// emitted rather than only how many adds happened.
+type roleAddCall struct {
+	guildID string
+	userID  string
+	roleID  string
 }
 
 func (g *fakeGuildManager) record(name string) {
@@ -148,9 +162,19 @@ func (g *fakeGuildManager) GuildMembersSearch(_, query string, _ int) ([]*discor
 	return g.searchResults[query], nil
 }
 
-func (g *fakeGuildManager) GuildMemberRoleAdd(_, _, _ string) error {
+func (g *fakeGuildManager) GuildMemberRoleAdd(guildID, userID, roleID string) error {
 	g.record("GuildMemberRoleAdd")
+	g.mu.Lock()
+	g.roleAdds = append(g.roleAdds, roleAddCall{guildID: guildID, userID: userID, roleID: roleID})
+	g.mu.Unlock()
 	return popErr(&g.MemberRoleAddErrs)
+}
+
+// roleAddCalls returns a copy of every recorded GuildMemberRoleAdd tuple.
+func (g *fakeGuildManager) roleAddCalls() []roleAddCall {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]roleAddCall(nil), g.roleAdds...)
 }
 
 func (g *fakeGuildManager) GuildMemberRoleRemove(_, _, _ string) error {

--- a/docs/adr/0009-validated-unit-picker.md
+++ b/docs/adr/0009-validated-unit-picker.md
@@ -1,0 +1,52 @@
+# ADR 0009: Warden internal bulk-add takes a validated unit picker, not free text
+
+## Status
+
+Accepted.
+
+## Decision
+
+`/warden-bulkadd-internal` chooses its unit from a `Choices`-backed dropdown,
+never from a typed string. Behind the dropdown is a small registry in
+`commands/warden_bulkadd_internal.go`:
+
+```go
+type wardenInternalUnit struct{ value, label, query string }
+```
+
+The operator picks a `value`; the command resolves it to a registry row and
+sends that row's author-controlled `query` to the milpac roster lookup. A value
+that isn't in the registry is rejected before any roster fetch or role grant.
+Adding a unit later is one new row: the dropdown choices and the lookup both
+derive from the same slice, so there is no other code to touch.
+
+## Why
+
+The command is a bulk role-grant with no cheap undo. The only way to take the
+role back is `/warden purge`, which wipes everyone in `Verified Warden Internal`
+and forces a full rebuild. So the cost of granting the wrong set of people is
+high and the recovery is disruptive.
+
+The roster lookup is a fuzzy position-group substring search. With a free-text
+field, a one-character slip turns a safe query into a dangerous one: `7` instead
+of `D/ACD` substring-matches most of the regiment, and the command would happily
+add all of them. The blast radius of a typo is the whole server.
+
+A picker removes that input entirely. The operator can only emit a `value` the
+registry already holds, and each registry `query` is verified by the author to
+isolate exactly one unit before it ships. The registry is therefore both the
+extension seam and the safety boundary: breadth is fixed at authoring time, not
+at the keyboard.
+
+This is also why there is no count cap on the command. A cap exists to bound
+operator-controlled breadth; with the picker there is no operator-controlled
+breadth left to bound, so a cap could only ever falsely reject a legitimately
+large unit. The safety lives in the registry, not in a backstop.
+
+## How to apply
+
+- Adding a unit: append one `wardenInternalUnit` row whose `query` you have
+  checked isolates only that unit's roster. Change nothing else.
+- Never replace the picker with a free-text option, and never feed a roster
+  lookup a position string an operator typed for a destructive or bulk grant.
+- For the empty-result handling that pairs with this fixed input, see ADR 0002.

--- a/docs/adr/0009-validated-unit-picker.md
+++ b/docs/adr/0009-validated-unit-picker.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Accepted. Implemented in #208 (issue #206).
 
 ## Decision
 
@@ -22,15 +22,17 @@ derive from the same slice, so there is no other code to touch.
 
 ## Why
 
-The command is a bulk role-grant with no cheap undo. The only way to take the
-role back is `/warden purge`, which wipes everyone in `Verified Warden Internal`
-and forces a full rebuild. So the cost of granting the wrong set of people is
-high and the recovery is disruptive.
+The command is a bulk role-grant with no cheap undo. `/warden remove` only takes
+the role off one member per call, so there is no cheap *bulk* undo: short of
+removing each member by hand, the only reset is `/warden purge`, which wipes
+everyone in `Verified Warden Internal` and forces a full rebuild. So the cost of
+granting the wrong set of people is high and the recovery is disruptive.
 
 The roster lookup is a fuzzy position-group substring search. With a free-text
-field, a one-character slip turns a safe query into a dangerous one: `7` instead
-of `D/ACD` substring-matches most of the regiment, and the command would happily
-add all of them. The blast radius of a typo is the whole server.
+field, a careless short query turns a safe lookup into a dangerous one: for
+example `7` instead of `D/ACD` substring-matches most of the regiment, and the
+command would happily add all of them. The blast radius of a typo is the whole
+server.
 
 A picker removes that input entirely. The operator can only emit a `value` the
 registry already holds, and each registry `query` is verified by the author to


### PR DESCRIPTION
Closes #206.

## What this adds

`/warden-bulkadd-internal` fills the `Verified Warden Internal` role from a unit's milpac roster instead of a hand-pasted list of Discord IDs. The operator picks a unit from a dropdown (one option today, `D/ACD`); the command pulls that unit's roster and grants the internal role to every member by Discord ID.

## How it works

- **Validated picker, not free text.** The unit comes from a `Choices` dropdown backed by a small registry of `{value, label, query}` rows. An unregistered value never resolves to a query, so a one-character slip can't substring-match most of the regiment. ADR 0009 records why the input is a one-option dropdown.
- **Add by ID.** The roster comes from `GetRosterByFuzzyPositionSearch`; each member is added with `GuildMemberRoleAdd` directly, one call per trooper, no name search. The add is additive and idempotent.
- **Outcome buckets.** The ephemeral report leads with the added-or-confirmed count and the reused mention embed, then lists by forum username: members not in this Discord (404), members with no linked Discord, and members that couldn't be added. A 5xx or transport fault goes to Sentry and the run continues past it.
- **Empty vs failure (ADR 0002).** An empty roster on fixed input is treated as a bug, not "the unit is empty": nothing changes, it's captured tagged with the unit value, and the operator is told it shouldn't have happened. There is no silent "added 0".
- Synchronous deferred-ephemeral like `bulkadd`, no goroutine or throttle or cap, and no `DefaultMemberPermissions` in code (the warden convention of governing access through Discord's server-side override).

## Tests

15 new behavioral tests covering the happy path, the 404 / no-Discord-linked / system-fault buckets, and the empty-roster ADR-0002 path. They reuse the existing warden test seams rather than adding new mocking. Coverage stays above floor: commands 90.8%, utils 90.6%.

## Files

- `commands/warden_bulkadd_internal.go` (new)
- `commands/warden_bulkadd_internal_test.go` (new)
- `commands/registry.go` (register the command)
- `docs/adr/0009-validated-unit-picker.md` (new)

## Manual gates CI can't cover

- Smoke test on the test guild.
- Configure the Discord server-side command-permission override for `/warden-bulkadd-internal` before announcing it. A new command name doesn't inherit `/warden`'s override.

*This was generated by AI*
