### PR TITLE
fix(warden): collapse per-member Sentry captures in bulk role-add loops

### DIFF
--- a/commands/warden.go
+++ b/commands/warden.go
@@ -284,8 +284,15 @@ func handleWardenBulkAdd(
 	// role deleted mid-run 404s every add with the same signature, which would
 	// otherwise page on-call once per member-role attempt. System faults feed it
 	// during the loop and it flushes once after; non-captured client faults (403,
-	// not-in-server 404) are listed but never routed here, per ADR 0001 (#214).
+	// not-in-server 404) are listed but never routed here, per ADR 0001 (#214). The
+	// flush is deferred immediately, so an early return or a panic between the loop
+	// and the flush can never silently drop pending captures; guildID is fixed for
+	// the run, so evaluating the deferred args here is exact.
 	faultCapture := newFaultCollector()
+	defer faultCapture.flush(
+		"Failed to add warden role in bulk",
+		"command", "warden", "guild", guildID,
+	)
 	for _, singleQuery := range requestedQueries {
 		member, memberErr := findGuildMember(gm, guildID, singleQuery)
 		if memberErr != nil {
@@ -302,7 +309,7 @@ func handleWardenBulkAdd(
 				// storm pages once per signature rather than once per member-role add.
 				class := classifyDiscordError(err)
 				if class.SystemFault {
-					faultCapture.add(err, member.User.ID)
+					faultCapture.recordSystemFault(err, member.User.ID)
 				}
 				failures = append(failures, roleMutationErrorMessage("add", roleName, formatUser(member), class))
 				allOK = false
@@ -312,12 +319,6 @@ func handleWardenBulkAdd(
 			addedMembers = append(addedMembers, member)
 		}
 	}
-
-	// Flush once after the loop: one capture per distinct fault signature.
-	faultCapture.flush(
-		"Failed to add warden role in bulk",
-		"command", "warden", "guild", guildID,
-	)
 
 	content := buildBulkAddSummary(len(addedMembers), failures)
 	var embed *discordgo.MessageEmbed

--- a/commands/warden.go
+++ b/commands/warden.go
@@ -280,6 +280,12 @@ func handleWardenBulkAdd(
 
 	var addedMembers []*discordgo.Member
 	var failures []string
+	// One collector per run collapses the per-member-role system-fault captures: a
+	// role deleted mid-run 404s every add with the same signature, which would
+	// otherwise page on-call once per member-role attempt. System faults feed it
+	// during the loop and it flushes once after; non-captured client faults (403,
+	// not-in-server 404) are listed but never routed here, per ADR 0001 (#214).
+	faultCapture := newFaultCollector()
 	for _, singleQuery := range requestedQueries {
 		member, memberErr := findGuildMember(gm, guildID, singleQuery)
 		if memberErr != nil {
@@ -291,10 +297,14 @@ func handleWardenBulkAdd(
 		for index, roleID := range roleIDs {
 			roleName := roleNames[index]
 			if err := gm.GuildMemberRoleAdd(guildID, member.User.ID, roleID); err != nil {
-				failures = append(failures, roleMutationErrorReply(
-					"add", roleName, formatUser(member), err,
-					"Failed to add warden role in bulk", "user", member.User.ID, "role", roleName,
-				))
+				// Build the per-member message immediately, but hand a genuine system
+				// fault to the collector instead of capturing it here, so a deleted-role
+				// storm pages once per signature rather than once per member-role add.
+				class := classifyDiscordError(err)
+				if class.SystemFault {
+					faultCapture.add(err, member.User.ID)
+				}
+				failures = append(failures, roleMutationErrorMessage("add", roleName, formatUser(member), class))
 				allOK = false
 			}
 		}
@@ -302,6 +312,12 @@ func handleWardenBulkAdd(
 			addedMembers = append(addedMembers, member)
 		}
 	}
+
+	// Flush once after the loop: one capture per distinct fault signature.
+	faultCapture.flush(
+		"Failed to add warden role in bulk",
+		"command", "warden", "guild", guildID,
+	)
 
 	content := buildBulkAddSummary(len(addedMembers), failures)
 	var embed *discordgo.MessageEmbed

--- a/commands/warden_bulkadd_collapse_test.go
+++ b/commands/warden_bulkadd_collapse_test.go
@@ -1,0 +1,158 @@
+package commands
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// bulkAddInteraction builds a /warden bulkadd interaction for the given scope
+// and comma-separated discordname list.
+func bulkAddInteraction(scope, names string) *discordgo.InteractionCreate {
+	return wardenInteraction("guild-1",
+		stringOption("command", "bulkadd"),
+		stringOption("flag", scope),
+		stringOption("discordname", names),
+	)
+}
+
+// searchMember is a one-result GuildMembersSearch entry keyed by its query.
+func searchMember(query, id string) (string, []*discordgo.Member) {
+	return query, []*discordgo.Member{{User: &discordgo.User{ID: id, Username: query}}}
+}
+
+// The headline #214 scenario for the PUBLIC loop: the resolved role is deleted
+// between resolution and the add loop, so every member's add 404s with the same
+// Unknown Role (10011) signature. Today each member fires its own capture; the
+// loop must collapse them into ONE Sentry event carrying the affected attempt
+// count and a sample member, while still listing every failure for the operator.
+func TestRunWardenBulkAdd_SameSignatureCollapsesToOneCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	aliceQ, aliceM := searchMember("alice", "111")
+	bobQ, bobM := searchMember("bob", "222")
+	carolQ, carolM := searchMember("carol", "333")
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		searchResults: map[string][]*discordgo.Member{
+			aliceQ: aliceM, bobQ: bobM, carolQ: carolM,
+		},
+		// All three adds 404 with Unknown Role: the role ID went stale mid-run.
+		MemberRoleAddErrs: []error{
+			restError(http.StatusNotFound, discordgo.ErrCodeUnknownRole, rawBodyMarker),
+			restError(http.StatusNotFound, discordgo.ErrCodeUnknownRole, rawBodyMarker),
+			restError(http.StatusNotFound, discordgo.ErrCodeUnknownRole, rawBodyMarker),
+		},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "alice, bob, carol"))
+
+	// One root cause, one Sentry event — not one per member.
+	if rec.count != 1 {
+		t.Fatalf("three same-signature stale-role 404s must collapse to ONE capture; got %d", rec.count)
+	}
+	if affected, ok := kvValue(rec.lastKV, "affected_count"); !ok || affected != 3 {
+		t.Fatalf("the collapsed capture must carry affected_count=3; got %v (kv %v)", affected, rec.lastKV)
+	}
+	// Entries are processed in list order, so the sample is the first member.
+	if sample, ok := kvValue(rec.lastKV, "sample_user"); !ok || sample != "111" {
+		t.Fatalf("sample_user must be the first failed member's Discord ID (111); got %v", sample)
+	}
+
+	// The per-member summary is unchanged: every failure is still listed.
+	got := lastEditContent(f.Calls())
+	for _, name := range []string{"alice", "bob", "carol"} {
+		if !strings.Contains(got, name) {
+			t.Fatalf("every failed member must still be listed in the summary; missing %q in %q", name, got)
+		}
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}
+
+// Two members fail with DISTINCT signatures in one public bulkadd run — one
+// stale-role 404, one transient 5xx. The collapse must key on signature, so each
+// gets its own event with its own affected_count of 1; a 10011 storm alongside a
+// 5xx must never fold into a single event (#214).
+func TestRunWardenBulkAdd_MixedSignaturesCaptureOncePerSignature(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	aliceQ, aliceM := searchMember("alice", "111")
+	bobQ, bobM := searchMember("bob", "222")
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		searchResults: map[string][]*discordgo.Member{
+			aliceQ: aliceM, bobQ: bobM,
+		},
+		MemberRoleAddErrs: []error{
+			restError(http.StatusNotFound, discordgo.ErrCodeUnknownRole, rawBodyMarker),
+			restError(http.StatusInternalServerError, 0, rawBodyMarker),
+		},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "alice, bob"))
+
+	if rec.count != 2 {
+		t.Fatalf("two distinct fault signatures must capture once each (no folding); got %d", rec.count)
+	}
+	statuses := map[any]bool{}
+	for _, kv := range rec.kvs {
+		if affected, ok := kvValue(kv, "affected_count"); !ok || affected != 1 {
+			t.Fatalf("each distinct-signature event must carry affected_count=1; got %v (kv %v)", affected, kv)
+		}
+		status, ok := kvValue(kv, "http_status")
+		if !ok {
+			t.Fatalf("each event must carry the http_status signature; got kv %v", kv)
+		}
+		statuses[status] = true
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("the two events must carry distinct http_status signatures; got %v", statuses)
+	}
+}
+
+// /warden bulkadd with scope "both" adds two roles per member, so affected_count
+// must count member-ROLE attempts, not distinct members. One member whose two
+// role-adds both fail with the same signature must collapse to one event with
+// affected_count=2, sampled to that member (#214).
+func TestRunWardenBulkAdd_BothScopeCountsRoleAttemptsNotMembers(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	aliceQ, aliceM := searchMember("alice", "111")
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{
+			wardenRole("r-int", wardenRoleBaseName+" Internal"),
+			wardenRole("r-ext", wardenRoleBaseName+" External"),
+		},
+		searchResults: map[string][]*discordgo.Member{aliceQ: aliceM},
+		// Both the Internal and External adds for the one member fail 5xx.
+		MemberRoleAddErrs: []error{
+			restError(http.StatusInternalServerError, 0, rawBodyMarker),
+			restError(http.StatusInternalServerError, 0, rawBodyMarker),
+		},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("both", "alice"))
+
+	if gm.countCalls("GuildMemberRoleAdd") != 2 {
+		t.Fatalf("scope 'both' must attempt two role adds for the member; got %d", gm.countCalls("GuildMemberRoleAdd"))
+	}
+	if rec.count != 1 {
+		t.Fatalf("two same-signature role attempts for one member must collapse to ONE capture; got %d", rec.count)
+	}
+	if affected, ok := kvValue(rec.lastKV, "affected_count"); !ok || affected != 2 {
+		t.Fatalf("affected_count must count member-role attempts (2), not distinct members (1); got %v", affected)
+	}
+	if sample, ok := kvValue(rec.lastKV, "sample_user"); !ok || sample != "111" {
+		t.Fatalf("sample_user must be the failed member's Discord ID (111); got %v", sample)
+	}
+}

--- a/commands/warden_bulkadd_collapse_test.go
+++ b/commands/warden_bulkadd_collapse_test.go
@@ -75,6 +75,51 @@ func TestRunWardenBulkAdd_SameSignatureCollapsesToOneCapture(t *testing.T) {
 	}
 }
 
+// The public mirror of the internal client-fault tests: in one /warden bulkadd
+// run, one member's add hits a 403 (missing permissions) and another hits a
+// not-in-server 404 (Unknown Member 10007). Both are captured-NEVER client
+// faults, so the public SystemFault gate must keep them out of the collector —
+// nothing pages — while still listing every faulted member for the operator.
+// Every other public collapse test feeds only system faults, so without this a
+// regression dropping the public SystemFault gate would fail no test.
+func TestRunWardenBulkAdd_ClientFaultsListedNotCaptured(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	aliceQ, aliceM := searchMember("alice", "111")
+	bobQ, bobM := searchMember("bob", "222")
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		searchResults: map[string][]*discordgo.Member{
+			aliceQ: aliceM, bobQ: bobM,
+		},
+		// alice draws a 403 (missing perms), bob a not-in-server 404 (Unknown
+		// Member): neither is a system fault, so neither may reach the collector.
+		MemberRoleAddErrs: []error{
+			restError(http.StatusForbidden, 50013, rawBodyMarker),
+			restError(http.StatusNotFound, discordgo.ErrCodeUnknownMember, rawBodyMarker),
+		},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "alice, bob"))
+
+	// Client faults must never page on-call.
+	if rec.count != 0 {
+		t.Fatalf("public bulkadd client faults (403, not-in-server 404) must NOT capture to Sentry; got %d", rec.count)
+	}
+	// Both faulted members are still surfaced, never silently dropped.
+	got := lastEditContent(f.Calls())
+	for _, name := range []string{"alice", "bob"} {
+		if !strings.Contains(got, name) {
+			t.Fatalf("every client-faulted member must still be listed in the summary; missing %q in %q", name, got)
+		}
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}
+
 // Two members fail with DISTINCT signatures in one public bulkadd run — one
 // stale-role 404, one transient 5xx. The collapse must key on signature, so each
 // gets its own event with its own affected_count of 1; a 10011 storm alongside a
@@ -118,6 +163,57 @@ func TestRunWardenBulkAdd_MixedSignaturesCaptureOncePerSignature(t *testing.T) {
 	}
 }
 
+// Two faults in one run share the HTTP status (404) but differ in Discord code —
+// Unknown Role (10011) and Unknown Guild (10004). The collapse keys on the
+// (status, Discord code) pair, so these are two distinct root causes and must NOT
+// fold into one event. Every other multi-signature test distinguishes only by
+// http_status, so a regression collapsing the key to status-only would still pass
+// them; and the emitted discord_code payload value is otherwise never asserted.
+// This pins both: two captures, carrying distinct discord_code values 10011 and
+// 10004 (#214).
+func TestRunWardenBulkAdd_SameStatusDifferentCodeCapturesPerCode(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	aliceQ, aliceM := searchMember("alice", "111")
+	bobQ, bobM := searchMember("bob", "222")
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		searchResults: map[string][]*discordgo.Member{
+			aliceQ: aliceM, bobQ: bobM,
+		},
+		// Same 404 status, different Discord code: a stale role vs a wrong guild.
+		MemberRoleAddErrs: []error{
+			restError(http.StatusNotFound, discordgo.ErrCodeUnknownRole, rawBodyMarker),
+			restError(http.StatusNotFound, discordgo.ErrCodeUnknownGuild, rawBodyMarker),
+		},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "alice, bob"))
+
+	// Same status, different code: two distinct signatures, never folded to one.
+	if rec.count != 2 {
+		t.Fatalf("two 404s with different Discord codes must capture once each (no status-only folding); got %d", rec.count)
+	}
+	codes := map[any]bool{}
+	for _, kv := range rec.kvs {
+		// Both faults share the 404 status: the discriminator is the Discord code.
+		if status, ok := kvValue(kv, "http_status"); !ok || status != http.StatusNotFound {
+			t.Fatalf("both events must carry the shared 404 http_status; got %v (kv %v)", status, kv)
+		}
+		code, ok := kvValue(kv, "discord_code")
+		if !ok {
+			t.Fatalf("each event must carry the discord_code signature value; got kv %v", kv)
+		}
+		codes[code] = true
+	}
+	// The two captures must carry the two distinct codes, not a single folded one.
+	if !codes[discordgo.ErrCodeUnknownRole] || !codes[discordgo.ErrCodeUnknownGuild] {
+		t.Fatalf("the two events must carry distinct discord_code values 10011 and 10004; got %v", codes)
+	}
+}
+
 // /warden bulkadd with scope "both" adds two roles per member, so affected_count
 // must count member-ROLE attempts, not distinct members. One member whose two
 // role-adds both fail with the same signature must collapse to one event with
@@ -154,5 +250,69 @@ func TestRunWardenBulkAdd_BothScopeCountsRoleAttemptsNotMembers(t *testing.T) {
 	}
 	if sample, ok := kvValue(rec.lastKV, "sample_user"); !ok || sample != "111" {
 		t.Fatalf("sample_user must be the failed member's Discord ID (111); got %v", sample)
+	}
+}
+
+// The zero-value faultCollector must be safe to record into without going through
+// newFaultCollector(): recordSystemFault lazy-inits the entries map, so a future
+// caller that builds the collector as a plain struct literal can never nil-panic
+// on the first record (the map-write that a nil map would panic on). A flush of
+// what it collected still emits exactly that one fault.
+func TestFaultCollector_ZeroValueRecordsWithoutNilPanic(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	var fc faultCollector // zero value: entries is a nil map
+	fc.recordSystemFault(restError(http.StatusInternalServerError, 0, rawBodyMarker), "111")
+	fc.flush("boom", "command", "warden")
+
+	if rec.count != 1 {
+		t.Fatalf("a zero-value collector must record and flush one fault; got %d", rec.count)
+	}
+	if affected, ok := kvValue(rec.lastKV, "affected_count"); !ok || affected != 1 {
+		t.Fatalf("the flushed fault must carry affected_count=1; got %v (kv %v)", affected, rec.lastKV)
+	}
+	if sample, ok := kvValue(rec.lastKV, "sample_user"); !ok || sample != "111" {
+		t.Fatalf("the flushed fault must carry the sample_user; got %v (kv %v)", sample, rec.lastKV)
+	}
+}
+
+// The public bulkadd flush is deferred immediately after the collector is built,
+// so a panic between recording a fault and the normal end of the loop cannot
+// silently discard pending captures — the exact per-member silent drop #214
+// fixes. Here alice's add 5xxs and is recorded, then a member with a nil User
+// makes the role-add path panic on member.User.ID; the deferred flush must still
+// emit alice's capture during unwinding. A plain post-loop flush statement would
+// be skipped by the panic and lose it.
+func TestRunWardenBulkAdd_PanicMidLoopStillFlushesPendingCaptures(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	aliceQ, aliceM := searchMember("alice", "111")
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		searchResults: map[string][]*discordgo.Member{
+			aliceQ: aliceM,
+			// A member with a nil User: dereferencing member.User.ID in the role-add
+			// path panics, standing in for any unexpected mid-loop blowup.
+			"boom": {{User: nil}},
+		},
+		// Only alice's add is reached; she 5xxs and is recorded before boom panics.
+		MemberRoleAddErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+
+	func() {
+		defer func() { _ = recover() }() // swallow the deliberate mid-loop panic
+		runWarden(f, gm, bulkAddInteraction("internal", "alice, boom"))
+	}()
+
+	// The deferred flush ran during panic unwinding, so alice's pending system-fault
+	// capture survived rather than being silently dropped.
+	if rec.count != 1 {
+		t.Fatalf("a panic mid-loop must still flush the pending capture via defer; got %d", rec.count)
+	}
+	if affected, ok := kvValue(rec.lastKV, "affected_count"); !ok || affected != 1 {
+		t.Fatalf("the flushed capture must carry affected_count=1; got %v (kv %v)", affected, rec.lastKV)
 	}
 }

--- a/commands/warden_bulkadd_internal.go
+++ b/commands/warden_bulkadd_internal.go
@@ -185,6 +185,11 @@ func runWardenBulkAddInternal(
 	var noDiscordLinked []string
 	var faults []string
 	var sawMissingPermissions bool
+	// One collector per run collapses the per-member system-fault captures: a role
+	// deleted mid-run 404s every add with the same signature, which would
+	// otherwise page on-call once per member. Faults feed it during the loop and
+	// it flushes once after (#214).
+	faultCapture := newFaultCollector()
 	for _, profile := range roster.LiteProfiles {
 		memberDiscordID := strings.TrimSpace(profile.DiscordID)
 		if memberDiscordID == "" {
@@ -213,14 +218,11 @@ func runWardenBulkAddInternal(
 			continue
 		}
 		if class.SystemFault {
-			// Genuine fault (5xx/transport): capture to Sentry tagged with the unit
-			// value so each registry entry fingerprints separately, list the member,
-			// and continue past it. The raw Discord body never reaches the reply.
-			captureError(
-				"Failed to add warden internal role in bulk",
-				err,
-				"command", "warden-bulkadd-internal", "guild", guildID, "user", memberDiscordID, "unit", unit.value,
-			)
+			// Genuine fault (5xx/transport, or a stale-role/guild config 404): hand it
+			// to the collector keyed by signature instead of capturing per member, so
+			// a role deleted mid-run pages once rather than once per trooper. List the
+			// member and continue past it. The raw Discord body never reaches the reply.
+			faultCapture.add(err, memberDiscordID)
 			faults = append(faults, profile.User.Username)
 			continue
 		}
@@ -236,6 +238,13 @@ func runWardenBulkAddInternal(
 		}
 		faults = append(faults, profile.User.Username)
 	}
+
+	// Flush once after the loop: one capture per distinct fault signature, tagged
+	// with the unit value so each registry entry fingerprints separately.
+	faultCapture.flush(
+		"Failed to add warden internal role in bulk",
+		"command", "warden-bulkadd-internal", "guild", guildID, "unit", unit.value,
+	)
 
 	slices.SortFunc(added, func(a, b *discordgo.Member) int {
 		return strings.Compare(a.User.Username, b.User.Username)

--- a/commands/warden_bulkadd_internal.go
+++ b/commands/warden_bulkadd_internal.go
@@ -188,8 +188,16 @@ func runWardenBulkAddInternal(
 	// One collector per run collapses the per-member system-fault captures: a role
 	// deleted mid-run 404s every add with the same signature, which would
 	// otherwise page on-call once per member. Faults feed it during the loop and
-	// it flushes once after (#214).
+	// it flushes once after (#214). The flush is deferred immediately, so an early
+	// return or a panic between the loop and the flush can never silently drop
+	// pending captures (the exact per-member silent drop this collector fixes); the
+	// message and the unit tag are fixed for the run, so evaluating the deferred
+	// args here is exact.
 	faultCapture := newFaultCollector()
+	defer faultCapture.flush(
+		"Failed to add warden internal role in bulk",
+		"command", "warden-bulkadd-internal", "guild", guildID, "unit", unit.value,
+	)
 	for _, profile := range roster.LiteProfiles {
 		memberDiscordID := strings.TrimSpace(profile.DiscordID)
 		if memberDiscordID == "" {
@@ -222,7 +230,7 @@ func runWardenBulkAddInternal(
 			// to the collector keyed by signature instead of capturing per member, so
 			// a role deleted mid-run pages once rather than once per trooper. List the
 			// member and continue past it. The raw Discord body never reaches the reply.
-			faultCapture.add(err, memberDiscordID)
+			faultCapture.recordSystemFault(err, memberDiscordID)
 			faults = append(faults, profile.User.Username)
 			continue
 		}
@@ -238,13 +246,6 @@ func runWardenBulkAddInternal(
 		}
 		faults = append(faults, profile.User.Username)
 	}
-
-	// Flush once after the loop: one capture per distinct fault signature, tagged
-	// with the unit value so each registry entry fingerprints separately.
-	faultCapture.flush(
-		"Failed to add warden internal role in bulk",
-		"command", "warden-bulkadd-internal", "guild", guildID, "unit", unit.value,
-	)
 
 	slices.SortFunc(added, func(a, b *discordgo.Member) int {
 		return strings.Compare(a.User.Username, b.User.Username)
@@ -294,7 +295,7 @@ func buildWardenInternalBulkAddSummary(
 }
 
 // wardenInternalPermissionsHint is the actionable line appended when a per-member
-// add failed on a 403. It reuses the substance of roleMutationErrorReply's
+// add failed on a 403. It reuses the substance of roleMutationErrorMessage's
 // missing-permissions branch (Manage Roles plus the role-hierarchy requirement)
 // without interpolating any raw Discord body.
 func wardenInternalPermissionsHint(roleName string) string {

--- a/commands/warden_bulkadd_internal_test.go
+++ b/commands/warden_bulkadd_internal_test.go
@@ -516,6 +516,22 @@ func TestRunWardenBulkAddInternal_PerMemberFaultCapturedAndRunContinues(t *testi
 	if rec.count != 1 {
 		t.Fatalf("a 5xx per-member fault must capture to Sentry exactly once; got %d", rec.count)
 	}
+	// Pin the "single fault → count 1" acceptance criterion directly on the payload,
+	// not just transitively via rec.count: the one collected fault carries an
+	// affected_count of 1 and a sample_user, so a regression that miscounts attempts
+	// or drops the sample fails here rather than only in the multi-fault tests.
+	if affected, ok := kvValue(rec.lastKV, "affected_count"); !ok || affected != 1 {
+		t.Fatalf("the single collected fault must carry affected_count=1; got %v (kv %v)", affected, rec.lastKV)
+	}
+	sample, ok := kvValue(rec.lastKV, "sample_user")
+	if !ok {
+		t.Fatalf("the single collected fault must carry a sample_user; got kv %v", rec.lastKV)
+	}
+	// Map iteration order decides which member drew the 5xx, so the sample is the
+	// faulted member's Discord ID — one of the two real roster IDs.
+	if sample != "111111111111111111" && sample != "222222222222222222" {
+		t.Fatalf("sample_user must be the faulted member's Discord ID; got %v", sample)
+	}
 	if unitVal, ok := kvValue(rec.lastKV, "unit"); !ok || unitVal != "D/ACD" {
 		t.Fatalf("the capture must be tagged with the unit value; got kv %v", rec.lastKV)
 	}

--- a/commands/warden_bulkadd_internal_test.go
+++ b/commands/warden_bulkadd_internal_test.go
@@ -376,15 +376,82 @@ func TestRunWardenBulkAddInternal_DeletedRole404CapturedNotMisreportedAbsent(t *
 	if !strings.Contains(got, "Could not be added (2)") {
 		t.Fatalf("a stale-role 404 must list both members under 'Could not be added'; got %q", got)
 	}
-	// Both stale-role faults are genuine config faults: each captures to Sentry.
-	if rec.count != 2 {
-		t.Fatalf("two stale-role 404s must capture to Sentry once each; got %d", rec.count)
+	// Both members hit the SAME fault signature (404 Unknown Role), so the loop
+	// must collapse them into ONE Sentry event for the one root cause, not page
+	// once per member (#214). The collapsed event carries the affected count and a
+	// sample member, plus the unit tag the per-member captures used to carry.
+	if rec.count != 1 {
+		t.Fatalf("two same-signature stale-role 404s must collapse to ONE capture; got %d", rec.count)
+	}
+	if affected, ok := kvValue(rec.lastKV, "affected_count"); !ok || affected != 2 {
+		t.Fatalf("the collapsed capture must carry affected_count=2; got %v (kv %v)", affected, rec.lastKV)
+	}
+	sample, ok := kvValue(rec.lastKV, "sample_user")
+	if !ok {
+		t.Fatalf("the collapsed capture must carry a sample_user; got kv %v", rec.lastKV)
+	}
+	// Roster iteration order is map-nondeterministic, so the sample is whichever
+	// present member the loop reached first; it must be one of the two real IDs.
+	if sample != "111111111111111111" && sample != "222222222222222222" {
+		t.Fatalf("sample_user must be one of the failed members' Discord IDs; got %v", sample)
 	}
 	if unitVal, ok := kvValue(rec.lastKV, "unit"); !ok || unitVal != "D/ACD" {
 		t.Fatalf("the capture must be tagged with the unit value; got kv %v", rec.lastKV)
 	}
 	if strings.Contains(got, rawBodyMarker) {
 		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}
+
+// Two members fail with DISTINCT fault signatures in one run — one stale-role
+// 404 (Unknown Role 10011), one transient 5xx. These are two different root
+// causes, so the collapse must NOT fold them together: each signature gets its
+// own Sentry event, with its own affected_count of 1. A 10011 storm alongside a
+// transient 5xx must surface as two events, never one (#214).
+func TestRunWardenBulkAddInternal_MixedSignaturesCaptureOncePerSignature(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	serveRosterAndProfiles(t, liteRoster(
+		liteMember("Present.A", "111111111111111111"),
+		liteMember("Present.B", "222222222222222222"),
+	), http.StatusOK, nil)
+
+	gm := internalRoleGM()
+	// One stale-role 404, one transient 5xx: two distinct signatures.
+	gm.MemberRoleAddErrs = []error{
+		restError(http.StatusNotFound, discordgo.ErrCodeUnknownRole, rawBodyMarker),
+		restError(http.StatusInternalServerError, 0, rawBodyMarker),
+	}
+	f := &fakeResponder{}
+
+	runWardenBulkAddInternal(f, gm, wardenBulkAddInternalInteraction("D/ACD"))
+
+	// Two distinct signatures must produce exactly two captures, one per signature.
+	if rec.count != 2 {
+		t.Fatalf("two distinct fault signatures must capture once each (no folding); got %d", rec.count)
+	}
+	// Each event carries affected_count=1, and the two events carry distinct
+	// signatures (different http_status), proving the collapse keys on signature.
+	statuses := map[any]bool{}
+	for _, kv := range rec.kvs {
+		if affected, ok := kvValue(kv, "affected_count"); !ok || affected != 1 {
+			t.Fatalf("each distinct-signature event must carry affected_count=1; got %v (kv %v)", affected, kv)
+		}
+		if _, ok := kvValue(kv, "sample_user"); !ok {
+			t.Fatalf("each event must carry a sample_user; got kv %v", kv)
+		}
+		status, ok := kvValue(kv, "http_status")
+		if !ok {
+			t.Fatalf("each event must carry the http_status signature; got kv %v", kv)
+		}
+		statuses[status] = true
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("the two events must carry distinct http_status signatures; got %v", statuses)
+	}
+	// Both members are still listed for the operator, unchanged by the collapse.
+	if got := lastEditContent(f.Calls()); !strings.Contains(got, "Could not be added (2)") {
+		t.Fatalf("both faulted members must still be listed; got %q", got)
 	}
 }
 

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -284,18 +284,18 @@ func channelsResolveErrorReply(err error, captureMsg string, kv ...any) error {
 	return fmt.Errorf("❌ Failed to retrieve guild channels (%s)", class.UserDetail)
 }
 
-// roleMutationErrorReply classifies a role add/remove failure, captures it to
-// Sentry only for genuine system faults, and returns a body-free, actionable
-// message. A 403 yields a specific role-hierarchy hint — the common cause is the
-// target role sitting above the bot's own role, or the bot missing Manage Roles.
-// captureMsg/kv are forwarded to captureError so each site keeps its own log
-// context (action, user, role).
-func roleMutationErrorReply(action, roleName, userLabel string, err error, captureMsg string, kv ...any) string {
-	class := classifyDiscordError(err)
-
+// roleMutationErrorMessage builds the body-free, actionable user-facing message
+// for a role add/remove failure from its classification. It does NOT capture —
+// the caller decides whether and how to send the fault to Sentry. The single
+// add/remove sites capture immediately via roleMutationErrorReply; the bulk
+// loops build the message here and route the capture through faultCollector so a
+// per-member storm collapses to one event per signature (#214). A 403 yields a
+// specific role-hierarchy hint — the common cause is the target role sitting
+// above the bot's own role, or the bot missing Manage Roles. The raw Discord
+// body is never interpolated; only the classifier's sanitized phrase appears.
+func roleMutationErrorMessage(action, roleName, userLabel string, class discordErrorClass) string {
 	switch {
 	case class.SystemFault:
-		captureError(captureMsg, err, kv...)
 		if class.ConfigFault {
 			return fmt.Sprintf("❌ Could not %s '%s' for %s: %s.", action, roleName, userLabel, configFaultHint(class))
 		}
@@ -307,5 +307,112 @@ func roleMutationErrorReply(action, roleName, userLabel string, err error, captu
 		)
 	default:
 		return fmt.Sprintf("❌ Could not %s '%s' for %s: Discord rejected the request.", action, roleName, userLabel)
+	}
+}
+
+// roleMutationErrorReply is the immediate-capture entry point for the single
+// /warden add and remove sites: it classifies a role add/remove failure,
+// captures it to Sentry once when it is a genuine system fault, and returns the
+// same body-free message roleMutationErrorMessage builds. captureMsg/kv are
+// forwarded to captureError so each site keeps its own log context. The bulk
+// loops deliberately do NOT use this — they would capture once per member; they
+// classify, build the message via roleMutationErrorMessage, and feed the capture
+// to a faultCollector instead (#214).
+func roleMutationErrorReply(action, roleName, userLabel string, err error, captureMsg string, kv ...any) string {
+	class := classifyDiscordError(err)
+	if class.SystemFault {
+		captureError(captureMsg, err, kv...)
+	}
+	return roleMutationErrorMessage(action, roleName, userLabel, class)
+}
+
+// faultSignature identifies a distinct captured fault for collapse: the pair of
+// HTTP status and Discord application error code. It is read straight off the
+// *discordgo.RESTError (the same status and Message.Code the classifier branches
+// on), so the collector does not need classifyDiscordError's contract to change.
+// A transport/connection error has no HTTP response, so it keys on the zero
+// signature {0, 0}; that is distinct from a real 5xx (status 500, code 0), so
+// the two never fold together.
+type faultSignature struct {
+	status      int
+	discordCode int
+}
+
+// faultSignatureOf extracts the (status, Discord code) signature from a Discord
+// REST failure. Anything without a structured HTTP response (a transport error)
+// returns the zero signature.
+func faultSignatureOf(err error) faultSignature {
+	var restErr *discordgo.RESTError
+	if !errors.As(err, &restErr) || restErr.Response == nil {
+		return faultSignature{}
+	}
+	sig := faultSignature{status: restErr.Response.StatusCode}
+	if restErr.Message != nil {
+		sig.discordCode = restErr.Message.Code
+	}
+	return sig
+}
+
+// collectedFault is the running tally for one fault signature within a single
+// bulk run: how many add attempts hit it, a representative error for the Sentry
+// payload, and the Discord ID of the first member that hit it (the debugging
+// foothold the collapsed event carries as sample_user).
+type collectedFault struct {
+	count      int
+	firstErr   error
+	sampleUser string
+}
+
+// faultCollector collapses the per-member captured system faults of a bulk
+// role-add loop into one Sentry event per distinct fault signature, so a single
+// root cause that hits every iteration (a role deleted mid-run ⇒ N Unknown Role
+// 404s, or a 5xx storm) pages on-call once instead of N times (#214). Both bulk
+// loops feed it every captured fault during iteration via add, then flush once
+// after the loop. It is per-invocation only: a fresh collector per run, no
+// cross-run or time-windowed dedup. Only genuine system faults belong here — the
+// caller filters on class.SystemFault, since non-captured client faults (403,
+// not-in-server 404) must stay uncaptured per ADR 0001.
+type faultCollector struct {
+	// order preserves first-seen signature order so flush emits deterministically.
+	order   []faultSignature
+	entries map[faultSignature]*collectedFault
+}
+
+func newFaultCollector() *faultCollector {
+	return &faultCollector{entries: map[faultSignature]*collectedFault{}}
+}
+
+// add records one failed add attempt for the signature of err, attributed to the
+// member userID. The first member per signature is kept as the sample; every
+// subsequent same-signature failure only bumps the count. For /warden bulkadd,
+// which adds several roles per member, each failed member-role attempt is one
+// add call, so affected_count counts attempts rather than distinct members.
+func (fc *faultCollector) add(err error, userID string) {
+	sig := faultSignatureOf(err)
+	entry, ok := fc.entries[sig]
+	if !ok {
+		entry = &collectedFault{firstErr: err, sampleUser: userID}
+		fc.entries[sig] = entry
+		fc.order = append(fc.order, sig)
+	}
+	entry.count++
+}
+
+// flush emits one captureError per distinct signature collected this run, each
+// carrying the affected attempt count, the sample member, and the signature
+// (status + Discord code) as searchable values, appended to the caller's shared
+// run context (command/guild, plus unit for the internal command). Calling it on
+// a collector that saw no system faults is a no-op, so a clean run pages nothing.
+func (fc *faultCollector) flush(captureMsg string, baseKV ...any) {
+	for _, sig := range fc.order {
+		entry := fc.entries[sig]
+		kv := append([]any(nil), baseKV...)
+		kv = append(kv,
+			"affected_count", entry.count,
+			"sample_user", entry.sampleUser,
+			"http_status", sig.status,
+			"discord_code", sig.discordCode,
+		)
+		captureError(captureMsg, entry.firstErr, kv...)
 	}
 }

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -287,12 +287,15 @@ func channelsResolveErrorReply(err error, captureMsg string, kv ...any) error {
 // roleMutationErrorMessage builds the body-free, actionable user-facing message
 // for a role add/remove failure from its classification. It does NOT capture —
 // the caller decides whether and how to send the fault to Sentry. The single
-// add/remove sites capture immediately via roleMutationErrorReply; the bulk
-// loops build the message here and route the capture through faultCollector so a
-// per-member storm collapses to one event per signature (#214). A 403 yields a
-// specific role-hierarchy hint — the common cause is the target role sitting
-// above the bot's own role, or the bot missing Manage Roles. The raw Discord
-// body is never interpolated; only the classifier's sanitized phrase appears.
+// add/remove sites capture immediately via roleMutationErrorReply; the PUBLIC
+// /warden bulkadd loop builds its per-member failure line here and routes the
+// capture through faultCollector so a per-member storm collapses to one event
+// per signature (#214). (The internal bulkadd loop also routes its captures
+// through the collector, but lists faulted members by forum username in bucketed
+// summaries rather than calling this.) A 403 yields a specific role-hierarchy
+// hint — the common cause is the target role sitting above the bot's own role,
+// or the bot missing Manage Roles. The raw Discord body is never interpolated;
+// only the classifier's sanitized phrase appears.
 func roleMutationErrorMessage(action, roleName, userLabel string, class discordErrorClass) string {
 	switch {
 	case class.SystemFault:
@@ -315,9 +318,11 @@ func roleMutationErrorMessage(action, roleName, userLabel string, class discordE
 // captures it to Sentry once when it is a genuine system fault, and returns the
 // same body-free message roleMutationErrorMessage builds. captureMsg/kv are
 // forwarded to captureError so each site keeps its own log context. The bulk
-// loops deliberately do NOT use this — they would capture once per member; they
-// classify, build the message via roleMutationErrorMessage, and feed the capture
-// to a faultCollector instead (#214).
+// loops deliberately do NOT use this — they would capture once per member; both
+// feed their system faults to a faultCollector instead (#214). The public
+// /warden bulkadd loop builds its per-member line via roleMutationErrorMessage;
+// the internal bulkadd loop lists faulted members by forum username in bucketed
+// summaries.
 func roleMutationErrorReply(action, roleName, userLabel string, err error, captureMsg string, kv ...any) string {
 	class := classifyDiscordError(err)
 	if class.SystemFault {
@@ -367,8 +372,8 @@ type collectedFault struct {
 // role-add loop into one Sentry event per distinct fault signature, so a single
 // root cause that hits every iteration (a role deleted mid-run ⇒ N Unknown Role
 // 404s, or a 5xx storm) pages on-call once instead of N times (#214). Both bulk
-// loops feed it every captured fault during iteration via add, then flush once
-// after the loop. It is per-invocation only: a fresh collector per run, no
+// loops feed it every captured fault during iteration via recordSystemFault, then
+// flush once after the loop. It is per-invocation only: a fresh collector per run, no
 // cross-run or time-windowed dedup. Only genuine system faults belong here — the
 // caller filters on class.SystemFault, since non-captured client faults (403,
 // not-in-server 404) must stay uncaptured per ADR 0001.
@@ -382,13 +387,24 @@ func newFaultCollector() *faultCollector {
 	return &faultCollector{entries: map[faultSignature]*collectedFault{}}
 }
 
-// add records one failed add attempt for the signature of err, attributed to the
-// member userID. The first member per signature is kept as the sample; every
-// subsequent same-signature failure only bumps the count. For /warden bulkadd,
-// which adds several roles per member, each failed member-role attempt is one
-// add call, so affected_count counts attempts rather than distinct members.
-func (fc *faultCollector) add(err error, userID string) {
+// recordSystemFault records one failed add attempt for the signature of err,
+// attributed to the member userID. It is for genuine system faults ONLY: every
+// error handed here is sent to Sentry by flush, so both bulk loops gate on
+// class.SystemFault before calling it — non-captured client faults (403,
+// not-in-server 404) must never reach the collector (ADR 0001, #214). The first
+// member per signature is kept as the sample; every subsequent same-signature
+// failure only bumps the count. For /warden bulkadd, which adds several roles per
+// member, each failed member-role attempt is one call, so affected_count counts
+// attempts rather than distinct members.
+//
+// The entries map is lazy-initialized here, so the zero-value faultCollector is
+// safe to record into even if a caller skipped newFaultCollector(); it can never
+// nil-panic on the first record.
+func (fc *faultCollector) recordSystemFault(err error, userID string) {
 	sig := faultSignatureOf(err)
+	if fc.entries == nil {
+		fc.entries = map[faultSignature]*collectedFault{}
+	}
 	entry, ok := fc.entries[sig]
 	if !ok {
 		entry = &collectedFault{firstErr: err, sampleUser: userID}

--- a/commands/warden_resterror_test.go
+++ b/commands/warden_resterror_test.go
@@ -501,10 +501,14 @@ func TestFindGuildMember_MentionGeneric4xxNoCapture(t *testing.T) {
 // a test and counts how many times it fires, so a test can assert the
 // 4xx-vs-5xx Sentry split without a live Sentry client. lastKV holds the kv
 // varargs from the most recent capture, so a test can also pin the context
-// fields (command/guild/role) a site is required to forward.
+// fields (command/guild/role) a site is required to forward. kvs keeps every
+// capture's kv in fire order, so a test that expects more than one capture (the
+// bulk-loop fault collapse, #214) can assert per-event payloads, not just the
+// most recent.
 type captureRecorder struct {
 	count  int
 	lastKV []any
+	kvs    [][]any
 }
 
 func (c *captureRecorder) install(t *testing.T) {
@@ -513,6 +517,7 @@ func (c *captureRecorder) install(t *testing.T) {
 	captureError = func(msg string, err error, kv ...any) {
 		c.count++
 		c.lastKV = kv
+		c.kvs = append(c.kvs, kv)
 	}
 	t.Cleanup(func() { captureError = prev })
 }

--- a/commands/warden_resterror_test.go
+++ b/commands/warden_resterror_test.go
@@ -711,9 +711,10 @@ func TestRunWardenAdd_RoleAdd5xxCapturesGenericRetry(t *testing.T) {
 // A non-403 4xx (here a 400 with a non-permission code) is an
 // operator/config-fixable client fault: it must show the generic "Discord
 // rejected the request" wording, never the raw body, and never capture to
-// Sentry. Covers the default arm of roleMutationErrorReply, which no other
-// mutation-site test exercises. (A 404 no longer reaches this arm — Unknown Role
-// and Unknown Guild codes are captured system faults; see the tests below.)
+// Sentry. Covers the default arm of roleMutationErrorMessage (reached here via
+// roleMutationErrorReply), which no other mutation-site test exercises. (A 404
+// no longer reaches this arm — Unknown Role and Unknown Guild codes are captured
+// system faults; see the tests below.)
 func TestRunWardenAdd_RoleAddGeneric4xxNoCapture(t *testing.T) {
 	rec := &captureRecorder{}
 	rec.install(t)


### PR DESCRIPTION
Closes #214.

Both warden bulk role-add loops, `/warden-bulkadd-internal` and the public `/warden bulkadd`, called `captureError` once per member. When a role was deleted between resolution and the loop, every add returned 404 Unknown Role (10011). Since #209 that 404 classifies as a captured system fault, so an N-member roster fired N Sentry events for one root cause.

This collapses the per-member captures within a single run to one event per fault signature, where a signature is the pair (HTTP status, Discord error code). Each collapsed event carries `affected_count`, a `sample_user` (the first member to hit the signature), the signature as searchable values, and the existing `command`/`guild`/`unit` context.

## Changes
- New `faultCollector` in `commands/warden_errors.go`. It keys by signature, tracks a per-signature count plus a representative error and the first member ID, and flushes one capture per signature.
- Split `roleMutationErrorReply` into a pure message builder and the immediate-capture wrapper. Single `/warden` add and remove keep capturing immediately; the bulk loops build the per-failure message and hand the capture to the collector.
- Both bulk loops feed the collector on system faults and flush once after the loop. The public loop counts member-role attempts rather than distinct members.

## Tests
- Updated `TestRunWardenBulkAddInternal_DeletedRole404CapturedNotMisreportedAbsent` to expect one collapsed capture.
- Added `warden_bulkadd_collapse_test.go`: same-signature collapse and mixed-signature (two events) for both loops, plus attempt counting for the both-role scope.

Unchanged, per the issue's out-of-scope list: which faults capture at all, cross-run dedup, the user-facing reply, and Sentry fingerprinting.

> *This was generated by AI*
