### PR TITLE
fix(warden): collapse per-member member-lookup Sentry captures in /warden bulkadd

### DIFF
--- a/commands/warden.go
+++ b/commands/warden.go
@@ -280,21 +280,32 @@ func handleWardenBulkAdd(
 
 	var addedMembers []*discordgo.Member
 	var failures []string
-	// One collector per run collapses the per-member-role system-fault captures: a
-	// role deleted mid-run 404s every add with the same signature, which would
-	// otherwise page on-call once per member-role attempt. System faults feed it
-	// during the loop and it flushes once after; non-captured client faults (403,
-	// not-in-server 404) are listed but never routed here, per ADR 0001 (#214). The
-	// flush is deferred immediately, so an early return or a panic between the loop
-	// and the flush can never silently drop pending captures; guildID is fixed for
-	// the run, so evaluating the deferred args here is exact.
+	// Two collectors per run, one per Discord call site, each collapsing its
+	// per-member system-fault captures to one event per fault signature (#214,
+	// #216). They are kept SEPARATE rather than shared because a member LOOKUP
+	// (GuildMember/GuildMembersSearch) and a role ADD (GuildMemberRoleAdd) are
+	// distinct root causes with their own flush message: a lookup 500 and a
+	// role-add 500 carry the same signature but must not fold into one event.
+	// System faults feed the collectors during the loop and they flush once after;
+	// non-captured client faults (403, not-in-server 404) are listed but never
+	// routed here, per ADR 0001. Both flushes are deferred immediately, so an early
+	// return or a panic between the loop and the flush can never silently drop
+	// pending captures; guildID is fixed for the run, so the deferred args are exact.
+	lookupFaultCapture := newFaultCollector()
+	defer lookupFaultCapture.flush(
+		"Failed to look up guild member in bulk",
+		"command", "warden", "guild", guildID,
+	)
 	faultCapture := newFaultCollector()
 	defer faultCapture.flush(
 		"Failed to add warden role in bulk",
 		"command", "warden", "guild", guildID,
 	)
 	for _, singleQuery := range requestedQueries {
-		member, memberErr := findGuildMember(gm, guildID, singleQuery)
+		// A lookup system fault feeds the lookup collector keyed by signature
+		// instead of capturing once per entry, so a 5xx storm during resolution
+		// pages once per signature rather than once per roster entry (#216).
+		member, memberErr := findGuildMemberCollecting(gm, guildID, singleQuery, lookupFaultCapture.recordSystemFault)
 		if memberErr != nil {
 			failures = append(failures, memberErr.Error())
 			continue
@@ -813,7 +824,22 @@ func formatUser(member *discordgo.Member) string {
 	return member.User.Username
 }
 
+// findGuildMember resolves a single roster entry to a guild member, capturing any
+// genuine lookup system fault to Sentry inline. It is the entry point for the
+// single /warden add and /warden remove sites, which capture immediately; the
+// bulk loop uses findGuildMemberCollecting with a collector-backed sink instead.
 func findGuildMember(gm GuildManager, guildID, query string) (*discordgo.Member, error) {
+	return findGuildMemberCollecting(gm, guildID, query, nil)
+}
+
+// findGuildMemberCollecting is findGuildMember with the lookup-fault capture
+// decision delegated to faultSink. With a nil sink the leaf helpers capture each
+// genuine system fault to Sentry inline (the single add/remove behavior); with a
+// collector-backed sink the /warden bulkadd loop routes those captures through a
+// faultCollector so a lookup-fault storm collapses to one event per signature
+// (#216). The user-facing messages and the non-captured outcomes (empty/too-long
+// query, not-in-server, no match, too many matches, 4xx) are identical either way.
+func findGuildMemberCollecting(gm GuildManager, guildID, query string, faultSink lookupFaultSink) (*discordgo.Member, error) {
 	trimmedQuery := strings.TrimSpace(query)
 	if trimmedQuery == "" {
 		return nil, fmt.Errorf("❌ Empty query")
@@ -835,18 +861,18 @@ func findGuildMember(gm GuildManager, guildID, query string) (*discordgo.Member,
 	// fault). A 404 means the user really isn't here; any other failure is
 	// surfaced (and captured if it's a genuine system fault).
 	if userID, ok := mentionUserID(trimmedQuery); ok {
-		return resolveMemberByID(gm, guildID, userID)
+		return resolveMemberByID(gm, guildID, userID, faultSink)
 	}
 
 	// Raw snowflake ID: same authoritative treatment as a mention.
 	if isSnowflakeID(trimmedQuery) {
-		return resolveMemberByID(gm, guildID, trimmedQuery)
+		return resolveMemberByID(gm, guildID, trimmedQuery, faultSink)
 	}
 
 	// Name search
 	members, err := gm.GuildMembersSearch(guildID, trimmedQuery, 10)
 	if err != nil {
-		return nil, searchErrorReply(err)
+		return nil, searchErrorReply(err, faultSink, trimmedQuery)
 	}
 
 	switch len(members) {
@@ -878,8 +904,9 @@ func mentionUserID(query string) (string, bool) {
 // mentions and raw snowflakes. The result is trusted: it never falls through to
 // a name search. A 404 yields a clear "not in this server" message; any other
 // failure is routed through the shared classifier so a genuine system fault is
-// captured to Sentry and the raw Discord body never reaches the reply.
-func resolveMemberByID(gm GuildManager, guildID, userID string) (*discordgo.Member, error) {
+// captured (inline when faultSink is nil, or collected when the bulk loop supplies
+// a collector-backed sink) and the raw Discord body never reaches the reply.
+func resolveMemberByID(gm GuildManager, guildID, userID string, faultSink lookupFaultSink) (*discordgo.Member, error) {
 	member, err := gm.GuildMember(guildID, userID)
 	if err != nil {
 		class := classifyDiscordError(err)
@@ -887,7 +914,7 @@ func resolveMemberByID(gm GuildManager, guildID, userID string) (*discordgo.Memb
 		case class.NotFound:
 			return nil, fmt.Errorf("❌ <@%s> is not in this server", userID)
 		case class.SystemFault:
-			captureError("Failed to look up guild member by ID", err, "user_id", userID)
+			recordLookupFault(faultSink, err, userID, "Failed to look up guild member by ID", "user_id", userID)
 			if class.ConfigFault {
 				return nil, fmt.Errorf("❌ Could not look up <@%s>: %s", userID, configFaultHint(class))
 			}

--- a/commands/warden.go
+++ b/commands/warden.go
@@ -280,17 +280,21 @@ func handleWardenBulkAdd(
 
 	var addedMembers []*discordgo.Member
 	var failures []string
-	// Two collectors per run, one per Discord call site, each collapsing its
-	// per-member system-fault captures to one event per fault signature (#214,
-	// #216). They are kept SEPARATE rather than shared because a member LOOKUP
-	// (GuildMember/GuildMembersSearch) and a role ADD (GuildMemberRoleAdd) are
-	// distinct root causes with their own flush message: a lookup 500 and a
-	// role-add 500 carry the same signature but must not fold into one event.
-	// System faults feed the collectors during the loop and they flush once after;
-	// non-captured client faults (403, not-in-server 404) are listed but never
-	// routed here, per ADR 0001. Both flushes are deferred immediately, so an early
-	// return or a panic between the loop and the flush can never silently drop
+	// Two collectors per run, one per operation phase (member lookup vs role add),
+	// each collapsing its per-entry system-fault captures to one event per fault
+	// signature (#214, #216). They are kept SEPARATE rather than shared because a
+	// member LOOKUP (GuildMember/GuildMembersSearch) and a role ADD
+	// (GuildMemberRoleAdd) are distinct root causes with their own flush message: a
+	// lookup 500 and a role-add 500 carry the same signature but must not fold into
+	// one event. System faults feed the collectors during the loop and they flush
+	// once after; non-captured client faults (403, not-in-server 404) are listed but
+	// never routed here, per ADR 0001. Both flushes are deferred immediately, so an
+	// early return or a panic between the loop and the flush can never silently drop
 	// pending captures; guildID is fixed for the run, so the deferred args are exact.
+	//
+	// Each collector MUST keep its own matching deferred flush: records only reach
+	// Sentry at flush, so dropping one defer would silently discard that phase's
+	// pending captures (partial Sentry blindness for that phase).
 	lookupFaultCapture := newFaultCollector()
 	defer lookupFaultCapture.flush(
 		"Failed to look up guild member in bulk",

--- a/commands/warden_bulkadd_lookup_collapse_test.go
+++ b/commands/warden_bulkadd_lookup_collapse_test.go
@@ -1,0 +1,273 @@
+package commands
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// The headline #216 scenario for the PUBLIC bulkadd member-LOOKUP path: Discord
+// throws a 5xx storm during the per-entry name search, so every entry's lookup
+// fails with the same signature before any role is even attempted. Today each
+// entry fires its own captureError("Failed to search members", ...); the loop
+// must collapse them into ONE Sentry event carrying the affected lookup count
+// and a sample entry, while still listing every failure for the operator.
+func TestRunWardenBulkAdd_LookupSameSignatureCollapsesToOneCapture(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		// Every name search 500s with the same signature: a lookup-side storm.
+		MembersSearchErrs: []error{
+			restError(http.StatusInternalServerError, 0, rawBodyMarker),
+			restError(http.StatusInternalServerError, 0, rawBodyMarker),
+			restError(http.StatusInternalServerError, 0, rawBodyMarker),
+		},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "alice, bob, carol"))
+
+	// One root cause, one Sentry event — not one per entry.
+	if rec.count != 1 {
+		t.Fatalf("three same-signature lookup 500s must collapse to ONE capture; got %d", rec.count)
+	}
+	if affected, ok := kvValue(rec.lastKV, "affected_count"); !ok || affected != 3 {
+		t.Fatalf("the collapsed capture must carry affected_count=3; got %v (kv %v)", affected, rec.lastKV)
+	}
+	// Entries are processed in list order, so the sample is the first entry.
+	if sample, ok := kvValue(rec.lastKV, "sample_user"); !ok || sample != "alice" {
+		t.Fatalf("sample_user must be the first failed entry (alice); got %v", sample)
+	}
+
+	// The per-entry summary is unchanged: every failed lookup is still listed.
+	got := lastEditContent(f.Calls())
+	if strings.Count(got, "❌") != 3 {
+		t.Fatalf("every failed lookup must still be listed in the summary; got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}
+
+// Two entries fail their lookup with DISTINCT signatures in one bulkadd run — one
+// 500, one 503. The collapse keys on signature, so each gets its own event with
+// its own affected_count of 1; a 500 storm alongside a 503 must never fold into a
+// single event.
+func TestRunWardenBulkAdd_LookupMixedSignaturesCaptureOncePerSignature(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		MembersSearchErrs: []error{
+			restError(http.StatusInternalServerError, 0, rawBodyMarker),
+			restError(http.StatusServiceUnavailable, 0, rawBodyMarker),
+		},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "alice, bob"))
+
+	if rec.count != 2 {
+		t.Fatalf("two distinct lookup signatures must capture once each (no folding); got %d", rec.count)
+	}
+	statuses := map[any]bool{}
+	for _, kv := range rec.kvs {
+		if affected, ok := kvValue(kv, "affected_count"); !ok || affected != 1 {
+			t.Fatalf("each distinct-signature event must carry affected_count=1; got %v (kv %v)", affected, kv)
+		}
+		if _, ok := kvValue(kv, "sample_user"); !ok {
+			t.Fatalf("each event must carry a sample_user; got kv %v", kv)
+		}
+		status, ok := kvValue(kv, "http_status")
+		if !ok {
+			t.Fatalf("each event must carry the http_status signature; got kv %v", kv)
+		}
+		statuses[status] = true
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("the two events must carry distinct http_status signatures; got %v", statuses)
+	}
+}
+
+// A single-entry bulkadd whose one lookup 500s must still emit exactly one event,
+// carrying affected_count=1 and the sample entry — the lower bound of the
+// collapse, pinned directly on the payload so a miscount fails here.
+func TestRunWardenBulkAdd_LookupSingleFaultCapturesOnceCountOne(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	gm := &fakeGuildManager{
+		roles:             []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		MembersSearchErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "alice"))
+
+	if rec.count != 1 {
+		t.Fatalf("a single lookup fault must capture exactly once; got %d", rec.count)
+	}
+	if affected, ok := kvValue(rec.lastKV, "affected_count"); !ok || affected != 1 {
+		t.Fatalf("the single collected lookup fault must carry affected_count=1; got %v (kv %v)", affected, rec.lastKV)
+	}
+	if sample, ok := kvValue(rec.lastKV, "sample_user"); !ok || sample != "alice" {
+		t.Fatalf("the single collected lookup fault must carry sample_user=alice; got %v (kv %v)", sample, rec.lastKV)
+	}
+}
+
+// The other lookup call site: mention/snowflake entries resolve through
+// GuildMember (resolveMemberByID), not GuildMembersSearch. A 5xx storm on that
+// path must collapse the same way and carry the resolved Discord ID as
+// sample_user, proving the by-ID site routes to the collector too, not only the
+// name-search site.
+func TestRunWardenBulkAdd_LookupByIDFaultRoutesToCollector(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		// Every GuildMember lookup 500s with the same signature.
+		MemberErrs: []error{
+			restError(http.StatusInternalServerError, 0, rawBodyMarker),
+			restError(http.StatusInternalServerError, 0, rawBodyMarker),
+		},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "<@111>, <@222>"))
+
+	if gm.countCalls("GuildMembersSearch") != 0 {
+		t.Fatalf("mention entries must resolve by ID, never fall through to name search; got calls %v", gm.Calls())
+	}
+	if rec.count != 1 {
+		t.Fatalf("two same-signature by-ID lookup 500s must collapse to ONE capture; got %d", rec.count)
+	}
+	if affected, ok := kvValue(rec.lastKV, "affected_count"); !ok || affected != 2 {
+		t.Fatalf("the collapsed by-ID capture must carry affected_count=2; got %v (kv %v)", affected, rec.lastKV)
+	}
+	// The first mention resolves to userID 111, the sample for the collapsed event.
+	if sample, ok := kvValue(rec.lastKV, "sample_user"); !ok || sample != "111" {
+		t.Fatalf("sample_user must be the first failed entry's resolved Discord ID (111); got %v", sample)
+	}
+}
+
+// The non-captured lookup outcomes must stay listed for the operator AND never
+// reach the collector: a not-in-server 404 (Unknown Member), a name with no
+// match, and a name with too many matches are all operator-fixable, not system
+// faults. Every other lookup-collapse test feeds only system faults, so without
+// this a regression dropping the SystemFault gate (routing a 404/no-match into
+// the collector) would fail no test.
+func TestRunWardenBulkAdd_LookupNonCapturedOutcomesListedNotCaptured(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		// The mention resolves by ID and 404s as a genuine absence (Unknown Member).
+		MemberErrs: []error{restError(http.StatusNotFound, discordgo.ErrCodeUnknownMember, rawBodyMarker)},
+		// "common" matches two members (too many); "ghost" is absent from the map (no match).
+		searchResults: map[string][]*discordgo.Member{
+			"common": {
+				{User: &discordgo.User{ID: "1", Username: "common"}},
+				{User: &discordgo.User{ID: "2", Username: "common"}},
+			},
+		},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "<@111>, ghost, common"))
+
+	if rec.count != 0 {
+		t.Fatalf("not-in-server / no-match / too-many lookup outcomes must NOT capture to Sentry; got %d", rec.count)
+	}
+	// All three are still surfaced to the operator, never silently dropped.
+	got := lastEditContent(f.Calls())
+	if strings.Count(got, "❌") != 3 {
+		t.Fatalf("every non-captured lookup failure must still be listed; got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}
+
+// A lookup 4xx client fault in bulk (here a 400 on the name search) is
+// operator-fixable, not a system fault: it must be listed for the operator and
+// never reach the collector, the lookup-path mirror of the role-add 403 case.
+func TestRunWardenBulkAdd_Lookup4xxListedNotCaptured(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	gm := &fakeGuildManager{
+		roles:             []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		MembersSearchErrs: []error{restError(http.StatusBadRequest, 50035, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "alice"))
+
+	if rec.count != 0 {
+		t.Fatalf("a 4xx lookup client fault must NOT capture to Sentry; got %d", rec.count)
+	}
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(got, "❌") {
+		t.Fatalf("the 4xx-faulted lookup must still be listed; got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}
+
+// The split must leave the single /warden add lookup capturing inline: a member
+// lookup 5xx on a single add still pages exactly once, NOT through a collector.
+// The bulk-only collapse must not regress the single-call path to zero captures
+// (a collector that never flushes) or to a collapsed payload.
+func TestRunWardenAdd_MemberLookup5xxCapturesOnceInline(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	// No membersByID: the snowflake lookup hits the injected 5xx instead of resolving.
+	gm := &fakeGuildManager{
+		roles:      []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		MemberErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, wardenAddInteraction())
+
+	if rec.count != 1 {
+		t.Fatalf("a single /warden add lookup 5xx must capture inline exactly once; got %d", rec.count)
+	}
+	got := lastEditContent(f.Calls())
+	if !strings.Contains(strings.ToLower(got), "try again shortly") {
+		t.Fatalf("a transient member-lookup fault must keep the retry hint, got %q", got)
+	}
+	if strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}
+
+// The remove path shares findGuildMember, so a single /warden remove lookup 5xx
+// must likewise capture inline exactly once, behavior-identical to before the
+// bulk-only collapse.
+func TestRunWardenRemove_MemberLookup5xxCapturesOnceInline(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+	gm := &fakeGuildManager{
+		roles:      []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		MemberErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, wardenRemoveInteraction())
+
+	if rec.count != 1 {
+		t.Fatalf("a single /warden remove lookup 5xx must capture inline exactly once; got %d", rec.count)
+	}
+	if got := lastEditContent(f.Calls()); strings.Contains(got, rawBodyMarker) {
+		t.Fatalf("must not leak the raw Discord body, got %q", got)
+	}
+}

--- a/commands/warden_bulkadd_lookup_collapse_test.go
+++ b/commands/warden_bulkadd_lookup_collapse_test.go
@@ -10,10 +10,10 @@ import (
 
 // The headline #216 scenario for the PUBLIC bulkadd member-LOOKUP path: Discord
 // throws a 5xx storm during the per-entry name search, so every entry's lookup
-// fails with the same signature before any role is even attempted. Today each
-// entry fires its own captureError("Failed to search members", ...); the loop
-// must collapse them into ONE Sentry event carrying the affected lookup count
-// and a sample entry, while still listing every failure for the operator.
+// fails with the same signature before any role is even attempted. The invariant
+// this file guards: when every entry's lookup fails with the same signature, the
+// bulk loop emits exactly one Sentry event carrying the affected count and a
+// sample entry, while still listing every failure for the operator.
 func TestRunWardenBulkAdd_LookupSameSignatureCollapsesToOneCapture(t *testing.T) {
 	rec := &captureRecorder{}
 	rec.install(t)
@@ -270,4 +270,106 @@ func TestRunWardenRemove_MemberLookup5xxCapturesOnceInline(t *testing.T) {
 	if got := lastEditContent(f.Calls()); strings.Contains(got, rawBodyMarker) {
 		t.Fatalf("must not leak the raw Discord body, got %q", got)
 	}
+}
+
+// The headline #216 guarantee: the lookup collector and the role-add collector
+// must stay SEPARATE, never folding a same-signature fault from the two phases
+// into one event. Here one run hits both phases with the SAME signature {500,0}:
+// entry "alice"'s member LOOKUP 500s (it never reaches a role add), while entry
+// "bob" resolves but its ROLE ADD 500s. Two distinct root causes, one shared
+// signature — so a single shared collector would collapse them to ONE event.
+// Assert TWO events fire, carrying the two distinct flush messages, proving the
+// build breaks if a future edit cross-wires the two collectors.
+func TestRunWardenBulkAdd_LookupAndRoleAddSameSignatureDoNotFold(t *testing.T) {
+	rec := &captureRecorder{}
+	rec.install(t)
+
+	gm := &fakeGuildManager{
+		roles: []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+		// alice (processed first) is a name search that 500s on lookup.
+		MembersSearchErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)},
+		// bob resolves cleanly, then its role add 500s — same {500,0} signature.
+		searchResults: map[string][]*discordgo.Member{
+			"bob": {{User: &discordgo.User{ID: "222", Username: "bob"}}},
+		},
+		MemberRoleAddErrs: []error{restError(http.StatusInternalServerError, 0, rawBodyMarker)},
+	}
+	f := &fakeResponder{}
+
+	runWarden(f, gm, bulkAddInteraction("internal", "alice, bob"))
+
+	// A lookup fault and a role-add fault sharing {500,0} must NOT fold: two
+	// collectors, two events.
+	if rec.count != 2 {
+		t.Fatalf("a lookup fault and a role-add fault of the same signature must NOT fold into one event; got %d", rec.count)
+	}
+	// The two events must carry the two distinct collector flush messages, so a
+	// cross-wiring (both phases feeding one collector) fails here.
+	const lookupMsg = "Failed to look up guild member in bulk"
+	const roleAddMsg = "Failed to add warden role in bulk"
+	seen := map[string]bool{}
+	for _, m := range rec.msgs {
+		seen[m] = true
+	}
+	if !seen[lookupMsg] {
+		t.Fatalf("expected the lookup collector's flush message %q among the events; got %v", lookupMsg, rec.msgs)
+	}
+	if !seen[roleAddMsg] {
+		t.Fatalf("expected the role-add collector's flush message %q among the events; got %v", roleAddMsg, rec.msgs)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("the two events must carry two DISTINCT flush messages (lookup vs role-add); got %v", rec.msgs)
+	}
+}
+
+// A bulk by-ID member lookup that 404s with a config fault (Unknown Guild 10004,
+// a wrong GUILD_ID) IS a captured system fault: it must reach the lookup
+// collector and page once, contrasted with a genuine absence (Unknown Member
+// 10007) which stays uncaptured. This guards the lookup-by-ID classifier branch
+// where a config-404 falls through `case class.NotFound` into
+// `case class.SystemFault` — a narrowing edit that routed Unknown Guild back into
+// the absent-member arm would silence the page and only fail here.
+func TestRunWardenBulkAdd_LookupByIDConfig404CapturedAbsenceNot(t *testing.T) {
+	t.Run("unknownGuild404Captured", func(t *testing.T) {
+		rec := &captureRecorder{}
+		rec.install(t)
+		gm := &fakeGuildManager{
+			roles:      []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+			MemberErrs: []error{restError(http.StatusNotFound, discordgo.ErrCodeUnknownGuild, rawBodyMarker)},
+		}
+		f := &fakeResponder{}
+
+		runWarden(f, gm, bulkAddInteraction("internal", "<@111>"))
+
+		if rec.count != 1 {
+			t.Fatalf("a config-fault 404 (Unknown Guild) on the by-ID lookup must be collected and page once; got %d", rec.count)
+		}
+		// Routed through the lookup collector, not captured inline: the event
+		// carries the collapsed payload's affected_count.
+		if affected, ok := kvValue(rec.lastKV, "affected_count"); !ok || affected != 1 {
+			t.Fatalf("the collected config-404 lookup fault must carry affected_count=1; got %v (kv %v)", affected, rec.lastKV)
+		}
+		if got := lastEditContent(f.Calls()); strings.Contains(got, rawBodyMarker) {
+			t.Fatalf("must not leak the raw Discord body, got %q", got)
+		}
+	})
+
+	t.Run("unknownMember404NotCaptured", func(t *testing.T) {
+		rec := &captureRecorder{}
+		rec.install(t)
+		gm := &fakeGuildManager{
+			roles:      []*discordgo.Role{wardenRole("r-int", wardenRoleBaseName+" Internal")},
+			MemberErrs: []error{restError(http.StatusNotFound, discordgo.ErrCodeUnknownMember, rawBodyMarker)},
+		}
+		f := &fakeResponder{}
+
+		runWarden(f, gm, bulkAddInteraction("internal", "<@111>"))
+
+		if rec.count != 0 {
+			t.Fatalf("a genuine absence (Unknown Member 404) on the by-ID lookup must NOT capture; got %d", rec.count)
+		}
+		if got := lastEditContent(f.Calls()); !strings.Contains(got, "❌") {
+			t.Fatalf("the absent member must still be listed for the operator; got %q", got)
+		}
+	})
 }

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -401,10 +401,10 @@ func faultSignatureOf(err error) faultSignature {
 // collectedFault is the running tally for one fault signature within a single
 // bulk run: how many faults hit it, a representative error for the Sentry
 // payload, and the first roster entry that hit it (the debugging foothold the
-// collapsed event carries as sample_user). The collector is shared by the
-// role-add and lookup phases, so sampleUser is NOT always a Discord ID: it is a
-// resolved Discord ID for the by-ID lookup and role-add sites, but the raw
-// search term (e.g. "alice") for a name lookup.
+// collapsed event carries as sample_user). The collector type serves both the
+// role-add and lookup phases (each phase using its own instance), so sampleUser
+// is NOT always a Discord ID: it is a resolved Discord ID for the by-ID lookup
+// and role-add sites, but the raw search term (e.g. "alice") for a name lookup.
 type collectedFault struct {
 	count      int
 	firstErr   error
@@ -434,30 +434,29 @@ func newFaultCollector() *faultCollector {
 }
 
 // recordSystemFault records one captured system fault for the signature of err,
-// attributed to the roster-entry sample (a resolved Discord ID for the by-ID
+// attributed to the roster-entry sampleUser (a resolved Discord ID for the by-ID
 // lookup and role-add callers, or the raw search term for a name lookup — see
-// collectedFault, the sample is not always a Discord ID). It is for genuine
-// system faults ONLY: every error handed here is sent to Sentry by flush, so
-// every caller gates on class.SystemFault before calling it — non-captured client
-// faults (403, not-in-server 404) must never reach the collector (ADR 0001, #214,
-// #216). The first sample per signature is kept; every subsequent same-signature
-// fault only bumps the count. The count's meaning depends on the caller: for the
-// role-add phase, which adds several roles per member, each failed member-role
-// attempt is one call, so affected_count counts attempts; for the lookup phase,
-// which resolves one entry per iteration, affected_count counts failed lookups
-// (one per entry).
+// collectedFault). It is for genuine system faults ONLY: every error handed here
+// is sent to Sentry by flush, so every caller gates on class.SystemFault before
+// calling it — non-captured client faults (403, not-in-server 404) must never
+// reach the collector (ADR 0001, #214, #216). The first sample per signature is
+// kept; every subsequent same-signature fault only bumps the count. The count's
+// meaning depends on the caller: for the role-add phase, which adds several roles
+// per member, each failed member-role attempt is one call, so affected_count
+// counts attempts; for the lookup phase, which resolves one entry per iteration,
+// affected_count counts failed lookups (one per entry).
 //
 // The entries map is lazy-initialized here, so the zero-value faultCollector is
 // safe to record into even if a caller skipped newFaultCollector(); it can never
 // nil-panic on the first record.
-func (fc *faultCollector) recordSystemFault(err error, userID string) {
+func (fc *faultCollector) recordSystemFault(err error, sampleUser string) {
 	sig := faultSignatureOf(err)
 	if fc.entries == nil {
 		fc.entries = map[faultSignature]*collectedFault{}
 	}
 	entry, ok := fc.entries[sig]
 	if !ok {
-		entry = &collectedFault{firstErr: err, sampleUser: userID}
+		entry = &collectedFault{firstErr: err, sampleUser: sampleUser}
 		fc.entries[sig] = entry
 		fc.order = append(fc.order, sig)
 	}

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -170,19 +170,59 @@ func isInteractionTokenExpired(err error) bool {
 	}
 }
 
-// searchErrorReply classifies a GuildMembersSearch failure, captures it to
-// Sentry only when it is a genuine system fault, and returns a body-free,
-// operator-facing error. The raw Discord response body is never interpolated.
-func searchErrorReply(err error) error {
-	class := classifyDiscordError(err)
+// lookupFaultSink receives a genuine member-lookup system fault (a 5xx/transport
+// error, or a stale-role/wrong-guild config 404) together with the roster entry
+// that triggered it. The single /warden add and /warden remove sites pass nil,
+// which makes the lookup capture to Sentry inline with its own message and
+// context. The /warden bulkadd loop passes a sink backed by a faultCollector, so
+// a lookup-fault storm across an N-entry roster collapses to one Sentry event per
+// fault signature instead of N (#216). The leaf gates on class.SystemFault before
+// calling the sink, mirroring the inline capture, so non-captured client faults
+// (403, not-in-server 404) never reach it (ADR 0001).
+type lookupFaultSink func(err error, sampleUser string)
+
+// recordLookupFault routes a genuine member-lookup system fault. With a nil sink
+// (the single add/remove sites) it captures to Sentry immediately with the call
+// site's own message and context, preserving the pre-#216 inline behavior. With a
+// non-nil sink (the bulk loop) it hands the fault to the collector instead, so the
+// inline message/context is dropped in favor of the collector's collapsed
+// per-signature payload. Only call this for class.SystemFault errors, the same
+// gate the inline capture used.
+func recordLookupFault(sink lookupFaultSink, err error, sampleUser, captureMsg string, kv ...any) {
+	if sink != nil {
+		sink(err, sampleUser)
+		return
+	}
+	captureError(captureMsg, err, kv...)
+}
+
+// searchErrorMessage builds the body-free, operator-facing error for a
+// GuildMembersSearch failure from its classification. It does NOT capture — the
+// caller decides whether and how to send the fault to Sentry (inline for the
+// single lookup sites, via the faultCollector for the bulk loop). The raw Discord
+// response body is never interpolated.
+func searchErrorMessage(class discordErrorClass) error {
 	if class.SystemFault {
-		captureError("Failed to search members", err)
 		if class.ConfigFault {
 			return fmt.Errorf("❌ Member search failed: %s", configFaultHint(class))
 		}
 		return errors.New("❌ Member search is temporarily unavailable (Discord error); please try again shortly")
 	}
 	return fmt.Errorf("❌ Member search failed (%s); check the query or try a mention/ID instead", class.UserDetail)
+}
+
+// searchErrorReply classifies a GuildMembersSearch failure, routes a genuine
+// system fault through recordLookupFault (capturing inline when faultSink is nil,
+// or collecting it when the bulk loop supplies a collector-backed sink), and
+// returns the same body-free, operator-facing error searchErrorMessage builds.
+// sampleUser is the roster entry that triggered the lookup, carried into the
+// collapsed bulk event as sample_user; it is ignored on the inline path.
+func searchErrorReply(err error, faultSink lookupFaultSink, sampleUser string) error {
+	class := classifyDiscordError(err)
+	if class.SystemFault {
+		recordLookupFault(faultSink, err, sampleUser, "Failed to search members")
+	}
+	return searchErrorMessage(class)
 }
 
 // purgeRecreateErrorReply classifies a purge role-recreation failure where the

--- a/commands/warden_errors.go
+++ b/commands/warden_errors.go
@@ -171,7 +171,7 @@ func isInteractionTokenExpired(err error) bool {
 }
 
 // lookupFaultSink receives a genuine member-lookup system fault (a 5xx/transport
-// error, or a stale-role/wrong-guild config 404) together with the roster entry
+// error, or a wrong-guild config 404) together with the roster entry
 // that triggered it. The single /warden add and /warden remove sites pass nil,
 // which makes the lookup capture to Sentry inline with its own message and
 // context. The /warden bulkadd loop passes a sink backed by a faultCollector, so
@@ -399,24 +399,30 @@ func faultSignatureOf(err error) faultSignature {
 }
 
 // collectedFault is the running tally for one fault signature within a single
-// bulk run: how many add attempts hit it, a representative error for the Sentry
-// payload, and the Discord ID of the first member that hit it (the debugging
-// foothold the collapsed event carries as sample_user).
+// bulk run: how many faults hit it, a representative error for the Sentry
+// payload, and the first roster entry that hit it (the debugging foothold the
+// collapsed event carries as sample_user). The collector is shared by the
+// role-add and lookup phases, so sampleUser is NOT always a Discord ID: it is a
+// resolved Discord ID for the by-ID lookup and role-add sites, but the raw
+// search term (e.g. "alice") for a name lookup.
 type collectedFault struct {
 	count      int
 	firstErr   error
 	sampleUser string
 }
 
-// faultCollector collapses the per-member captured system faults of a bulk
-// role-add loop into one Sentry event per distinct fault signature, so a single
-// root cause that hits every iteration (a role deleted mid-run ⇒ N Unknown Role
-// 404s, or a 5xx storm) pages on-call once instead of N times (#214). Both bulk
-// loops feed it every captured fault during iteration via recordSystemFault, then
-// flush once after the loop. It is per-invocation only: a fresh collector per run, no
-// cross-run or time-windowed dedup. Only genuine system faults belong here — the
-// caller filters on class.SystemFault, since non-captured client faults (403,
-// not-in-server 404) must stay uncaptured per ADR 0001.
+// faultCollector collapses the per-entry captured system faults of a bulk run
+// into one Sentry event per distinct fault signature, so a single root cause
+// that hits every iteration (a role deleted mid-run ⇒ N Unknown Role 404s, or a
+// 5xx storm) pages on-call once instead of N times (#214, #216). It serves both
+// phases of the bulk loop — the member-lookup phase
+// (GuildMember/GuildMembersSearch) and the role-add phase (GuildMemberRoleAdd) —
+// each of which constructs its own collector, feeds it every captured fault during
+// iteration via recordSystemFault, and flushes once after the loop. It is
+// per-invocation only: a fresh collector per run, no cross-run or time-windowed
+// dedup. Only genuine system faults belong here — the caller filters on
+// class.SystemFault, since non-captured client faults (403, not-in-server 404)
+// must stay uncaptured per ADR 0001.
 type faultCollector struct {
 	// order preserves first-seen signature order so flush emits deterministically.
 	order   []faultSignature
@@ -427,15 +433,19 @@ func newFaultCollector() *faultCollector {
 	return &faultCollector{entries: map[faultSignature]*collectedFault{}}
 }
 
-// recordSystemFault records one failed add attempt for the signature of err,
-// attributed to the member userID. It is for genuine system faults ONLY: every
-// error handed here is sent to Sentry by flush, so both bulk loops gate on
-// class.SystemFault before calling it — non-captured client faults (403,
-// not-in-server 404) must never reach the collector (ADR 0001, #214). The first
-// member per signature is kept as the sample; every subsequent same-signature
-// failure only bumps the count. For /warden bulkadd, which adds several roles per
-// member, each failed member-role attempt is one call, so affected_count counts
-// attempts rather than distinct members.
+// recordSystemFault records one captured system fault for the signature of err,
+// attributed to the roster-entry sample (a resolved Discord ID for the by-ID
+// lookup and role-add callers, or the raw search term for a name lookup — see
+// collectedFault, the sample is not always a Discord ID). It is for genuine
+// system faults ONLY: every error handed here is sent to Sentry by flush, so
+// every caller gates on class.SystemFault before calling it — non-captured client
+// faults (403, not-in-server 404) must never reach the collector (ADR 0001, #214,
+// #216). The first sample per signature is kept; every subsequent same-signature
+// fault only bumps the count. The count's meaning depends on the caller: for the
+// role-add phase, which adds several roles per member, each failed member-role
+// attempt is one call, so affected_count counts attempts; for the lookup phase,
+// which resolves one entry per iteration, affected_count counts failed lookups
+// (one per entry).
 //
 // The entries map is lazy-initialized here, so the zero-value faultCollector is
 // safe to record into even if a caller skipped newFaultCollector(); it can never

--- a/commands/warden_resterror_test.go
+++ b/commands/warden_resterror_test.go
@@ -504,11 +504,14 @@ func TestFindGuildMember_MentionGeneric4xxNoCapture(t *testing.T) {
 // fields (command/guild/role) a site is required to forward. kvs keeps every
 // capture's kv in fire order, so a test that expects more than one capture (the
 // bulk-loop fault collapse, #214) can assert per-event payloads, not just the
-// most recent.
+// most recent. msgs keeps every capture's message in the same fire order, so a
+// test can tell the two bulk collectors apart by their distinct flush messages
+// (the lookup vs role-add separation invariant, #216).
 type captureRecorder struct {
 	count  int
 	lastKV []any
 	kvs    [][]any
+	msgs   []string
 }
 
 func (c *captureRecorder) install(t *testing.T) {
@@ -518,6 +521,7 @@ func (c *captureRecorder) install(t *testing.T) {
 		c.count++
 		c.lastKV = kv
 		c.kvs = append(c.kvs, kv)
+		c.msgs = append(c.msgs, msg)
 	}
 	t.Cleanup(func() { captureError = prev })
 }

--- a/commands/warden_resterror_test.go
+++ b/commands/warden_resterror_test.go
@@ -600,7 +600,7 @@ func TestSystemFaultHelpers_ConfigFaultVsTransientRendering(t *testing.T) {
 		name   string
 		render func(err error) string
 	}{
-		{"search", func(err error) string { return searchErrorReply(err).Error() }},
+		{"search", func(err error) string { return searchErrorReply(err, nil, "").Error() }},
 		{"roleResolve", func(err error) string { return roleResolveErrorReply(err, "cap").Error() }},
 		{"channelsResolve", func(err error) string { return channelsResolveErrorReply(err, "cap").Error() }},
 		{"purgeRecreate", func(err error) string { return purgeRecreateErrorReply("Some Role", err, "cap") }},


### PR DESCRIPTION
Closes #216.

Followup to #214 (PR #215). #214 collapsed the per-member Sentry captures in the `/warden bulkadd` role-add loop but left the member lookup that runs before it. For each roster entry the public loop calls `findGuildMember`, and a lookup system fault captured once per member: `resolveMemberByID` via `captureError("Failed to look up guild member by ID", ...)` for mention/ID queries, and `searchErrorReply` via `captureError("Failed to search members", ...)` for name searches. A Discord 5xx storm during a bulk add therefore fired N events for one root cause.

This routes the bulk loop's lookup faults through a per-run collector that emits one event per fault signature (HTTP status plus Discord error code), carrying `affected_count` and a `sample_user`. It reuses the `faultCollector` from #214.

## Changes
- Pulled the inline `captureError` calls out of `resolveMemberByID` and `searchErrorReply` behind a `lookupFaultSink` (a nil sink captures inline with the site's own message; a non-nil sink routes to the collector). `searchErrorReply` is split into a pure `searchErrorMessage` and a classify-and-route wrapper, mirroring the `roleMutationErrorReply` split from #214.
- `findGuildMember` keeps its signature, so single `/warden add` and `/warden remove` stay behavior-identical; it delegates to a new `findGuildMemberCollecting(..., faultSink)`. The bulk loop passes the collector's `recordSystemFault`.
- The lookup path uses its own collector, separate from the role-add one. A member lookup and a role add are distinct call sites whose same-status faults should not fold into one event, and each carries its own flush message.

## Tests
- New `warden_bulkadd_lookup_collapse_test.go`: same-signature collapse (search and by-ID paths), mixed-signature (two events), single-fault count 1, non-captured outcomes (not-in-server, no match, too many matches, 4xx) listed but uncaptured, and single add/remove lookup faults still capturing once inline.

Unchanged, per the issue's out-of-scope list: the role-add collapse, the internal `/warden-bulkadd-internal` command, which faults capture at all, and Sentry fingerprinting.

> *This was generated by AI*
