### PR TITLE
fix(loa): attribute LOAs to the subject, not the submitter

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,14 +44,30 @@ belong here, not inline in code comments.
 - **Xenforo forum** — the regiment's web forum. The bot reads its MySQL DB
   (`xf_thread`, `xf_post`) for LOA scanning.
 - **LOA (Leave of Absence)** — a forum thread declaring a member away from
-  duty for a date range. Parsed from a specific Xenforo BBCode template
-  (yellow `[COLOR=rgb(213, 185, 0)]` labels around `Username`, `Start Date`,
-  `End Date`). Template drift silently breaks parsing. One thread is exactly
+  duty for a date range. Filed via a **PAF** and parsed from its Xenforo
+  BBCode template (labels around the **Subject**'s username, `Start Date`, and
+  `End Date`). The PAF records both a **Submitter** and a **Subject**; the LOA
+  belongs to the **Subject** — that is who `/loa` and `/awol` key on, never the
+  Submitter. Template drift silently breaks parsing. One thread is exactly
   one LOA — a second LOA always means a new thread, so `ThreadID` uniquely
   identifies an LOA. **Filing an LOA is itself a forum post**, so it resets the
   trooper's last-post clock; this is why a long unexcused gap immediately
   followed by an LOA is rare in practice (the accountable-day model still
   handles it correctly if it occurs).
+- **PAF (Personnel Action Form)** — a forum form for filing a personnel
+  action. An LOA is filed via an LOA-request PAF, which records both a
+  Submitter and a Subject. A PAF's field labels are what the bot parses, so a
+  forum-side relabel is a change to the bot's parsing contract, not a cosmetic
+  edit.
+- **Subject** — the trooper an LOA is *for*; the person going on leave. The
+  LOA belongs to the Subject, and it is the only party the bot attributes the
+  LOA to. _Avoid_: bare "Username" — the PAF historically carries the Submitter
+  and the Subject under the same `Username` label, so "the username" is
+  ambiguous.
+- **Submitter** — the account that files a PAF. For an LOA this may be the
+  Subject themselves (a self-request) or someone acting on their behalf (e.g.
+  their squad lead). The bot never attributes the LOA to the Submitter.
+  _Avoid_: author, poster.
 - **LOA node** — a Xenforo forum section that hosts LOA threads. Production
   scans five (`180,400,540,178,369`); the code default is `180`.
 - **LOA cache** — `utils.GlobalLOACache`, the in-process cache populated by a

--- a/docs/adr/0010-loa-subject-attribution.md
+++ b/docs/adr/0010-loa-subject-attribution.md
@@ -1,0 +1,61 @@
+# ADR 0010: LOA Subject attribution — parse the last Username label
+
+## Status
+
+Accepted. Fixes #221 (`/loa` showed the person who filed an LOA instead of the
+trooper on leave).
+
+## Decision
+
+`parseLOAPost` attributes an LOA to its **Subject** — the last `Username` label
+in the post body — not the first.
+
+An LOA is filed via a **PAF** (Personnel Action Form). When one trooper files on
+behalf of another, the PAF body carries **two** `Username` labels: the
+**Submitter** first (auto-filled from the filing account), then the **Subject**
+inside the Rank/Username/Primary Billet block. The LOA belongs to the Subject.
+The parser reads all `Username` matches and keeps the **last** one. A
+self-request has a single label (or a duplicate naming the same person), so the
+rule leaves those unchanged. `Start Date` / `End Date` are never duplicated in
+practice and keep their first-match extraction.
+
+## Why
+
+The old parser took the first `Username` match, so every on-behalf LOA was filed
+under the submitter — the real trooper never appeared in `/loa`, and `/awol`
+credited the wrong person with LOA coverage. Against a full mirror of the LOA
+forum nodes, of the posts where the two labels differ the **last** label matches
+the machine-generated thread title (`[LOA Request] - <Rank>.<Name> | …`) 95% of
+the time and the first only 2%; across all posts the last label agrees with the
+title 98.9% vs 94.2%. So last-match is strictly better in every bucket, and no
+post carries three or more labels.
+
+We took the body's last label rather than the title because `/loa` keys the
+cache on the `Username` **field** and looks it up against each roster member's
+forum username — the body value is that field, whereas the title is a rendered
+display string with a rank prefix that would need stripping and risks a
+display-vs-username mismatch. Last-match also needs no special handling for the
+posts that lack a standard title.
+
+We fixed the parser rather than the forum form. The form's field labels are the
+bot's parsing contract, so any relabel is a coupled, coordinated change — and,
+crucially, a form change cannot reach the PAFs already filed. The parser fix
+does: the LOA cache is in-process with no persistence, so every deploy
+cold-starts and re-scans the last year of threads, re-attributing the historical
+on-behalf PAFs on the next release with no migration.
+
+## Consequences
+
+- Fixes heal on the **next release deploy** (cold-start re-scan). There is no
+  hot path; prod stays wrong until then.
+- `/awol` is corrected for free — same cache, now keyed on the Subject.
+- If the form is ever relabelled so the Submitter line is no longer a `Username`
+  label, the Subject becomes the lone label and the last-match rule still holds.
+- The rule assumes no field *after* the Subject carries a label containing the
+  substring `Username` (a hypothetical `Submitter Username` or `Forum Username`
+  would be grabbed instead). This holds across every current post — the max is
+  two labels, the second being the Subject. Anchoring the label to line-start
+  would harden against that drift, but was **rejected**: it drops two real LOAs
+  whose `Rank`/`Username`/`Billet` fields are collapsed onto one line
+  (`Rank: PVT Username: Name …`). Form drift is instead guarded by the
+  mirror-seeded regression cases, per the LOA parsing note in CLAUDE.md.

--- a/utils/loa.go
+++ b/utils/loa.go
@@ -19,6 +19,7 @@ import (
 var reFormatBBCode = regexp.MustCompile(`(?i)\[/?(?:b|i|u|s|color|size|font)(?:=[^\]]*)?\]`)
 
 var (
+	// reUsername: the Subject is the LAST match — see parseLOAPost and ADR 0010.
 	reUsername  = regexp.MustCompile(`(?i)Username\s*:?\s*(\S+)`)
 	reStartDate = regexp.MustCompile(`(?i)Start Date\s*:?\s*[\r\n]+\s*([^\r\n]+)`)
 	reEndDate   = regexp.MustCompile(`(?i)End Date\s*:?\s*[\r\n]+\s*([^\r\n]+)`)
@@ -358,15 +359,21 @@ func parseLOAPost(msg string) (LOAEntry, bool) {
 	// post's bold/color/size wrapping (the source of historical silent failures).
 	msg = reFormatBBCode.ReplaceAllString(msg, "")
 
-	usernameMatch := reUsername.FindStringSubmatch(msg)
+	usernameMatches := reUsername.FindAllStringSubmatch(msg, -1)
 	startMatch := reStartDate.FindStringSubmatch(msg)
 	endMatch := reEndDate.FindStringSubmatch(msg)
 
-	if len(usernameMatch) < 2 || len(startMatch) < 2 || len(endMatch) < 2 {
+	if len(usernameMatches) == 0 || len(startMatch) < 2 || len(endMatch) < 2 {
 		return LOAEntry{}, false
 	}
 
-	username := strings.TrimSpace(usernameMatch[1])
+	// The LOA belongs to the Subject, not the Submitter. An on-behalf PAF lists
+	// the Submitter under a leading Username label and the Subject under a second
+	// one inside the Rank/Username/Primary Billet block, so the Subject is always
+	// the LAST Username match. A self-request has a single label (or a duplicate
+	// naming the same person), which this rule leaves unchanged. See ADR 0010.
+	subjectMatch := usernameMatches[len(usernameMatches)-1]
+	username := strings.TrimSpace(subjectMatch[1])
 	startDate, ok := parseLOADate(startMatch[1])
 	if !ok {
 		return LOAEntry{}, false

--- a/utils/loa_test.go
+++ b/utils/loa_test.go
@@ -172,6 +172,56 @@ func TestParseLOAPost(t *testing.T) {
 			wantEnd:   "2026-04-19",
 		},
 		{
+			// Real mirror shape (thread 100403): an on-behalf PAF carries TWO
+			// Username labels — the SUBMITTER first (auto-filled from the filing
+			// account), then the SUBJECT (the trooper actually on leave) inside
+			// the Rank/Username/Primary Billet block. The LOA belongs to the
+			// Subject, so the LAST label wins, not the first. This is the #221
+			// regression: the old first-match parser attributed the LOA to the
+			// submitter. See docs/adr/0010-loa-subject-attribution.md.
+			name: "on-behalf PAF: subject is the last Username label, not the submitter",
+			msg: "[COLOR=rgb(213, 185, 0)][B]Username:[/B] [/COLOR]Filer.S\n\n" +
+				"[B][COLOR=rgb(213, 185, 0)]Rank[/COLOR][/B]: SPC\n\n" +
+				"[B][COLOR=rgb(213, 185, 0)]Username[/COLOR][/B]: Leaver.T\n\n" +
+				"[B][COLOR=rgb(213, 185, 0)]Primary Billet[/COLOR][/B]: A/ACD\n\n" +
+				"[B][COLOR=rgb(213, 185, 0)]Start Date[/COLOR][/B] \nJul 10, 2099\n" +
+				"[B][COLOR=rgb(213, 185, 0)]End Date[/COLOR][/B] \nJul 24, 2099\n\n" +
+				"[HR][/HR]\n[B][COLOR=rgb(213, 185, 0)]Submitter Name[/COLOR][/B] \nSSG.Filer.S\n",
+			wantOK:    true,
+			wantUser:  "Leaver.T",
+			wantStart: "2099-07-10",
+			wantEnd:   "2099-07-24",
+		},
+		{
+			// Real mirror shape (thread 38835): an older PAF collapses Rank,
+			// Username, and Billet onto ONE line, so the Username label is not at
+			// the start of its line. The parser must still extract the Subject —
+			// this pins the decision NOT to anchor the label to line-start (which
+			// would silently drop this real LOA). See ADR 0010 Consequences.
+			name: "collapsed single-line Rank/Username/Billet still parses the subject",
+			msg: "[B]Rank[/B]: PVT [B]Username[/B]: Collapsed.C   [B]Billet[/B]: 2/B/ACD\n" +
+				"Reason:\nDeployment\n\nStart Date\nJan 1, 2099\nEnd Date\nJan 8, 2099\n",
+			wantOK:    true,
+			wantUser:  "Collapsed.C",
+			wantStart: "2099-01-01",
+			wantEnd:   "2099-01-08",
+		},
+		{
+			// Self PAF with the same two-label shape (submitter == subject): the
+			// last-label rule must still resolve to that one person, so self-LOAs
+			// stay correct after the on-behalf fix.
+			name: "self PAF: duplicate Username labels resolve to the same subject",
+			msg: "[COLOR=rgb(213, 185, 0)][B]Username:[/B] [/COLOR]Same.S\n\n" +
+				"[B][COLOR=rgb(213, 185, 0)]Rank[/COLOR][/B]: SPC\n\n" +
+				"[B][COLOR=rgb(213, 185, 0)]Username[/COLOR][/B]: Same.S\n\n" +
+				"[B][COLOR=rgb(213, 185, 0)]Start Date[/COLOR][/B] \nAug 1, 2099\n" +
+				"[B][COLOR=rgb(213, 185, 0)]End Date[/COLOR][/B] \nAug 8, 2099\n",
+			wantOK:    true,
+			wantUser:  "Same.S",
+			wantStart: "2099-08-01",
+			wantEnd:   "2099-08-08",
+		},
+		{
 			// Free-text date (thread 95564, "probably May 8, 2026") must still be rejected —
 			// leniency covers template variation, not unparseable prose.
 			name:   "free-text uncertain date is still rejected",


### PR DESCRIPTION
## What

`/loa` showed whoever *filed* an LOA rather than the trooper actually on leave.
Reported in #221: a squad lead filed on behalf of a trooper, and `/loa` listed
the squad lead as on leave.

## Root cause

An LOA is filed via a PAF (Personnel Action Form). When one trooper files on
behalf of another, the post body carries two `Username` labels: the submitter
first (auto-filled from the filing account), then the subject inside the
Rank/Username/Primary Billet block. `parseLOAPost` read the first match, so it
keyed the LOA on the submitter. `/awol` reads the same cache, so it credited the
wrong person with LOA coverage as well.

## Fix

Take the last `Username` label. Checked against a full mirror of the five LOA
forum nodes:

- Of the posts where the two labels differ, the last matches the
  machine-generated thread title (`[LOA Request] - <Rank>.<Name> | dates`) 95%
  of the time; the first, 2%.
- Across all posts, last-match agrees with the title 98.9% against 94.2% for
  first-match, so it is better in every bucket.
- No post carries three or more labels. Self-requests have a single label and
  are unchanged.
- `Start Date`/`End Date` stay on first-match (only 2 of 6161 posts ever
  duplicate them).

I weighed reading the subject from the thread title and passed on it: the body
`Username` is the same namespace as the roster lookup key, whereas the title is
a display string that needs rank-stripping. Anchoring the label to line-start
would guard against a future `Submitter Username`-style field, but it drops two
real LOAs whose fields sit on one collapsed line, so I left it out. Both
trade-offs are recorded in ADR 0010.

## Healing the history

The LOA cache is in-process with no persistence, so every deploy cold-starts and
re-scans the last year of threads. The roughly 300 historical on-behalf LOAs
re-attribute on the next release. No migration.

## Out of scope

A forum-side form relabel. The form's labels are the parser's contract, so a
relabel couples a bot deploy anyway, and it cannot reach PAFs already filed.

## Testing

Regression cases seeded from real post shapes (thread 100403 on-behalf, thread
38835 collapsed-line). Full gate green: golangci-lint, race tests, coverage
floors (utils 91.0%, commands 91.5%), build.

Manual gate: this wants a test-guild smoke test of `/loa` on a position with an
on-behalf LOA, since CI cannot exercise the live Discord gateway.

Fixes #221

> *This was generated by AI*
