### PR TITLE
fix(utils): capture HandleError delivery failures to Sentry (#201)

### DIFF
--- a/utils/handlers.go
+++ b/utils/handlers.go
@@ -87,6 +87,12 @@ func HandleError(r InteractionResponder, i *discordgo.InteractionCreate, message
 //
 // Only the sanitized `message` is ever shown to the user; the raw delivery error
 // goes to captureError, never into the user-facing content.
+//
+// The capture is intentionally unconditional on the failure's status class:
+// HandleError runs synchronously inside the interaction window, so any delivery
+// fault here is genuine. This differs from warden's post-window edit helpers,
+// which gate capture on a token-expiry predicate because their edits race the
+// interaction-token lifetime.
 func deliverErrorReply(r InteractionResponder, i *discordgo.InteractionCreate, message string, resp *discordgo.InteractionResponse) {
 	err := r.InteractionRespond(i.Interaction, resp)
 	if err == nil {
@@ -108,19 +114,24 @@ func deliverErrorReply(r InteractionResponder, i *discordgo.InteractionCreate, m
 		"command", interactionCommandName(i), "guild_id", i.GuildID)
 }
 
-// interactionCommandName returns the invoked application-command name for
-// capture context, or "" when none is resolvable (a message component, or a
-// malformed interaction). The type assertion is guarded so a nil or non-command
-// Data never panics — capture context is best-effort, never a new failure mode.
+// interactionCommandName extracts a best-effort label for capture context: the
+// invoked application-command name, or — for a message component — its CustomID,
+// so component delivery failures don't page Sentry with a blank command. It
+// returns "" when neither is resolvable. The type assertions and nil checks are
+// purely defensive (capture context must never become a new failure mode); they
+// are not a nil-interaction guard for HandleError, which dereferences i.Type
+// before this helper ever runs.
 func interactionCommandName(i *discordgo.InteractionCreate) string {
 	if i == nil || i.Interaction == nil {
 		return ""
 	}
-	data, ok := i.Data.(discordgo.ApplicationCommandInteractionData)
-	if !ok {
-		return ""
+	if data, ok := i.Data.(discordgo.ApplicationCommandInteractionData); ok {
+		return data.Name
 	}
-	return data.Name
+	if data, ok := i.Data.(discordgo.MessageComponentInteractionData); ok {
+		return data.CustomID
+	}
+	return ""
 }
 
 // alreadyAcknowledgedCode is Discord's error code for "Interaction has already

--- a/utils/handlers.go
+++ b/utils/handlers.go
@@ -12,6 +12,13 @@ import (
 
 var Logger *slog.Logger
 
+// captureError is the Sentry-capture seam used by HandleError's delivery-failure
+// paths. It points at CaptureError in production; tests swap it to assert that a
+// genuine failure to deliver an error reply pages Sentry while the expected
+// already-acknowledged case that succeeds on the edit fallback does not (ADR
+// 0001). This mirrors the swappable seam the warden error helpers use.
+var captureError = CaptureError
+
 func InitLogger(levelStr string) {
 	var level slog.Level
 	switch levelStr {
@@ -50,46 +57,70 @@ func HandleError(r InteractionResponder, i *discordgo.InteractionCreate, message
 	Info("Error handling interaction", "message", message)
 
 	if i.Type == discordgo.InteractionApplicationCommand {
-		err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		deliverErrorReply(r, i, message, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
 				Content: message,
 				Flags:   discordgo.MessageFlagsEphemeral,
 			},
 		})
-		if err != nil {
-			if isAlreadyAcknowledged(err) {
-				Debug("Retrying error response as edit", "error", err)
-				if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-					Content: &message,
-				}); err != nil {
-					Error("Failed to send error message", "error", err)
-				}
-			} else {
-				Error("Failed to send error message", "error", err)
-			}
-		}
 		return
 	}
 
-	err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	deliverErrorReply(r, i, message, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
 			Content: message,
 		},
 	})
-	if err != nil {
-		if isAlreadyAcknowledged(err) {
-			Debug("Retrying error response as edit", "error", err)
-			if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-				Content: &message,
-			}); err != nil {
-				Error("Failed to send error message", "error", err)
-			}
-		} else {
-			Error("Failed to send error message", "error", err)
-		}
+}
+
+// deliverErrorReply sends the prepared error response and handles delivery
+// failure. The normal path — respond succeeds, or the already-acknowledged
+// respond falls back to an edit that succeeds — captures nothing. A genuine
+// delivery fault does page Sentry via captureError (ADR 0001):
+//
+//   - a respond failure that is NOT "already acknowledged" is a genuine system
+//     fault (the reply never reached Discord), and
+//   - a fallback-edit failure after an already-acknowledged respond means the
+//     user's error reply was lost.
+//
+// Only the sanitized `message` is ever shown to the user; the raw delivery error
+// goes to captureError, never into the user-facing content.
+func deliverErrorReply(r InteractionResponder, i *discordgo.InteractionCreate, message string, resp *discordgo.InteractionResponse) {
+	err := r.InteractionRespond(i.Interaction, resp)
+	if err == nil {
+		return
 	}
+
+	if isAlreadyAcknowledged(err) {
+		Debug("Retrying error response as edit", "error", err)
+		if editErr := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Content: &message,
+		}); editErr != nil {
+			captureError("Failed to deliver interaction error reply via edit fallback", editErr,
+				"command", interactionCommandName(i), "guild_id", i.GuildID)
+		}
+		return
+	}
+
+	captureError("Failed to deliver interaction error reply", err,
+		"command", interactionCommandName(i), "guild_id", i.GuildID)
+}
+
+// interactionCommandName returns the invoked application-command name for
+// capture context, or "" when none is resolvable (a message component, or a
+// malformed interaction). The type assertion is guarded so a nil or non-command
+// Data never panics — capture context is best-effort, never a new failure mode.
+func interactionCommandName(i *discordgo.InteractionCreate) string {
+	if i == nil || i.Interaction == nil {
+		return ""
+	}
+	data, ok := i.Data.(discordgo.ApplicationCommandInteractionData)
+	if !ok {
+		return ""
+	}
+	return data.Name
 }
 
 // alreadyAcknowledgedCode is Discord's error code for "Interaction has already

--- a/utils/handlers_test.go
+++ b/utils/handlers_test.go
@@ -210,7 +210,8 @@ type capturedError struct {
 // swapCaptureError replaces the package capture seam with a recorder for the
 // duration of the test and returns a pointer to the slice of recorded calls, so
 // a test can assert the capture / no-capture split without touching the global
-// Sentry hub.
+// Sentry hub. Tests using this seam must stay non-parallel: it mutates the
+// package-global captureError, so a t.Parallel() sibling would race the swap.
 func swapCaptureError(t *testing.T) *[]capturedError {
 	t.Helper()
 	var recorded []capturedError
@@ -392,5 +393,63 @@ func TestHandleError_Component_RespondSucceeds_NoCapture(t *testing.T) {
 
 	if len(*captured) != 0 {
 		t.Fatalf("expected 0 captures on the normal success path, got %d: %+v", len(*captured), *captured)
+	}
+}
+
+func TestHandleError_Component_AlreadyAck_EditSucceeds_NoCapture(t *testing.T) {
+	captured := swapCaptureError(t)
+	f := &fakeResponder{
+		RespondErrs: []error{errors.New("already been acknowledged")},
+	}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionMessageComponent,
+	}}
+
+	HandleError(f, i, "cancelled")
+
+	if len(*captured) != 0 {
+		t.Fatalf("expected 0 captures when the edit fallback succeeds, got %d: %+v", len(*captured), *captured)
+	}
+}
+
+func TestHandleError_AppCommand_NonAckError_CapturesCommandName(t *testing.T) {
+	// Exercises interactionCommandName's happy path: a real
+	// ApplicationCommandInteractionData resolves to its command Name in the
+	// capture context. Every other test leaves i.Data nil, so this closes the
+	// gap on the type-assertion success branch.
+	captured := swapCaptureError(t)
+	f := &fakeResponder{RespondErrs: []error{errors.New("HTTP 503 Service Unavailable")}}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionApplicationCommand,
+		Data: discordgo.ApplicationCommandInteractionData{Name: "milpac"},
+	}}
+
+	HandleError(f, i, "boom")
+
+	if len(*captured) != 1 {
+		t.Fatalf("expected 1 capture for a non-ack delivery failure, got %d: %+v", len(*captured), *captured)
+	}
+	if cmd, ok := kvValue((*captured)[0].kv, "command"); !ok || cmd != "milpac" {
+		t.Fatalf("expected command context %q in capture, got %v (ok=%v)", "milpac", cmd, ok)
+	}
+}
+
+func TestHandleError_Component_NonAckError_CapturesCustomID(t *testing.T) {
+	// Component interactions carry no command Name, so the capture context falls
+	// back to the component's CustomID — a blank command otherwise hurts triage.
+	captured := swapCaptureError(t)
+	f := &fakeResponder{RespondErrs: []error{errors.New("HTTP 502 Bad Gateway")}}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionMessageComponent,
+		Data: discordgo.MessageComponentInteractionData{CustomID: "warden_purge_confirm"},
+	}}
+
+	HandleError(f, i, "cancelled")
+
+	if len(*captured) != 1 {
+		t.Fatalf("expected 1 capture for a non-ack delivery failure, got %d: %+v", len(*captured), *captured)
+	}
+	if cmd, ok := kvValue((*captured)[0].kv, "command"); !ok || cmd != "warden_purge_confirm" {
+		t.Fatalf("expected component CustomID %q as command context, got %v (ok=%v)", "warden_purge_confirm", cmd, ok)
 	}
 }

--- a/utils/handlers_test.go
+++ b/utils/handlers_test.go
@@ -199,3 +199,198 @@ func TestHandleError_Component_NonAckError_NoFallback(t *testing.T) {
 		t.Fatalf("expected 1 call (no fallback on non-ack error), got %d", len(calls))
 	}
 }
+
+// capturedError records one captureError seam invocation for assertions.
+type capturedError struct {
+	msg string
+	err error
+	kv  []any
+}
+
+// swapCaptureError replaces the package capture seam with a recorder for the
+// duration of the test and returns a pointer to the slice of recorded calls, so
+// a test can assert the capture / no-capture split without touching the global
+// Sentry hub.
+func swapCaptureError(t *testing.T) *[]capturedError {
+	t.Helper()
+	var recorded []capturedError
+	orig := captureError
+	captureError = func(msg string, err error, kv ...any) {
+		recorded = append(recorded, capturedError{msg: msg, err: err, kv: kv})
+	}
+	t.Cleanup(func() { captureError = orig })
+	return &recorded
+}
+
+// kvValue returns the value paired with key in a captureError kv slice.
+func kvValue(kv []any, key string) (any, bool) {
+	for i := 0; i+1 < len(kv); i += 2 {
+		if k, ok := kv[i].(string); ok && k == key {
+			return kv[i+1], true
+		}
+	}
+	return nil, false
+}
+
+func TestHandleError_AppCommand_NonAckError_Captures(t *testing.T) {
+	captured := swapCaptureError(t)
+	respondErr := errors.New("HTTP 503 Service Unavailable")
+	f := &fakeResponder{RespondErrs: []error{respondErr}}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type:    discordgo.InteractionApplicationCommand,
+		GuildID: "guild-123",
+	}}
+
+	HandleError(f, i, "boom")
+
+	if len(*captured) != 1 {
+		t.Fatalf("expected 1 capture for a non-ack delivery failure, got %d: %+v", len(*captured), *captured)
+	}
+	if !errors.Is((*captured)[0].err, respondErr) {
+		t.Fatalf("captured err = %v, want %v", (*captured)[0].err, respondErr)
+	}
+	if gid, ok := kvValue((*captured)[0].kv, "guild_id"); !ok || gid != "guild-123" {
+		t.Fatalf("expected guild_id context %q in capture, got %v (ok=%v)", "guild-123", gid, ok)
+	}
+	// A non-ack failure must not attempt the edit fallback.
+	if calls := f.Calls(); len(calls) != 1 {
+		t.Fatalf("expected 1 call (Respond only), got %d", len(calls))
+	}
+}
+
+func TestHandleError_AppCommand_FallbackEditFails_Captures(t *testing.T) {
+	captured := swapCaptureError(t)
+	editErr := errors.New("HTTP 500 Internal Server Error")
+	f := &fakeResponder{
+		RespondErrs: []error{errors.New("already been acknowledged")},
+		EditErrs:    []error{editErr},
+	}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionApplicationCommand,
+	}}
+
+	HandleError(f, i, "boom")
+
+	if len(*captured) != 1 {
+		t.Fatalf("expected 1 capture for a lost fallback edit, got %d: %+v", len(*captured), *captured)
+	}
+	if !errors.Is((*captured)[0].err, editErr) {
+		t.Fatalf("captured err = %v, want the edit error %v", (*captured)[0].err, editErr)
+	}
+	calls := f.Calls()
+	if len(calls) != 2 || calls[1].Method != "Edit" {
+		t.Fatalf("expected Respond+Edit, got %+v", calls)
+	}
+}
+
+func TestHandleError_AppCommand_RespondSucceeds_NoCapture(t *testing.T) {
+	captured := swapCaptureError(t)
+	f := &fakeResponder{}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionApplicationCommand,
+	}}
+
+	HandleError(f, i, "boom")
+
+	if len(*captured) != 0 {
+		t.Fatalf("expected 0 captures on the normal success path, got %d: %+v", len(*captured), *captured)
+	}
+}
+
+func TestHandleError_AppCommand_AlreadyAck_EditSucceeds_NoCapture(t *testing.T) {
+	captured := swapCaptureError(t)
+	f := &fakeResponder{
+		RespondErrs: []error{errors.New("already been acknowledged")},
+	}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionApplicationCommand,
+	}}
+
+	HandleError(f, i, "boom")
+
+	if len(*captured) != 0 {
+		t.Fatalf("expected 0 captures when the edit fallback succeeds, got %d: %+v", len(*captured), *captured)
+	}
+}
+
+func TestHandleError_AppCommand_NoRawErrorBodyInUserMessage(t *testing.T) {
+	swapCaptureError(t)
+	// Respond fails as already-acknowledged while carrying a raw Discord body; the
+	// edit fallback is the user-facing delivery and must carry only the sanitized
+	// message, never the raw body.
+	rawBody := `HTTP 400 Bad Request: {"message":"secret internal detail","code":40060} already been acknowledged`
+	f := &fakeResponder{RespondErrs: []error{errors.New(rawBody)}}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionApplicationCommand,
+	}}
+
+	HandleError(f, i, "❌ user-facing boom")
+
+	calls := f.Calls()
+	if len(calls) != 2 || calls[1].Method != "Edit" {
+		t.Fatalf("expected Respond+Edit, got %+v", calls)
+	}
+	got := "<nil>"
+	if calls[1].Edit.Content != nil {
+		got = *calls[1].Edit.Content
+	}
+	if got != "❌ user-facing boom" {
+		t.Fatalf("edit content = %q, want the sanitized message", got)
+	}
+	if strings.Contains(got, "secret internal detail") {
+		t.Fatalf("raw Discord error body leaked into the user-facing message: %q", got)
+	}
+}
+
+func TestHandleError_Component_NonAckError_Captures(t *testing.T) {
+	captured := swapCaptureError(t)
+	respondErr := errors.New("HTTP 502 Bad Gateway")
+	f := &fakeResponder{RespondErrs: []error{respondErr}}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionMessageComponent,
+	}}
+
+	HandleError(f, i, "cancelled")
+
+	if len(*captured) != 1 {
+		t.Fatalf("expected 1 capture for a non-ack delivery failure, got %d: %+v", len(*captured), *captured)
+	}
+	if !errors.Is((*captured)[0].err, respondErr) {
+		t.Fatalf("captured err = %v, want %v", (*captured)[0].err, respondErr)
+	}
+}
+
+func TestHandleError_Component_FallbackEditFails_Captures(t *testing.T) {
+	captured := swapCaptureError(t)
+	editErr := errors.New("HTTP 500")
+	f := &fakeResponder{
+		RespondErrs: []error{errors.New("already been acknowledged")},
+		EditErrs:    []error{editErr},
+	}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionMessageComponent,
+	}}
+
+	HandleError(f, i, "cancelled")
+
+	if len(*captured) != 1 {
+		t.Fatalf("expected 1 capture for a lost fallback edit, got %d: %+v", len(*captured), *captured)
+	}
+	if !errors.Is((*captured)[0].err, editErr) {
+		t.Fatalf("captured err = %v, want the edit error %v", (*captured)[0].err, editErr)
+	}
+}
+
+func TestHandleError_Component_RespondSucceeds_NoCapture(t *testing.T) {
+	captured := swapCaptureError(t)
+	f := &fakeResponder{}
+	i := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionMessageComponent,
+	}}
+
+	HandleError(f, i, "cancelled")
+
+	if len(*captured) != 0 {
+		t.Fatalf("expected 0 captures on the normal success path, got %d: %+v", len(*captured), *captured)
+	}
+}


### PR DESCRIPTION
Closes #201.

`utils.HandleError` logged every error-reply delivery failure at Error level but never reached Sentry, so a real delivery outage gave on-call nothing to act on. This routes the genuine-fault branches through `utils.CaptureError` per ADR 0001.

## What changed

The two near-identical branches (application-command and message-component) fold into one `deliverErrorReply` helper. On a delivery failure the helper routes through a swappable `captureError` seam (pointing at `utils.CaptureError`, mirroring the warden error-helper pattern):

- a respond failure that is not "already acknowledged" is captured, since the reply never reached Discord;
- a fallback-edit failure after an acknowledged respond is captured, since the user's reply was lost.

The normal path captures nothing: the respond succeeds, or an already-acknowledged respond falls back to a successful edit. Capture context carries the command name and `guild_id`. The raw delivery error only goes to `captureError`; the user still sees the sanitized message.

## Double-capture check

Confirmed orthogonal. Warden's own edit-failure captures fire on its direct `InteractionResponseEdit` helpers, which never route through `HandleError`. The per-site captures from #194, #195, and #191 record the underlying API fault before calling `HandleError`; a failed delivery of that message is a separate fault. Each error flows through exactly one capture path.

## Tests

8 new behavioral tests cover the capture and no-capture split for both branches, plus the no-raw-body guarantee. Full CI gate green locally: lint clean, `go mod tidy` a no-op, race tests pass, coverage floors held (utils 90.7%, commands 90.9%), build clean.

> *This was generated by AI*