### PR TITLE
fix(warden): split 404 reasons by Discord error code in classifier (#209)

### DIFF
--- a/commands/warden_bulkadd_internal_test.go
+++ b/commands/warden_bulkadd_internal_test.go
@@ -345,6 +345,49 @@ func TestRunWardenBulkAddInternal_NotInGuild404ListedNotAddedNoCapture(t *testin
 	}
 }
 
+// The headline #209 scenario: the resolved role is deleted between resolution
+// and the add loop, so every add 404s with Unknown Role (10011). This must NOT
+// be misread as the members being absent ("Not in this Discord") — that conflates
+// a config fault with genuine absence. Each add is a captured system fault listed
+// under "Could not be added", and the raw Discord body never leaks.
+func TestRunWardenBulkAddInternal_DeletedRole404CapturedNotMisreportedAbsent(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	serveRosterAndProfiles(t, liteRoster(
+		liteMember("Present.A", "111111111111111111"),
+		liteMember("Present.B", "222222222222222222"),
+	), http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	// Both present members 404 with Unknown Role: the role ID went stale.
+	gm.MemberRoleAddErrs = []error{
+		restError(http.StatusNotFound, discordgo.ErrCodeUnknownRole, rawBodyMarker),
+		restError(http.StatusNotFound, discordgo.ErrCodeUnknownRole, rawBodyMarker),
+	}
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	got := lastEditContent(f.Calls())
+	// Present members must NOT be reported as absent.
+	if strings.Contains(got, "Not in this Discord") {
+		t.Fatalf("a deleted-role 404 must not misreport present members as 'Not in this Discord'; got %q", got)
+	}
+	if !strings.Contains(got, "Could not be added (2)") {
+		t.Fatalf("a stale-role 404 must list both members under 'Could not be added'; got %q", got)
+	}
+	// Both stale-role faults are genuine config faults: each captures to Sentry.
+	if rec.count != 2 {
+		t.Fatalf("two stale-role 404s must capture to Sentry once each; got %d", rec.count)
+	}
+	if unitVal, ok := kvValue(rec.lastKV, "unit"); !ok || unitVal != "D/ACD" {
+		t.Fatalf("the capture must be tagged with the unit value; got kv %v", rec.lastKV)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}
+
 // A non-404 client fault on an add (here a 403 — bot lacks Manage Roles or the
 // role sits above it) is still surfaced, never silently dropped, but it is an
 // operator-fixable condition so it must NOT capture to Sentry.

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -21,18 +21,23 @@ var captureError = utils.CaptureError
 // "HTTP <status>, <full JSON body>", which we must keep out of user-facing
 // replies (ADR 0001: CaptureError is for genuine internal failures only).
 type discordErrorClass struct {
-	// SystemFault is true for 5xx responses and transport errors. Only these
-	// should be sent to Sentry via utils.CaptureError; 4xx client/config faults
-	// must not page on-call for an ordinary, fixable condition.
+	// SystemFault is true for 5xx responses, transport errors, and the
+	// config-fault 404s (a stale/deleted role or a wrong guild ID — see NotFound).
+	// Only these should be sent to Sentry via utils.CaptureError; ordinary,
+	// operator-fixable 4xx client faults must not page on-call.
 	SystemFault bool
 	// MissingPermissions is true for a 403 Forbidden, the common case where the
 	// bot lacks Manage Roles or the target role sits above the bot's own role.
 	// Callers use it to render a specific, actionable hierarchy hint.
 	MissingPermissions bool
-	// NotFound is true for a 404. On a targeted member-by-ID/mention lookup this
-	// means the user is genuinely absent from the guild — a clear, non-system
-	// condition the caller renders as "not in this server" rather than capturing
-	// or downgrading into a name search.
+	// NotFound is true only for a 404 that means the targeted entity is genuinely
+	// absent: Discord's Unknown Member (10007) code, or a bare 404 with no
+	// application error code. On a member-by-ID/mention lookup the caller renders
+	// it as "not in this server" rather than capturing or downgrading into a name
+	// search. A 404 carrying Unknown Role (10011), Unknown Guild (10004), or any
+	// other unexpected code is NOT a genuine absence — it is a stale-ID/config
+	// fault routed to SystemFault instead, so a role deleted mid-operation pages
+	// on-call rather than misreporting every member as absent.
 	NotFound bool
 	// UserDetail is a short, body-free phrase safe to show an operator. It never
 	// contains the raw Discord error body.
@@ -64,10 +69,7 @@ func classifyDiscordError(err error) discordErrorClass {
 			UserDetail:         "missing permissions",
 		}
 	case status == http.StatusNotFound:
-		return discordErrorClass{
-			NotFound:   true,
-			UserDetail: "not found",
-		}
+		return classifyNotFound(restErr)
 	case status >= 400 && status < 500:
 		return discordErrorClass{
 			UserDetail: "Discord rejected the request",
@@ -78,6 +80,39 @@ func classifyDiscordError(err error) discordErrorClass {
 			SystemFault: true,
 			UserDetail:  "Discord returned a server error",
 		}
+	}
+}
+
+// classifyNotFound splits a 404 by its Discord application error code, because a
+// 404 alone is ambiguous: a role-add (PUT .../members/{user}/roles/{role}) can
+// 404 for an absent member, a stale/deleted role, or a wrong guild ID. Reading
+// restErr.Message.Code tells them apart, the same Message.Code pattern
+// isInteractionTokenExpired uses below.
+//
+//   - Unknown Member (10007), or a bare 404 with no application error code, is a
+//     genuine absence: NotFound, non-captured, rendered as "not in this server".
+//   - Unknown Role (10011), Unknown Guild (10004), or any other unexpected code
+//     is a stale-ID/config fault: SystemFault, so it pages on-call (ADR 0001)
+//     instead of a deleted role silently misreporting every member as absent.
+//
+// The raw response body is still discarded — only a sanitized UserDetail phrase
+// is carried, so nothing leaks into a user-facing reply.
+func classifyNotFound(restErr *discordgo.RESTError) discordErrorClass {
+	code := 0
+	if restErr.Message != nil {
+		code = restErr.Message.Code
+	}
+
+	if code == 0 || code == discordgo.ErrCodeUnknownMember {
+		return discordErrorClass{
+			NotFound:   true,
+			UserDetail: "not found",
+		}
+	}
+
+	return discordErrorClass{
+		SystemFault: true,
+		UserDetail:  "unknown role or guild",
 	}
 }
 

--- a/commands/warden_resterror_test.go
+++ b/commands/warden_resterror_test.go
@@ -151,6 +151,46 @@ func TestClassifyDiscordError_404BareCodeStaysNotFound(t *testing.T) {
 	}
 }
 
+// classifyNotFound routes ANY non-zero 404 code that isn't Unknown Member through
+// a single catch-all into SystemFault, not just the named Unknown Role / Unknown
+// Guild codes. Pin that with an arbitrary, never-named code so a future refactor
+// to explicit `case` arms can't silently narrow the contract and let an
+// unexpected code fall back to NotFound.
+func TestClassifyDiscordError_404UnexpectedCodeIsSystemFault(t *testing.T) {
+	err := restError(http.StatusNotFound, 12345, rawBodyMarker)
+	c := classifyDiscordError(err)
+	if !c.SystemFault {
+		t.Fatalf("a 404 with an unexpected non-zero code must classify as a captured system fault")
+	}
+	if c.NotFound {
+		t.Fatalf("a 404 with an unexpected non-zero code must NOT set NotFound — only Unknown Member or a bare 404 is a genuine absence")
+	}
+	if strings.Contains(c.UserDetail, rawBodyMarker) {
+		t.Fatalf("classifier leaked the raw Discord body: %q", c.UserDetail)
+	}
+}
+
+// discordgo leaves RESTError.Message nil when a 404's response body isn't
+// parseable JSON, so there is no application error code to read. classifyNotFound's
+// restErr.Message == nil guard must treat that as a bare 404 — NotFound, no
+// capture — without dereferencing the nil Message. The restError helper always
+// sets a non-nil Message, so this RESTError is built inline to exercise the
+// genuine nil-Message branch.
+func TestClassifyDiscordError_404NilMessageStaysNotFound(t *testing.T) {
+	err := &discordgo.RESTError{
+		Response:     &http.Response{StatusCode: http.StatusNotFound, Status: "404 Not Found"},
+		ResponseBody: []byte("not parseable json"),
+		Message:      nil,
+	}
+	c := classifyDiscordError(err)
+	if c.SystemFault {
+		t.Fatalf("a 404 with a nil Message (unparseable body) must not be a system fault")
+	}
+	if !c.NotFound {
+		t.Fatalf("a 404 with a nil Message must stay NotFound, matching the bare-404 contract")
+	}
+}
+
 // --- mention/ID lookup: authoritative, never falls through to name search ---
 
 // A valid mention for a present member resolves via the targeted GuildMember
@@ -508,6 +548,11 @@ func TestRunWardenAdd_RoleAddUnknownRole404CapturesDistinct(t *testing.T) {
 	if strings.Contains(got, "Discord rejected the request") {
 		t.Fatalf("an Unknown Role 404 must surface a line distinct from the plain not-found rendering, got %q", got)
 	}
+	// Positively pin the SystemFault arm's wording the operator actually sees, so
+	// a regression rendering an empty-but-non-generic line still fails here.
+	if !strings.Contains(got, "Discord error") {
+		t.Fatalf("an Unknown Role 404 must render the system-fault wording (%q), got %q", "Discord error", got)
+	}
 	if rec.count != 1 {
 		t.Fatalf("an Unknown Role 404 (stale/deleted role) must capture to Sentry once; got %d", rec.count)
 	}
@@ -534,6 +579,11 @@ func TestRunWardenRemove_RoleRemoveUnknownGuild404Captures(t *testing.T) {
 	}
 	if strings.Contains(got, "Discord rejected the request") {
 		t.Fatalf("an Unknown Guild 404 must surface a line distinct from the plain not-found rendering, got %q", got)
+	}
+	// Positively pin the SystemFault arm's wording the operator actually sees, so
+	// a regression rendering an empty-but-non-generic line still fails here.
+	if !strings.Contains(got, "Discord error") {
+		t.Fatalf("an Unknown Guild 404 must render the system-fault wording (%q), got %q", "Discord error", got)
 	}
 	if rec.count != 1 {
 		t.Fatalf("an Unknown Guild 404 (bad guild ID) must capture to Sentry once; got %d", rec.count)

--- a/commands/warden_resterror_test.go
+++ b/commands/warden_resterror_test.go
@@ -82,21 +82,72 @@ func TestClassifyDiscordError_RESTErrorNilResponseIsSystemFault(t *testing.T) {
 	}
 }
 
-// A 404 is a distinct, non-system client fault: the targeted member-by-ID
-// lookup proved the user is absent. It must set NotFound (so findGuildMember can
-// render a clear "not in this server" message) without setting SystemFault or
-// MissingPermissions, and never leak the raw body.
-func TestClassifyDiscordError_404IsNotFound(t *testing.T) {
+// A 404 carrying Unknown Member (10007) is a distinct, non-system client fault:
+// the targeted member-by-ID lookup proved the user is genuinely absent. It must
+// set NotFound (so findGuildMember can render a clear "not in this server"
+// message) without setting SystemFault or MissingPermissions, and never leak the
+// raw body.
+func TestClassifyDiscordError_404UnknownMemberIsNotFound(t *testing.T) {
 	err := restError(http.StatusNotFound, 10007, rawBodyMarker)
 	c := classifyDiscordError(err)
 	if c.SystemFault {
-		t.Fatalf("a 404 must not be a system fault")
+		t.Fatalf("a 404 Unknown Member must not be a system fault")
 	}
 	if !c.NotFound {
-		t.Fatalf("a 404 must set NotFound so callers can show a clear absent-member message")
+		t.Fatalf("a 404 Unknown Member must set NotFound so callers can show a clear absent-member message")
 	}
 	if strings.Contains(c.UserDetail, rawBodyMarker) {
 		t.Fatalf("classifier leaked the raw Discord body: %q", c.UserDetail)
+	}
+}
+
+// A 404 carrying Unknown Role (10011) is NOT a genuine absence — the role ID
+// went stale or the role was deleted, a config fault. It must classify as a
+// captured system fault (SystemFault), never as NotFound (which would misreport
+// the role's members as "not in this server"), and never leak the raw body.
+func TestClassifyDiscordError_404UnknownRoleIsSystemFault(t *testing.T) {
+	err := restError(http.StatusNotFound, discordgo.ErrCodeUnknownRole, rawBodyMarker)
+	c := classifyDiscordError(err)
+	if !c.SystemFault {
+		t.Fatalf("a 404 Unknown Role (stale/deleted role) must classify as a captured system fault")
+	}
+	if c.NotFound {
+		t.Fatalf("a 404 Unknown Role must NOT set NotFound — it is a config fault, not an absent member")
+	}
+	if strings.Contains(c.UserDetail, rawBodyMarker) {
+		t.Fatalf("classifier leaked the raw Discord body: %q", c.UserDetail)
+	}
+}
+
+// A 404 carrying Unknown Guild (10004) means the guild ID is wrong — a config
+// fault, not an absent member. Same treatment as Unknown Role: captured system
+// fault, never NotFound, never a body leak.
+func TestClassifyDiscordError_404UnknownGuildIsSystemFault(t *testing.T) {
+	err := restError(http.StatusNotFound, discordgo.ErrCodeUnknownGuild, rawBodyMarker)
+	c := classifyDiscordError(err)
+	if !c.SystemFault {
+		t.Fatalf("a 404 Unknown Guild (bad guild ID) must classify as a captured system fault")
+	}
+	if c.NotFound {
+		t.Fatalf("a 404 Unknown Guild must NOT set NotFound — it is a config fault, not an absent member")
+	}
+	if strings.Contains(c.UserDetail, rawBodyMarker) {
+		t.Fatalf("classifier leaked the raw Discord body: %q", c.UserDetail)
+	}
+}
+
+// A bare 404 with no application error code (Discord can answer a member lookup
+// with a 404 and no body code) must keep the genuine-absence behavior: NotFound,
+// no capture. This preserves the targeted member-lookup contract — only an
+// unexpected NON-zero 404 code is a config fault.
+func TestClassifyDiscordError_404BareCodeStaysNotFound(t *testing.T) {
+	err := restError(http.StatusNotFound, 0, rawBodyMarker)
+	c := classifyDiscordError(err)
+	if c.SystemFault {
+		t.Fatalf("a bare 404 (no application error code) must not be a system fault")
+	}
+	if !c.NotFound {
+		t.Fatalf("a bare 404 must stay NotFound so the member-lookup path keeps its absent-member message")
 	}
 }
 
@@ -144,6 +195,28 @@ func TestFindGuildMember_Mention404ClearMessageNoSearchNoCapture(t *testing.T) {
 	}
 	if rec.count != 0 {
 		t.Fatalf("a 404 mention must NOT capture to Sentry; got %d", rec.count)
+	}
+}
+
+// The targeted member lookup must keep its absent-member behavior for a bare 404
+// (no application error code) just as for Unknown Member: a clear "not in this
+// server" message, no name search, no Sentry capture. The new code-aware
+// classifier only treats an unexpected NON-zero 404 code as a config fault, so
+// the member-lookup contract is unchanged for the codeless case.
+func TestFindGuildMember_MentionBare404StaysNotInServerNoCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{MemberErrs: []error{restError(http.StatusNotFound, 0, rawBodyMarker)}}
+
+	_, err := findGuildMember(gm, "guild-1", "<@123456789012345678>")
+	if err == nil {
+		t.Fatal("expected an error when the mentioned member is absent")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "not in this server") {
+		t.Fatalf("a bare 404 must keep the clear absent-member message, got %q", err.Error())
+	}
+	if rec.count != 0 {
+		t.Fatalf("a bare 404 mention must NOT capture to Sentry; got %d", rec.count)
 	}
 }
 
@@ -389,14 +462,16 @@ func TestRunWardenAdd_RoleAdd5xxCapturesGenericRetry(t *testing.T) {
 	}
 }
 
-// A non-403 4xx (here a 404) is still an operator/config-fixable client fault:
-// it must show the generic "Discord rejected the request" wording, never the
-// raw body, and never capture to Sentry. Covers the default arm of
-// roleMutationErrorReply, which no other mutation-site test exercises.
+// A non-403 4xx (here a 400 with a non-permission code) is an
+// operator/config-fixable client fault: it must show the generic "Discord
+// rejected the request" wording, never the raw body, and never capture to
+// Sentry. Covers the default arm of roleMutationErrorReply, which no other
+// mutation-site test exercises. (A 404 no longer reaches this arm — Unknown Role
+// and Unknown Guild codes are captured system faults; see the tests below.)
 func TestRunWardenAdd_RoleAddGeneric4xxNoCapture(t *testing.T) {
 	rec := &captureRecorder{}
 	rec.install(t)
-	gm := wardenRoleAddGM(restError(http.StatusNotFound, 10011, rawBodyMarker))
+	gm := wardenRoleAddGM(restError(http.StatusBadRequest, 50035, rawBodyMarker))
 	f := &fakeResponder{}
 
 	runWarden(f, gm, wardenAddInteraction())
@@ -410,6 +485,58 @@ func TestRunWardenAdd_RoleAddGeneric4xxNoCapture(t *testing.T) {
 	}
 	if rec.count != 0 {
 		t.Fatalf("a generic 4xx role add must NOT capture to Sentry; got %d", rec.count)
+	}
+}
+
+// A role-add 404 carrying Unknown Role (10011) — the resolved role was deleted
+// between resolution and the add — is a config fault, not an absent member. It
+// must capture to Sentry exactly once, render an operator-facing line DISTINCT
+// from the plain "Discord rejected the request" not-found rendering, and never
+// leak the raw Discord body.
+func TestRunWardenAdd_RoleAddUnknownRole404CapturesDistinct(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := wardenRoleAddGM(restError(http.StatusNotFound, discordgo.ErrCodeUnknownRole, rawBodyMarker))
+	f := &fakeResponder{}
+
+	runWarden(f, gm, wardenAddInteraction())
+
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("role-add Unknown Role 404 leaked the raw Discord body: %q", got)
+	}
+	if strings.Contains(got, "Discord rejected the request") {
+		t.Fatalf("an Unknown Role 404 must surface a line distinct from the plain not-found rendering, got %q", got)
+	}
+	if rec.count != 1 {
+		t.Fatalf("an Unknown Role 404 (stale/deleted role) must capture to Sentry once; got %d", rec.count)
+	}
+}
+
+// The remove path shares the classifier, so a role-remove 404 carrying Unknown
+// Guild (10004) — a wrong guild ID — must capture exactly once and never leak
+// the raw body, mirroring the add path's Unknown Role coverage.
+func TestRunWardenRemove_RoleRemoveUnknownGuild404Captures(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{
+		roles:                []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		membersByID:          map[string]*discordgo.Member{"123456789012345678": {User: &discordgo.User{ID: "123456789012345678", Username: "trooper"}}},
+		MemberRoleRemoveErrs: []error{restError(http.StatusNotFound, discordgo.ErrCodeUnknownGuild, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, wardenRemoveInteraction())
+
+	got := lastEditContent(f.Calls())
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("role-remove Unknown Guild 404 leaked the raw Discord body: %q", got)
+	}
+	if strings.Contains(got, "Discord rejected the request") {
+		t.Fatalf("an Unknown Guild 404 must surface a line distinct from the plain not-found rendering, got %q", got)
+	}
+	if rec.count != 1 {
+		t.Fatalf("an Unknown Guild 404 (bad guild ID) must capture to Sentry once; got %d", rec.count)
 	}
 }
 


### PR DESCRIPTION
Closes #209.

`classifyDiscordError` branched on HTTP status alone, so every 404 collapsed into the not-found bucket. But the role-add call (`PUT .../members/{user}/roles/{role}`) returns 404 for distinct reasons, and only one of them means the user is genuinely absent:

- Unknown Member (10007): the user isn't in the guild
- Unknown Role (10011): the role ID is stale or the role was deleted
- Unknown Guild (10004): the guild ID is wrong

When a target role was deleted between resolution and the add loop, every member's add 404'd as Unknown Role, the operator saw a generic rejection per trooper, and the real config fault never reached Sentry.

## What changed

The `http.StatusNotFound` case now delegates to `classifyNotFound`, which reads `restErr.Message.Code` (the same `Message.Code` pattern `isInteractionTokenExpired` already uses):

- Unknown Member (10007), or a bare codeless 404, stays a non-captured `NotFound`, so `resolveMemberByID`'s "not in this server" path is unchanged.
- Unknown Role (10011), Unknown Guild (10004), or any other unexpected code routes to the existing `SystemFault` bucket.

Reusing `SystemFault` means every consumer (the role-mutation reply helpers and the `runWardenBulkAddInternal` per-member loop, which already branch on it) captures via `utils.CaptureError` and renders its body-free system-fault line. No caller changes were needed, so add, remove, and bulkadd-internal all benefit from the single classifier change. The sanitized UserDetail phrase keeps any raw Discord body out of replies.

## Tests

New tests cover the split across the role-mutation paths: Unknown Member stays non-captured, Unknown Role and Unknown Guild are captured exactly once, the deleted-role bulkadd scenario surfaces a line distinct from plain not-found, and no body leaks. Full CI gate green locally: lint clean, `go mod tidy` a no-op, race tests pass, coverage floors held (utils 90.6%, commands 90.9%), build clean.

The 429 rate-limit class noted in the issue stays out of scope, tracked as a separate follow-up.

> *This was generated by AI*