### PR TITLE
Add /promo command + weekly sweep (#4)

### DIFF
--- a/commands/promo.go
+++ b/commands/promo.go
@@ -1,0 +1,1134 @@
+package commands
+
+// /promo: S1 promotion checker (issue 7Cav/cavbot2#4).
+//
+// Lists every trooper in a scope (a position/unit, or all Active Duty
+// holders of one rank) whose promotion would be possible as of a given date
+// (default today), via either the standard ladder (promo_eligibility.go) or
+// the Veteran Rank Retention Ch.4 §VII alternative path (vii.go). Both
+// engines are ports of the author's internal S1 promotion tooling.
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+	"golang.org/x/sync/errgroup"
+)
+
+// Promotion-path values for the `type`/`exclude` filter options. automatic
+// and discretionary are the standard-ladder Type values from
+// promotionRequirements; vii and lateral are the alternative paths.
+const (
+	promoTypeAutomatic     = "automatic"
+	promoTypeDiscretionary = "discretionary"
+	promoTypeVii           = "vii"
+	promoTypeLateral       = "lateral"
+)
+
+// promoFilter narrows the candidate list. include keeps only candidates with
+// that path; exclude drops candidates whose ONLY path is the excluded one. The
+// two are mutually exclusive (validated in runPromo); both empty = no filter.
+type promoFilter struct {
+	include string
+	exclude string
+}
+
+// apply narrows candidates per the filter (no-op when neither is set).
+func (f promoFilter) apply(candidates []promoCandidate) []promoCandidate {
+	switch {
+	case f.include != "":
+		return filterPromoCandidates(candidates, f.include)
+	case f.exclude != "":
+		return filterPromoExcluding(candidates, f.exclude)
+	default:
+		return candidates
+	}
+}
+
+// phrase is the noun phrase for prose ("automatic promotion", "promotion
+// excluding §VII", or plain "promotion").
+func (f promoFilter) phrase() string { return promoFilterPhrase(f.include, f.exclude) }
+
+// tag labels filenames and logs ("automatic", "excl-vii", or "").
+func (f promoFilter) tag() string {
+	if f.exclude != "" {
+		return "excl-" + f.exclude
+	}
+	return f.include
+}
+
+// promoCandidate is one line of /promo output.
+type promoCandidate struct {
+	Username  string
+	MilpacURL string
+	RankShort string
+	// Primary is the trooper's primary billet (milpac position title).
+	Primary string
+	Verdict promoEligibility
+	// Vii is non-nil when the §VII path was evaluated; ViaVII marks a
+	// candidate eligible through §VII (standard gates may be unmet).
+	Vii    *viiResult
+	ViaVII bool
+	// LateralTarget is the warrant rank a winged aviator NCO can move to
+	// laterally (e.g. CPL → WO1); empty when the lateral path doesn't apply.
+	LateralTarget string
+}
+
+// promoMessageLimit is the per-message packing bound, under Discord's
+// 2000-character cap with headroom for the sweep's header prefix. Long
+// candidate lists span multiple messages instead of truncating.
+const promoMessageLimit = 1900
+
+// promoOverflowReserve is the space held back from promoMessageLimit for the
+// "…and N more" notice, so appending it can never overflow the message.
+const promoOverflowReserve = 80
+
+// promoDisclaimer heads every /promo output (list and single-trooper), since
+// both derive eligibility from hand-entered milpac data.
+const promoDisclaimer = "⚠️ Due to potential discrepancies in MILPAC notation, this command may produce inaccurate results. Treat the output of this command as a candidate list, not a guarantee. Please report inaccurate outputs to S6 so that we may investigate and repair."
+
+// promoRankOrder lists milpac rank short forms most-senior-first (military
+// precedence: officers, then warrants, then enlisted, the milpac display
+// order). It drives candidate-list sorting; ranks not listed sort last.
+var promoRankOrder = []string{
+	"GOA", "GEN", "LTG", "MG", "BG", "COL", "LTC", "MAJ", "CPT", "1LT", "2LT",
+	"CW5", "CW4", "CW3", "CW2", "WO1",
+	"CSM", "SGM", "1SG", "MSG", "SFC", "SSG", "SGT", "CPL", "SPC", "PFC", "PVT", "RCT",
+}
+
+var promoRankSeniority = func() map[string]int {
+	m := make(map[string]int, len(promoRankOrder))
+	for idx, rank := range promoRankOrder {
+		m[rank] = idx
+	}
+	return m
+}()
+
+// promoRankIndex returns the sort key for a rank short form: seniority index
+// (lower = more senior), with unknown ranks after every known one.
+func promoRankIndex(rankShort string) int {
+	if idx, ok := promoRankSeniority[strings.ToUpper(rankShort)]; ok {
+		return idx
+	}
+	return len(promoRankOrder)
+}
+
+// promoNextRankIndex is the seniority sort key for a "next rank" cell, taking
+// the first rank of a compound target (SPC's "CPL/WO1" sorts as CPL).
+func promoNextRankIndex(nextRank string) int {
+	return promoRankIndex(strings.SplitN(nextRank, "/", 2)[0])
+}
+
+// promoDate renders dates in the org's DDMMMYY style (e.g. 23JUL26).
+func promoDate(t time.Time) string {
+	return strings.ToUpper(t.Format("02Jan06"))
+}
+
+// parsePromoDate parses user-entered dates in the org's DDMMMYY style
+// (case-insensitive, e.g. 30JUL26); YYYY-MM-DD is accepted as a fallback.
+func parsePromoDate(s string) (time.Time, error) {
+	v := strings.TrimSpace(s)
+	if len(v) == 7 {
+		// Go month names parse case-sensitively, so canonicalize to "02Jan06".
+		canon := v[:2] + strings.ToUpper(v[2:3]) + strings.ToLower(v[3:5]) + v[5:]
+		if t, err := time.Parse("02Jan06", canon); err == nil {
+			return t, nil
+		}
+	}
+	return time.Parse("2006-01-02", v)
+}
+
+// scopeDisplay renders a scope label for prose: the activeduty sentinel reads
+// "active duty"; a position/unit or rank code is upper-cased (ACD, S1, PFC)
+// regardless of how the user typed it, since those are always upper-case in
+// milpac usage.
+func scopeDisplay(scope string) string {
+	if isActiveDutyScope(scope) {
+		return "active duty"
+	}
+	return strings.ToUpper(scope)
+}
+
+// promoPhrase is the "<type> promotion" noun phrase for sentences, e.g.
+// "No active duty members eligible for lateral promotion as of 23JUL26".
+func promoPhrase(promoType string) string {
+	switch promoType {
+	case "":
+		return "promotion"
+	case promoTypeVii:
+		return "§VII promotion"
+	default:
+		return promoType + " promotion"
+	}
+}
+
+// promoTypeWord is a single filter value rendered for prose (§VII for vii).
+func promoTypeWord(t string) string {
+	if t == promoTypeVii {
+		return "§VII"
+	}
+	return t
+}
+
+// promoFilterPhrase is the noun phrase reflecting the active filter: the
+// include phrase for a type filter, or "promotion excluding <path>" for an
+// exclude filter (the two are mutually exclusive).
+func promoFilterPhrase(promoType, excludeType string) string {
+	if excludeType != "" {
+		return "promotion excluding " + promoTypeWord(excludeType)
+	}
+	return promoPhrase(promoType)
+}
+
+// upperFirst capitalizes the leading ASCII letter for sentence starts.
+func upperFirst(s string) string {
+	if s == "" || s[0] < 'a' || s[0] > 'z' {
+		return s
+	}
+	return string(s[0]-'a'+'A') + s[1:]
+}
+
+func Promo() Command {
+	return Command{
+		Definition: &discordgo.ApplicationCommand{
+			Name:        "promo",
+			Description: "Check promotion eligibility (standard ladder + §VII) for a position scope or one trooper",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "position",
+					Description: "Position/unit (fuzzy, e.g. 'ACD', '1-7', 'S1') or 'activeduty' for the whole roster (default)",
+					Required:    false,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "user",
+					Description: "Check one trooper by forum username (full verdict breakdown)",
+					Required:    false,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "rank",
+					Description: "Check every active-duty trooper at this rank (milpac short form, e.g. PFC)",
+					Required:    false,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "as_of",
+					Description: "Check eligibility as of this date (DDMMMYY, e.g. 30JUL26; default today)",
+					Required:    false,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionBoolean,
+					Name:        "force_file_output",
+					Description: "Always attach the full candidate list as a file. Long lists attach automatically.",
+					Required:    false,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "type",
+					Description: "Only list one promotion path",
+					Required:    false,
+					Choices: []*discordgo.ApplicationCommandOptionChoice{
+						{Name: "automatic", Value: promoTypeAutomatic},
+						{Name: "discretionary", Value: promoTypeDiscretionary},
+						{Name: "vii (veteran rank retention)", Value: promoTypeVii},
+						{Name: "lateral", Value: promoTypeLateral},
+					},
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "exclude",
+					Description: "Hide one promotion path (e.g. exclude:vii shows everyone except §VII-only candidates)",
+					Required:    false,
+					Choices: []*discordgo.ApplicationCommandOptionChoice{
+						{Name: "automatic", Value: promoTypeAutomatic},
+						{Name: "discretionary", Value: promoTypeDiscretionary},
+						{Name: "vii (veteran rank retention)", Value: promoTypeVii},
+						{Name: "lateral", Value: promoTypeLateral},
+					},
+				},
+			},
+		},
+		Handler: handlePromoCommand,
+	}
+}
+
+func handlePromoCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	runPromo(utils.NewSessionResponder(s), i, time.Now())
+}
+
+// runPromo is the testable core; now pins "today" for tests.
+func runPromo(r utils.InteractionResponder, i *discordgo.InteractionCreate, now time.Time) {
+	username, discordID := interactionUsernameAndID(i)
+	utils.Info("🚀 Starting Promo Check", "command", "Promo", "username", username, "discord_id", discordID)
+
+	position, user, rank, promoType, excludeType := "", "", "", "", ""
+	forceFile := false
+	asOf := now
+	for _, opt := range i.ApplicationCommandData().Options {
+		switch opt.Name {
+		case "position":
+			position = opt.StringValue()
+		case "user":
+			user = opt.StringValue()
+		case "rank":
+			rank = opt.StringValue()
+		case "type":
+			promoType = opt.StringValue()
+		case "exclude":
+			excludeType = opt.StringValue()
+		case "force_file_output":
+			forceFile = opt.BoolValue()
+		case "as_of":
+			parsed, err := parsePromoDate(opt.StringValue())
+			if err != nil {
+				utils.HandleError(r, i, fmt.Sprintf("❌ Invalid as_of date %q. Use DDMMMYY (e.g. 30JUL26).", opt.StringValue()))
+				return
+			}
+			asOf = parsed
+		}
+	}
+	utils.Debug("🔍 Processing promo options", "position", position, "user", user, "rank", rank, "type", promoType, "as_of", asOf.Format("2006-01-02"))
+
+	// `user` is a single-trooper check and stands alone; `position` and `rank`
+	// combine (position scopes the roster, rank narrows within it). Default to
+	// the whole Active Duty roster when no scope is given.
+	if user != "" {
+		if position != "" || rank != "" {
+			utils.HandleError(r, i, "❌ `user` checks one trooper on its own; don't combine it with `position` or `rank`.")
+			return
+		}
+		runPromoUser(r, i, user, asOf)
+		return
+	}
+	if promoType != "" && excludeType != "" {
+		utils.HandleError(r, i, "❌ Use either `type` (show only one path) or `exclude` (hide one path), not both.")
+		return
+	}
+	if position == "" {
+		position = promoActiveDutyScope
+	}
+	rank = strings.ToUpper(strings.TrimSpace(rank))
+
+	// Scope label: the position, optionally narrowed by a rank (e.g. "ACD PVT",
+	// "active duty PVT"). Prose uses scopeDisplay/promoFilterPhrase; filenames
+	// and logs keep the raw scope (plus a filter tag for logs).
+	scope := scopeDisplay(position)
+	if rank != "" {
+		scope = strings.TrimSpace(scope + " " + rank)
+	}
+	filterTag := promoType
+	if excludeType != "" {
+		filterTag = "excl-" + excludeType
+	}
+	logScope := scope
+	if filterTag != "" {
+		logScope += " (" + filterTag + ")"
+	}
+
+	err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("Checking %s eligibility for %s as of %s...", promoFilterPhrase(promoType, excludeType), scope, promoDate(asOf)),
+		},
+	})
+	if err != nil {
+		utils.CaptureError("❌ Interaction response failed", err)
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to respond to interaction: %v", err))
+		return
+	}
+
+	// Same fan-out shape as AFSM: per-member milpac fetches are ~1.4s each and
+	// rosters run 50+, so serial evaluation would blow the timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	filter := promoFilter{include: promoType, exclude: excludeType}
+	res, err := collectPromoCandidates(ctx, position, rank, asOf, filter)
+	if err != nil {
+		utils.CaptureError("❌ Roster fetch failed", err)
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to fetch roster: %v", err))
+		return
+	}
+	// Position/rank are user-supplied, so an empty roster is a plausible user
+	// outcome: message only, no Sentry (ADR 0002).
+	if res.EmptyRoster {
+		switch {
+		case rank != "" && !isActiveDutyScope(position):
+			utils.HandleError(r, i, fmt.Sprintf("❌ No %s troopers hold rank %s.", scopeDisplay(position), rank))
+		case rank != "":
+			utils.HandleError(r, i, fmt.Sprintf("❌ No active-duty troopers hold rank %s. Use the milpac short form (e.g. PFC, SGT, CW2).", rank))
+		default:
+			utils.HandleError(r, i, emptyRosterSearchMessage(position))
+		}
+		return
+	}
+	res.Candidates = filter.apply(res.Candidates)
+
+	message, omitted := formatPromoMessage(scope, filter, asOf, res.Candidates, res.SkippedCount, res.ViiActive)
+	attach := forceFile || omitted > 0
+	edit := &discordgo.WebhookEdit{Content: &message}
+	if attach {
+		// The message keeps the inline list (and its "…and N more" notice);
+		// the full detail rides along as both a CSV (for spreadsheets) and an
+		// HTML report (for reading with clickable links).
+		edit.Files = []*discordgo.File{
+			promoCSVFile(scope, filter, asOf, res),
+			promoReportFile(scope, filter, asOf, res),
+		}
+	}
+	if err := r.InteractionResponseEdit(i.Interaction, edit); err != nil {
+		captureDeferredEditFailure(i, "Promo", err)
+		return
+	}
+	utils.Info("✨ Done!", "command", "Promo", "scope", logScope,
+		"eligible", len(res.Candidates), "omitted_from_message", omitted, "attached_file", attach)
+}
+
+// candidateFilterCategories lists the filter categories a candidate matches:
+// its standard ladder type (automatic/discretionary) if standard-eligible,
+// plus vii and/or lateral for those paths. These are the values the type and
+// exclude filters key off. A candidate in the list always has at least one.
+func candidateFilterCategories(c promoCandidate) []string {
+	var cats []string
+	if c.Verdict.Eligible {
+		cats = append(cats, c.Verdict.Type) // automatic or discretionary
+	}
+	if c.ViaVII {
+		cats = append(cats, promoTypeVii)
+	}
+	if c.LateralTarget != "" {
+		cats = append(cats, promoTypeLateral)
+	}
+	return cats
+}
+
+// filterPromoCandidates keeps only candidates matching the given promotion
+// path. automatic/discretionary require STANDARD eligibility of that ladder
+// type; vii keeps §VII eligibles and lateral keeps winged-aviator warrant
+// moves, both regardless of standard-ladder status.
+func filterPromoCandidates(candidates []promoCandidate, promoType string) []promoCandidate {
+	filtered := make([]promoCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		for _, cat := range candidateFilterCategories(c) {
+			if cat == promoType {
+				filtered = append(filtered, c)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+// filterPromoExcluding drops candidates whose ONLY path is the excluded one -
+// a candidate keeps its place if it has any other reason to be promoted. So
+// exclude:vii hides §VII-only troopers but keeps someone eligible via both the
+// standard ladder and §VII.
+func filterPromoExcluding(candidates []promoCandidate, excludeType string) []promoCandidate {
+	filtered := make([]promoCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		for _, cat := range candidateFilterCategories(c) {
+			if cat != excludeType {
+				filtered = append(filtered, c)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+// evaluatePromoMember returns (candidate, nil) when the trooper is eligible
+// for promotion as of asOf, (nil, nil) when not, and (nil, err) when the
+// record could not be processed and should be skipped + reported.
+func evaluatePromoMember(
+	ctx context.Context,
+	member utils.LiteProfileResponse,
+	asOf time.Time,
+	rankModel *viiRankModel,
+) (*promoCandidate, error) {
+	utils.Debug("👤 Processing member", "username", member.User.Username)
+
+	rankShort := member.Rank.RankShort
+	_, hasLadder := promotionRequirements[rankShort]
+	if !hasLadder && rankModel == nil {
+		// No standard ladder for this rank (COL+, or unrecognized) and no
+		// §VII path this run: not a candidate, not worth a milpac fetch.
+		// With a rank model present the fetch must happen: §VII can restore a
+		// previously-held rank regardless of the standard ladder.
+		return nil, nil
+	}
+
+	// Course completions and §VII service history live in the full profile.
+	fullProfile, err := utils.GetMilpacByUsername(ctx, member.User.Username)
+	if err != nil {
+		return nil, fmt.Errorf("milpac fetch failed: %w", err)
+	}
+
+	courses := parseCourseCompletions(fullProfile.Records)
+	verdict := calculatePromotionEligibility(
+		rankShort,
+		fullProfile.PromotionDate,
+		fullProfile.JoinDate,
+		courses,
+		fullProfile.Primary.PositionTitle,
+		fullProfile.Mos,
+		asOf,
+	)
+
+	var vii *viiResult
+	if rankModel != nil {
+		v := viiAnalyze(fullProfile, rankModel, asOf)
+		vii = &v
+	}
+	viaVII := vii != nil && vii.EligibleNow
+
+	// Lateral path: an NCO whose rank has a warrant equivalent moves across
+	// when flight-qualified (wings + 15-series MOS, the same pairing the §VII
+	// engine uses for warrant display), e.g. CPL → WO1.
+	lateralTarget := ""
+	if target, ok := viiE2W[strings.ToUpper(rankShort)]; ok &&
+		viiHasWings(fullProfile) && viiIsAviation(fullProfile) {
+		lateralTarget = target
+	}
+
+	if !verdict.Eligible && !viaVII && lateralTarget == "" {
+		utils.Debug("⏳ Member not eligible", "username", member.User.Username, "days_until", verdict.DaysUntilEligible)
+		return nil, nil
+	}
+
+	milpacID, err := utils.ExtractMilpacIDFromUniformURL(member.UniformUrl)
+	if err != nil {
+		return nil, fmt.Errorf("uniform URL parse failed: %w", err)
+	}
+
+	utils.Info("✨ Member eligible for promotion", "username", member.User.Username, "next_rank", verdict.NextRank, "via_vii", viaVII, "lateral", lateralTarget)
+	return &promoCandidate{
+		Username:      member.User.Username,
+		MilpacURL:     fmt.Sprintf("https://7cav.us/rosters/profile/%s", milpacID),
+		RankShort:     rankShort,
+		Primary:       fullProfile.Primary.PositionTitle,
+		Verdict:       verdict,
+		Vii:           vii,
+		ViaVII:        viaVII,
+		LateralTarget: lateralTarget,
+	}, nil
+}
+
+// formatPromoMessage renders the candidate list as a single Discord message
+// and reports how many candidates did not fit. A roster-wide scope can return
+// hundreds of candidates (far more than Discord will carry and more than
+// anyone wants paged through a channel), so the message shows as many as fit
+// and the caller attaches the full report when omitted > 0. The disclaimer
+// always renders: eligibility is parsed from user-entered milpac data, so
+// formatting drift can silently skew results (same rationale as /afsm).
+func formatPromoMessage(scope string, filter promoFilter, asOf time.Time, candidates []promoCandidate, skippedCount int, viiActive bool) (string, int) {
+	footer := promoFooter(skippedCount, viiActive)
+
+	var b strings.Builder
+	b.WriteString(promoDisclaimer)
+	b.WriteString("\n\n")
+
+	if len(candidates) == 0 {
+		b.WriteString(fmt.Sprintf("No %s members eligible for %s as of %s", scope, filter.phrase(), promoDate(asOf)))
+		b.WriteString(footer)
+		return strings.TrimRight(b.String(), "\n"), 0
+	}
+
+	b.WriteString(fmt.Sprintf("**%s members eligible for %s as of %s:**\n", upperFirst(scope), filter.phrase(), promoDate(asOf)))
+
+	// Reserve room for the footer and a worst-case overflow notice so the
+	// message cannot be pushed over the limit by what gets appended after
+	// the loop.
+	budget := promoMessageLimit - len(footer) - promoOverflowReserve
+	listed := 0
+	for _, c := range candidates {
+		line := formatPromoLine(c)
+		if b.Len()+len(line) > budget {
+			break
+		}
+		b.WriteString(line)
+		listed++
+	}
+	omitted := len(candidates) - listed
+	if omitted > 0 {
+		b.WriteString(fmt.Sprintf("…and %d more. Full list in the attached report.", omitted))
+	}
+	b.WriteString(footer)
+	return strings.TrimRight(b.String(), "\n"), omitted
+}
+
+// promoFooter renders the shared trailing notices (§VII degradation, skipped
+// members) appended to the message.
+func promoFooter(skippedCount int, viiActive bool) string {
+	var footer strings.Builder
+	if !viiActive {
+		footer.WriteString("\nℹ️ Veteran Rank Retention (§VII) check unavailable this run (rank data fetch failed); standard ladder only.")
+	}
+	if skippedCount > 0 {
+		noun := "members"
+		if skippedCount == 1 {
+			noun = "member"
+		}
+		footer.WriteString(fmt.Sprintf("\n⚠️ %d %s skipped due to errors (reported)", skippedCount, noun))
+	}
+	return footer.String()
+}
+
+// formatPromoLine renders one candidate. Standard candidates show the ladder
+// step; §VII-only candidates the restoration target and previously-held
+// evidence; lateral-only candidates the warrant move. A candidate eligible
+// via several paths reads as the most conventional one (standard, then
+// §VII), with the other paths appended as flags.
+func formatPromoLine(c promoCandidate) string {
+	lateralNote := func() string {
+		if c.LateralTarget == "" {
+			return ""
+		}
+		return ", also lateral → " + c.LateralTarget
+	}
+	if !c.Verdict.Eligible && !c.ViaVII {
+		return fmt.Sprintf("[%s](<%s>) %s → %s (lateral, flight wings)\n", c.Username, c.MilpacURL, c.RankShort, c.LateralTarget)
+	}
+	if c.ViaVII && !c.Verdict.Eligible {
+		line := fmt.Sprintf("[%s](<%s>) %s → %s (§VII veteran retention", c.Username, c.MilpacURL, c.RankShort, c.Vii.Target.Short)
+		if c.Vii.TargetHeldDate != "" {
+			line += ", held " + c.Vii.TargetHeldDate
+		}
+		return line + lateralNote() + ")\n"
+	}
+	line := fmt.Sprintf("[%s](<%s>) %s → %s (%s", c.Username, c.MilpacURL, c.RankShort, c.Verdict.NextRank, c.Verdict.Type)
+	if len(c.Verdict.PendingDisplayCourses) > 0 {
+		line += ", pending: " + strings.Join(c.Verdict.PendingDisplayCourses, ", ")
+	}
+	if c.ViaVII {
+		line += ", also §VII → " + c.Vii.Target.Short
+	}
+	return line + lateralNote() + ")\n"
+}
+
+// promoScan is the result of one position-scope eligibility pass.
+type promoScan struct {
+	Candidates   []promoCandidate
+	SkippedCount int
+	// ViiActive is false when the ranks fetch failed and the pass degraded
+	// to standard-ladder-only.
+	ViiActive   bool
+	EmptyRoster bool
+}
+
+// collectPromoCandidates runs the full eligibility pass for a position scope:
+// roster fetch, then the shared evaluatePromoRoster tail. Errors are returned
+// only for the roster fetch; per-member failures are counted in SkippedCount
+// and reported to Sentry.
+// promoActiveDutyScope is the special position value that sweeps the entire
+// Active Duty roster (ROSTER_TYPE_COMBAT) instead of a fuzzy position search.
+// It is also the default scope when /promo is called with no mode option.
+// The legacy "active-duty" spelling is still accepted (isActiveDutyScope).
+const promoActiveDutyScope = "activeduty"
+
+func isActiveDutyScope(position string) bool {
+	return strings.EqualFold(strings.ReplaceAll(position, "-", ""), promoActiveDutyScope)
+}
+
+// isDevcomScope matches the DEVCOM department, which spans the DEVCOM HQ and
+// its D/DEVCOM sub-unit; a fuzzy search on one term misses the other, so
+// resolvePositionRoster merges both.
+func isDevcomScope(position string) bool {
+	return strings.EqualFold(strings.TrimSpace(position), "DEVCOM")
+}
+
+// resolvePositionRoster fetches the lite roster for a position scope,
+// special-casing activeduty (the whole combat roster) and DEVCOM (HQ +
+// D/DEVCOM sub-unit, merged and deduplicated by username). Shared by /promo
+// and /billetaudit.
+func resolvePositionRoster(ctx context.Context, position string) (*utils.LiteRosterResponse, error) {
+	if isActiveDutyScope(position) {
+		return utils.GetLiteRoster(ctx, "ROSTER_TYPE_COMBAT")
+	}
+	if isDevcomScope(position) {
+		merged := map[string]utils.LiteProfileResponse{}
+		for _, term := range []string{"DEVCOM", "D/DEVCOM"} {
+			r, err := utils.GetRosterByFuzzyPositionSearch(ctx, term)
+			if err != nil {
+				return nil, err
+			}
+			for _, p := range r.LiteProfiles {
+				merged[p.User.Username] = p // dedup: same member from both searches
+			}
+		}
+		return &utils.LiteRosterResponse{LiteProfiles: merged}, nil
+	}
+	return utils.GetRosterByFuzzyPositionSearch(ctx, position)
+}
+
+// collectPromoCandidates runs the eligibility pass for a position scope,
+// optionally narrowed to a single rank (case-insensitive milpac short form).
+// position + rank combine: position scopes the roster, rank filters within it.
+func collectPromoCandidates(ctx context.Context, position, rank string, asOf time.Time, filter promoFilter) (promoScan, error) {
+	roster, err := resolvePositionRoster(ctx, position)
+	if err != nil {
+		return promoScan{}, err
+	}
+
+	members := make([]utils.LiteProfileResponse, 0, len(roster.LiteProfiles))
+	for _, member := range roster.LiteProfiles {
+		if rank == "" || strings.EqualFold(member.Rank.RankShort, rank) {
+			members = append(members, member)
+		}
+	}
+	utils.Info("📋 Retrieved roster", "member_count", len(members), "position", position, "rank", rank)
+
+	if len(members) == 0 {
+		return promoScan{EmptyRoster: true}, nil
+	}
+	return evaluatePromoRoster(ctx, members, position, asOf, filter), nil
+}
+
+// evaluatePromoRoster is the scope-independent tail of an eligibility pass:
+// rank-model fetch (degradable), concurrent per-member evaluation, and the
+// seniority sort. scopeLabel is for error reporting only.
+func evaluatePromoRoster(ctx context.Context, members []utils.LiteProfileResponse, scopeLabel string, asOf time.Time, filter promoFilter) promoScan {
+	// Rank model for the §VII path, fetched once per pass (after the callers'
+	// empty-roster early returns, so an empty scope costs no extra call). A
+	// failure degrades to standard-ladder-only rather than failing the pass.
+	var rankModel *viiRankModel
+	if ranksResp, ranksErr := utils.GetRanks(ctx); ranksErr != nil {
+		utils.CaptureError("Ranks fetch failed; §VII path disabled for this pass", ranksErr)
+	} else {
+		rankModel = buildRankModel(ranksResp)
+	}
+
+	// Drop the members the lite roster already rules out, so the fan-out only
+	// spends milpac fetches on records that could change the answer.
+	fetchable := make([]utils.LiteProfileResponse, 0, len(members))
+	for _, member := range members {
+		if filter.needsProfile(member, asOf, rankModel) {
+			fetchable = append(fetchable, member)
+		}
+	}
+	utils.Info("🔎 Pre-filtered roster on lite data",
+		"scope", scopeLabel, "filter", filter.tag(), "roster", len(members),
+		"fetching", len(fetchable), "ruled_out", len(members)-len(fetchable))
+	members = fetchable
+
+	results := make([]*promoCandidate, len(members))
+	errs := make([]error, len(members))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for idx, member := range members {
+		idx, member := idx, member
+		g.Go(func() error {
+			results[idx], errs[idx] = evaluatePromoMember(gctx, member, asOf, rankModel)
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	scan := promoScan{ViiActive: rankModel != nil}
+	for idx, member := range members {
+		if err := errs[idx]; err != nil {
+			utils.CaptureError("Promo member evaluation failed", err, "username", member.User.Username, "position", scopeLabel)
+			scan.SkippedCount++
+			continue
+		}
+		if results[idx] != nil {
+			scan.Candidates = append(scan.Candidates, *results[idx])
+		}
+	}
+
+	// Most-senior current rank first, then alphabetical for stable output.
+	sort.Slice(scan.Candidates, func(a, b int) bool {
+		ra, rb := promoRankIndex(scan.Candidates[a].RankShort), promoRankIndex(scan.Candidates[b].RankShort)
+		if ra != rb {
+			return ra < rb
+		}
+		return scan.Candidates[a].Username < scan.Candidates[b].Username
+	})
+	return scan
+}
+
+// ---------------------------------------------------------------------------
+// Single-trooper mode
+// ---------------------------------------------------------------------------
+
+// runPromoUser handles /promo user:<name>, the full verdict breakdown for
+// one trooper (the issue #4 "auto-validate a promotion" optional), mirroring
+// the source tool's single-member view.
+func runPromoUser(r utils.InteractionResponder, i *discordgo.InteractionCreate, username string, asOf time.Time) {
+	err := r.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("Checking promotion eligibility for %s as of %s...", username, promoDate(asOf)),
+		},
+	})
+	if err != nil {
+		utils.CaptureError("❌ Interaction response failed", err)
+		utils.HandleError(r, i, fmt.Sprintf("❌ Failed to respond to interaction: %v", err))
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	profile, err := utils.GetMilpacByUsername(ctx, username)
+	if err != nil {
+		// Username is user-supplied: not-found is a plausible outcome.
+		utils.HandleError(r, i, fmt.Sprintf("❌ No milpac found for %q. Use the forum username exactly as it appears on the roster.", username))
+		return
+	}
+
+	var vii *viiResult
+	viiActive := false
+	if ranksResp, ranksErr := utils.GetRanks(ctx); ranksErr != nil {
+		utils.CaptureError("Ranks fetch failed; §VII path disabled for this pass", ranksErr)
+	} else {
+		v := viiAnalyze(profile, buildRankModel(ranksResp), asOf)
+		vii = &v
+		viiActive = true
+	}
+
+	verdict := calculatePromotionEligibility(
+		profile.Rank.RankShort,
+		profile.PromotionDate,
+		profile.JoinDate,
+		parseCourseCompletions(profile.Records),
+		profile.Primary.PositionTitle,
+		profile.Mos,
+		asOf,
+	)
+
+	response := formatPromoUserVerdict(profile, verdict, vii, viiActive, asOf)
+	if err := r.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &response}); err != nil {
+		captureDeferredEditFailure(i, "Promo", err)
+		return
+	}
+	utils.Info("✨ Done!", "command", "Promo", "user", username, "eligible", verdict.Eligible || (vii != nil && vii.EligibleNow))
+}
+
+func checkmark(ok bool) string {
+	if ok {
+		return "✅"
+	}
+	return "❌"
+}
+
+// formatPromoUserVerdict renders the single-trooper breakdown: every standard
+// gate with its status, then the §VII verdict with evidence or reasons.
+func formatPromoUserVerdict(profile *utils.ProfileResponse, v promoEligibility, vii *viiResult, viiActive bool, asOf time.Time) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Promotion verdict for %s (%s) as of %s**\n",
+		profile.User.Username, profile.Rank.RankShort, promoDate(asOf))
+
+	if v.NoRequirements {
+		if _, known := promoRankSeniority[strings.ToUpper(profile.Rank.RankShort)]; known {
+			// Recognized ranks with no TIG/TIS ladder entry (1SG, CSM, SGM,
+			// general officers). Several still advance, but by taking a
+			// different billet, not by a time-based ladder (e.g. 1SG→SGM/CSM
+			// into a Bn/Regt HQ senior-enlisted seat). COL is NOT here: it has
+			// a ladder entry gated on the regiment-HQ MOS. State it neutrally
+			// rather than claiming "topped out".
+			fmt.Fprintf(&b, "Standard ladder: no standard TIG/TIS ladder for %s. Any advancement is billet-based and handled by S1 (see 7CAV-R-023).\n", profile.Rank.RankShort)
+		} else {
+			b.WriteString("Standard ladder: no standard promotion ladder for this rank.\n")
+		}
+	} else {
+		status := "not yet eligible"
+		if v.Eligible {
+			status = "eligible"
+		}
+		fmt.Fprintf(&b, "Standard ladder: **%s for %s** (%s)\n", status, v.NextRank, v.Type)
+		if v.TigRequired == 0 {
+			fmt.Fprintf(&b, "%s TIG %s (eligibility is not determined by TIG)\n", checkmark(v.TigMet), formatDays(v.TigDays))
+		} else {
+			fmt.Fprintf(&b, "%s TIG %s (need %s)\n", checkmark(v.TigMet), formatDays(v.TigDays), formatDays(v.TigRequired))
+		}
+		if v.TisRequired > 0 {
+			fmt.Fprintf(&b, "%s TIS %s (need %s)\n", checkmark(v.TisMet), formatDays(v.TisDays), formatDays(v.TisRequired))
+		}
+		if len(v.MissingCourses) > 0 {
+			labels := make([]string, 0, len(v.MissingCourses))
+			for _, c := range v.MissingCourses {
+				labels = append(labels, courseLabels[c])
+			}
+			fmt.Fprintf(&b, "❌ Courses missing: %s\n", strings.Join(labels, ", "))
+		} else if len(v.PendingDisplayCourses) > 0 {
+			fmt.Fprintf(&b, "ℹ️ Pending (non-blocking): %s\n", strings.Join(v.PendingDisplayCourses, ", "))
+		}
+		if len(v.RequiredBillets) > 0 {
+			detected := v.DetectedBillet
+			if detected == "" {
+				detected = "none detected"
+			}
+			fmt.Fprintf(&b, "%s Billet: %s (needs %s)\n", checkmark(v.BilletMet), detected, strings.Join(v.RequiredBillets, "/"))
+		}
+		if len(v.RequiredMos) > 0 {
+			detected := v.DetectedMos
+			if detected == "" {
+				detected = "none listed"
+			}
+			fmt.Fprintf(&b, "%s MOS: %s (needs %s, regiment HQ)\n", checkmark(v.MosMet), detected, strings.Join(v.RequiredMos, "/"))
+		}
+		if !v.Eligible && v.DaysUntilEligible > 0 {
+			fmt.Fprintf(&b, "⏳ ~%d day(s) until time requirements met.\n", v.DaysUntilEligible)
+		}
+	}
+
+	if target, ok := viiE2W[strings.ToUpper(profile.Rank.RankShort)]; ok &&
+		viiHasWings(profile) && viiIsAviation(profile) {
+		fmt.Fprintf(&b, "\nLateral: **eligible for %s** (flight wings + aviation MOS).", target)
+	}
+
+	switch {
+	case !viiActive:
+		b.WriteString("\nℹ️ Veteran Rank Retention (§VII) check unavailable this run (rank data fetch failed).")
+	case vii.EligibleNow:
+		fmt.Fprintf(&b, "\nVeteran Rank Retention (§VII): **eligible for %s**", vii.Target.Short)
+		if vii.TargetHeldDate != "" {
+			fmt.Fprintf(&b, ", held %s", vii.TargetHeldDate)
+			if vii.TargetHeldRole != "" {
+				fmt.Fprintf(&b, " as %s", vii.TargetHeldRole)
+			}
+		}
+		b.WriteString(".")
+	case vii.PotentiallyEligible:
+		target := ""
+		if vii.PotentialRank != nil {
+			target = " for " + vii.PotentialRank.Short
+		}
+		fmt.Fprintf(&b, "\nVeteran Rank Retention (§VII): potentially eligible%s.\n%s", target, vii.Reason())
+	default:
+		b.WriteString("\nVeteran Rank Retention (§VII): not applicable.")
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(promoDisclaimer)
+	return b.String()
+}
+
+// formatDays renders a day count like the source tool ("3m 15d", "1y 2m").
+func formatDays(days int) string {
+	if days < 0 {
+		return "unknown"
+	}
+	if days < 30 {
+		return fmt.Sprintf("%dd", days)
+	}
+	months := days / 30
+	if months < 12 {
+		return fmt.Sprintf("%dm %dd", months, days%30)
+	}
+	return fmt.Sprintf("%dy %dm", months/12, months%12)
+}
+
+// ---------------------------------------------------------------------------
+// Report export (HTML + CSV)
+// ---------------------------------------------------------------------------
+
+// promoCandidatePaths lists a candidate's eligibility paths, most conventional
+// first: standard, then §VII, then lateral.
+func promoCandidatePaths(c promoCandidate) []string {
+	var paths []string
+	if c.Verdict.Eligible {
+		paths = append(paths, "standard")
+	}
+	if c.ViaVII {
+		paths = append(paths, "§VII")
+	}
+	if c.LateralTarget != "" {
+		paths = append(paths, "lateral")
+	}
+	return paths
+}
+
+// promoCandidateTypes lists the promotion type(s) a candidate qualifies under,
+// automatic first; automatic is always prioritised over the discretionary
+// paths in display. §VII and lateral are ALWAYS discretionary, never
+// automatic, so a standard-automatic candidate who also has a §VII path reads
+// "automatic & discretionary".
+func promoCandidateTypes(c promoCandidate) []string {
+	set := map[string]bool{}
+	if c.Verdict.Eligible {
+		set[c.Verdict.Type] = true // "automatic" or "discretionary"
+	}
+	if c.ViaVII || c.LateralTarget != "" {
+		set["discretionary"] = true
+	}
+	var out []string
+	for _, t := range []string{"automatic", "discretionary"} {
+		if set[t] {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// promoReportFile renders the full candidate list as a standalone HTML
+// report, attached whenever the list outruns one message or the caller asks
+// for it. HTML rather than CSV because this is read rather than pivoted: at
+// a few hundred rows the table stays legible in a browser, milpac links stay
+// clickable, and there is no spreadsheet import step. Everything is inlined
+// so the file works straight from a Discord download.
+func promoReportFile(scope string, filter promoFilter, asOf time.Time, scan promoScan) *discordgo.File {
+	title := fmt.Sprintf("%s eligibility: %s, %s",
+		upperFirst(filter.phrase()), scope, promoDate(asOf))
+
+	var b strings.Builder
+	writeReportHead(&b, title, promoReportCSS)
+	fmt.Fprintf(&b, "<p class=\"meta\">%d candidate(s)", len(scan.Candidates))
+	if scan.SkippedCount > 0 {
+		fmt.Fprintf(&b, " · %d skipped due to errors (reported)", scan.SkippedCount)
+	}
+	if !scan.ViiActive {
+		b.WriteString(" · §VII check unavailable this run, standard ladder only")
+	}
+	b.WriteString("</p>\n")
+	b.WriteString("<div class=\"controls\"><input id=\"q\" type=\"search\" placeholder=\"Filter (e.g. discretionary, SGT, §VII)…\" autofocus>" +
+		"<span class=\"hint\">click a column to sort · <span id=\"shown\"></span></span></div>\n")
+
+	b.WriteString("<table id=\"t\"><thead><tr>" +
+		"<th>Trooper</th><th>Rank</th><th>Billet</th><th>Next</th><th>Path</th><th>Type</th>" +
+		"<th>TIG</th><th>TIS</th><th>Pending</th><th>§VII held</th><th>Lateral</th>" +
+		"</tr></thead><tbody>\n")
+	for _, c := range scan.Candidates {
+		viiHeld := ""
+		if c.ViaVII {
+			viiHeld = c.Vii.Target.Short
+			if c.Vii.TargetHeldDate != "" {
+				viiHeld += " (held " + c.Vii.TargetHeldDate
+				if c.Vii.TargetHeldRole != "" {
+					viiHeld += " as " + c.Vii.TargetHeldRole
+				}
+				viiHeld += ")"
+			}
+		}
+		// data-sort carries the raw sort key so a column sorts by meaning, not
+		// display text: Rank and Next by seniority (lower index = more senior),
+		// TIG/TIS by day count rather than the "3m 15d" string.
+		fmt.Fprintf(&b, "<tr><td><a href=\"%s\">%s</a></td><td data-sort=\"%d\">%s</td><td>%s</td><td data-sort=\"%d\">%s</td><td>%s</td><td>%s</td>"+
+			"<td data-sort=\"%d\">%s</td><td data-sort=\"%d\">%s</td><td>%s</td><td>%s</td><td>%s</td></tr>\n",
+			html.EscapeString(c.MilpacURL), html.EscapeString(c.Username),
+			promoRankIndex(c.RankShort), html.EscapeString(c.RankShort),
+			html.EscapeString(c.Primary),
+			promoNextRankIndex(c.Verdict.NextRank), html.EscapeString(c.Verdict.NextRank),
+			html.EscapeString(strings.Join(promoCandidatePaths(c), ", ")),
+			html.EscapeString(strings.Join(promoCandidateTypes(c), " & ")),
+			c.Verdict.TigDays, formatDays(c.Verdict.TigDays),
+			c.Verdict.TisDays, formatDays(c.Verdict.TisDays),
+			html.EscapeString(strings.Join(c.Verdict.PendingDisplayCourses, ", ")),
+			html.EscapeString(viiHeld), html.EscapeString(c.LateralTarget))
+	}
+	b.WriteString("</tbody></table>\n")
+	writeReportFoot(&b, promoDisclaimer, promoReportScript)
+
+	return reportFile(
+		fmt.Sprintf("promo_report_%s_%s.html", promoFileScope(scope, filter), asOf.Format("2006-01-02")),
+		"text/html", b.String())
+}
+
+// promoReportScript powers the HTML report's client-side filter and
+// column sort. Self-contained (no external libs) so it runs straight from a
+// Discord download; no template data is interpolated, so it is a static
+// constant. A cell may carry a data-sort attribute (raw numeric value) which
+// the sort uses in place of the display text.
+// promoReportCSS adds the interactive affordances on top of reportBaseCSS:
+// the filter box and the sortable, clickable column headers.
+const promoReportCSS = `.controls{margin:0 0 1rem;font-size:.9rem}
+.controls input{padding:.35rem .5rem;font-size:.9rem;width:16rem;max-width:100%}
+.controls .hint{color:#777;margin-left:.5rem}
+th{cursor:pointer;user-select:none;white-space:nowrap}
+th:hover{background:#e9e9e9}
+th.sorted-asc::after{content:" \25B2";color:#888}
+th.sorted-desc::after{content:" \25BC";color:#888}`
+
+const promoReportScript = `<script>
+(function(){
+  var table=document.getElementById('t'), tbody=table.tBodies[0];
+  var q=document.getElementById('q'), shown=document.getElementById('shown');
+  var total=tbody.rows.length;
+  function rows(){return Array.prototype.slice.call(tbody.rows);}
+  function updateCount(){
+    var n=rows().filter(function(r){return r.style.display!=='none';}).length;
+    shown.textContent=n+' of '+total+' shown';
+  }
+  function applyFilter(){
+    var s=q.value.toLowerCase();
+    rows().forEach(function(r){
+      r.style.display=r.textContent.toLowerCase().indexOf(s)>-1?'':'none';
+    });
+    updateCount();
+  }
+  q.addEventListener('input',applyFilter);
+  function val(td){
+    var d=td.getAttribute('data-sort');
+    if(d!==null){var f=parseFloat(d);return isNaN(f)?d:f;}
+    return td.textContent.toLowerCase();
+  }
+  var headers=table.tHead.rows[0].cells, dir={};
+  Array.prototype.forEach.call(headers,function(th,idx){
+    th.addEventListener('click',function(){
+      var asc=dir[idx]=!dir[idx];
+      Array.prototype.forEach.call(headers,function(h){h.className='';});
+      th.className=asc?'sorted-asc':'sorted-desc';
+      rows().sort(function(a,b){
+        var av=val(a.cells[idx]),bv=val(b.cells[idx]);
+        if(av<bv)return asc?-1:1;
+        if(av>bv)return asc?1:-1;
+        return 0;
+      }).forEach(function(r){tbody.appendChild(r);});
+    });
+  });
+  updateCount();
+})();
+</script>
+`
+
+// promoFileScope makes a scope+type label safe for a filename.
+func promoFileScope(scope string, filter promoFilter) string {
+	repl := strings.NewReplacer(" ", "-", "/", "-")
+	fileScope := strings.ToLower(repl.Replace(strings.TrimSpace(scope)))
+	if tag := filter.tag(); tag != "" {
+		fileScope += "_" + tag
+	}
+	return fileScope
+}
+
+// promoCSVFile is the machine-readable companion to the HTML report, for
+// pivoting in a spreadsheet. Same rows as the HTML table; encoding/csv handles
+// escaping, and the strings.Builder target means no I/O error path in practice.
+func promoCSVFile(scope string, filter promoFilter, asOf time.Time, scan promoScan) *discordgo.File {
+	rows := make([][]string, 0, len(scan.Candidates))
+	for _, c := range scan.Candidates {
+		viiHeld := ""
+		if c.ViaVII {
+			viiHeld = c.Vii.Target.Short
+			if c.Vii.TargetHeldDate != "" {
+				viiHeld += " (held " + c.Vii.TargetHeldDate
+				if c.Vii.TargetHeldRole != "" {
+					viiHeld += " as " + c.Vii.TargetHeldRole
+				}
+				viiHeld += ")"
+			}
+		}
+		rows = append(rows, []string{
+			c.Username, c.RankShort, c.Primary, c.Verdict.NextRank,
+			strings.Join(promoCandidatePaths(c), ", "), strings.Join(promoCandidateTypes(c), " & "),
+			fmt.Sprintf("%d", c.Verdict.TigDays), fmt.Sprintf("%d", c.Verdict.TisDays),
+			strings.Join(c.Verdict.PendingDisplayCourses, ";"), viiHeld, c.LateralTarget, c.MilpacURL,
+		})
+	}
+	header := []string{
+		"username", "current_rank", "primary_billet", "next_rank", "path", "type",
+		"tig_days", "tis_days", "pending_courses", "vii_held", "lateral_target", "milpac_url",
+	}
+	return reportFile(
+		fmt.Sprintf("promo_report_%s_%s.csv", promoFileScope(scope, filter), asOf.Format("2006-01-02")),
+		"text/csv", csvReport(header, rows))
+}

--- a/commands/promo.go
+++ b/commands/promo.go
@@ -536,12 +536,12 @@ func formatPromoMessage(scope string, filter promoFilter, asOf time.Time, candid
 	b.WriteString("\n\n")
 
 	if len(candidates) == 0 {
-		b.WriteString(fmt.Sprintf("No %s members eligible for %s as of %s", scope, filter.phrase(), promoDate(asOf)))
+		fmt.Fprintf(&b, "No %s members eligible for %s as of %s", scope, filter.phrase(), promoDate(asOf))
 		b.WriteString(footer)
 		return strings.TrimRight(b.String(), "\n"), 0
 	}
 
-	b.WriteString(fmt.Sprintf("**%s members eligible for %s as of %s:**\n", upperFirst(scope), filter.phrase(), promoDate(asOf)))
+	fmt.Fprintf(&b, "**%s members eligible for %s as of %s:**\n", upperFirst(scope), filter.phrase(), promoDate(asOf))
 
 	// Reserve room for the footer and a worst-case overflow notice so the
 	// message cannot be pushed over the limit by what gets appended after
@@ -558,7 +558,7 @@ func formatPromoMessage(scope string, filter promoFilter, asOf time.Time, candid
 	}
 	omitted := len(candidates) - listed
 	if omitted > 0 {
-		b.WriteString(fmt.Sprintf("…and %d more. Full list in the attached report.", omitted))
+		fmt.Fprintf(&b, "…and %d more. Full list in the attached report.", omitted)
 	}
 	b.WriteString(footer)
 	return strings.TrimRight(b.String(), "\n"), omitted
@@ -576,7 +576,7 @@ func promoFooter(skippedCount int, viiActive bool) string {
 		if skippedCount == 1 {
 			noun = "member"
 		}
-		footer.WriteString(fmt.Sprintf("\n⚠️ %d %s skipped due to errors (reported)", skippedCount, noun))
+		fmt.Fprintf(&footer, "\n⚠️ %d %s skipped due to errors (reported)", skippedCount, noun)
 	}
 	return footer.String()
 }

--- a/commands/promo_eligibility.go
+++ b/commands/promo_eligibility.go
@@ -1,0 +1,522 @@
+package commands
+
+// Promotion-eligibility engine, ported from the author's internal S1
+// promotion tooling (private). Requirements are transcribed from 7CAV-R-023
+// Rank Promotion and Reduction Guidelines, which is the source of truth for
+// every threshold below.
+//
+// Scope note: this implements the STANDARD promotion ladder only. The
+// Veteran Rank Retention (Ch.4 §VII) alternative path from the source tool's
+// veteran-retention engine is intentionally out of scope here: it needs full service
+// record archaeology and is tracked as a follow-up.
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/7cav/cavbot2/utils"
+)
+
+// promotionRequirement describes what a rank needs to advance to nextRank.
+// courses are hard requirements (block eligibility); displayCourses are
+// informational only and surface in output without gating.
+type promotionRequirement struct {
+	NextRank       string
+	TigMonths      int // time-in-grade, months (30-day months per R-023 practice)
+	TisMonths      int // time-in-service, months; 0 = no TIS requirement
+	Type           string
+	Courses        []string
+	DisplayCourses []string
+	// Billets that satisfy the position requirement; nil = no requirement.
+	Billets []string
+	// MosCodes gates the step on the trooper's MOS (prefix match), for
+	// promotions defined by an appointment rather than a position title -
+	// COL→BG requires a regiment-HQ MOS. nil = no MOS requirement.
+	MosCodes []string
+}
+
+// promotionRequirements is keyed by rankShort. Transcribed from the source
+// tool's requirements table (7CAV-R-023), with one deliberate deviation: the
+// source surfaced ODS as an informational "pending" course on the NCO ladder,
+// but ODS only matters for commissioning (which needs a Platoon Leader
+// assignment first). S1 asked for it to be dropped from /promo output
+// (2026-07-23). DisplayCourses stays plumbed for future informational needs.
+var promotionRequirements = map[string]promotionRequirement{
+	"PVT": {NextRank: "PFC", TigMonths: 1, Type: "automatic"},
+	"PFC": {NextRank: "SPC", TigMonths: 2, Type: "automatic"},
+	"SPC": {NextRank: "CPL/WO1", TigMonths: 4, Type: "automatic", Courses: []string{"ncoaPhase1", "ncoaPhase2", "sac"}},
+	"CPL": {NextRank: "SGT", TigMonths: 4, TisMonths: 9, Type: "discretionary", Billets: []string{"ASL", "SL"}},
+	"WO1": {NextRank: "CW2", TigMonths: 4, TisMonths: 9, Type: "discretionary", Billets: []string{"ASL", "SL"}},
+	"SGT": {NextRank: "SSG", TigMonths: 6, TisMonths: 15, Type: "discretionary", Billets: []string{"SL", "PSG"}},
+	"CW2": {NextRank: "CW3", TigMonths: 6, TisMonths: 15, Type: "discretionary", Billets: []string{"SL", "PSG"}},
+	"SSG": {NextRank: "SFC", TigMonths: 6, TisMonths: 22, Type: "discretionary", Billets: []string{"PSG"}},
+	"CW3": {NextRank: "CW4", TigMonths: 6, TisMonths: 22, Type: "discretionary", Billets: []string{"PSG"}},
+	"SFC": {NextRank: "MSG", TigMonths: 6, TisMonths: 28, Type: "discretionary", Billets: []string{"PSG"}},
+	"CW4": {NextRank: "CW5", TigMonths: 6, TisMonths: 28, Type: "discretionary", Billets: []string{"PSG"}},
+	// Officer billet gates: a Platoon Leader rates 2LT-1LT, so PL satisfies
+	// the 1LT gate but NOT the CPT gate.
+	"2LT": {NextRank: "1LT", TigMonths: 6, Type: "discretionary", Billets: []string{"PL", "XO", "CO", "DEPT"}},
+	"1LT": {NextRank: "CPT", TigMonths: 6, Type: "discretionary", Billets: []string{"XO", "CO", "DEPT"}},
+	"CPT": {NextRank: "MAJ", TigMonths: 6, Type: "discretionary", Courses: []string{"rdptc"}, Billets: []string{"XO", "CO", "DEPT"}},
+	"MAJ": {NextRank: "LTC", TigMonths: 6, Type: "discretionary", Courses: []string{"rdptc"}, Billets: []string{"XO", "CO", "DEPT"}},
+	"LTC": {NextRank: "COL", TigMonths: 6, Type: "discretionary"},
+	// COL→BG needs a regiment-HQ billet, denoted by a general-staff MOS
+	// (S1, 2026-07-25), and nine months at COL: R-023 Ch.2 §III sets the
+	// minimum TIG for O-7 at nine months, the only rung whose TIG comes from
+	// that section rather than the Chapter 2 table. The same section notes
+	// that billet limitations can waive it (Ch.5), which the ladder does not
+	// model: a waived promotion simply proposes early, as billet/fast-track
+	// promotions do at every other rank.
+	"COL": {NextRank: "BG", TigMonths: 9, Type: "discretionary", MosCodes: generalStaffMos},
+}
+
+// generalStaffMos are the MOS codes denoting a regiment-HQ (Regimental Staff)
+// appointment, which gates COL→BG (S1, 2026-07-25): 00B General Officer, 00Z
+// Command Sergeant Major, 01A Officer Generalist. 00D (Officer Pool) is NOT
+// included: the MOS table lists it separately from Regimental Staff, and a
+// pool officer is not in a regiment-HQ billet.
+var generalStaffMos = []string{"00B", "00Z", "01A"}
+
+// courseLabels maps internal course keys to display names.
+var courseLabels = map[string]string{
+	"ncoaPhase1": "NCOA I",
+	"ncoaPhase2": "NCOA II",
+	"sac":        "SAC",
+	"ods":        "ODS",
+	"rdptc":      "RDPTC",
+}
+
+// courseCompletions tracks which gating courses a trooper's service record shows.
+type courseCompletions struct {
+	NcoaPhase1 bool
+	NcoaPhase2 bool
+	Sac        bool
+	Ods        bool
+	Rdptc      bool
+}
+
+func (c courseCompletions) has(key string) bool {
+	switch key {
+	case "ncoaPhase1":
+		return c.NcoaPhase1
+	case "ncoaPhase2":
+		return c.NcoaPhase2
+	case "sac":
+		return c.Sac
+	case "ods":
+		return c.Ods
+	case "rdptc":
+		return c.Rdptc
+	}
+	return false
+}
+
+// parseCourseCompletions scans milpac service records for course-graduation
+// entries. String heuristics mirror the source implementation, which was
+// tuned against real record wording ("Graduated NCOA Warrior Leadership
+// Course Phase I", "Graduated NCOA WLC - 01*01-14", "Attended the Server
+// Administration Course", ...).
+func parseCourseCompletions(records []utils.Record) courseCompletions {
+	var c courseCompletions
+	for _, record := range records {
+		details := strings.ToLower(record.RecordDetails)
+
+		if strings.Contains(details, "ncoa") &&
+			(strings.Contains(details, "phase i") || strings.Contains(details, "phase 1") || strings.Contains(details, "wlc")) {
+			// "phase i" is a prefix of "phase ii": disambiguate.
+			if strings.Contains(details, "phase ii") || strings.Contains(details, "phase 2") {
+				c.NcoaPhase2 = true
+			} else {
+				c.NcoaPhase1 = true
+			}
+		}
+		if strings.Contains(details, "ncoa") &&
+			(strings.Contains(details, "phase ii") || strings.Contains(details, "phase 2")) {
+			c.NcoaPhase2 = true
+		}
+		if strings.Contains(details, "server admin") {
+			c.Sac = true
+		}
+		if strings.Contains(details, "officer development school") || strings.Contains(details, " ods") {
+			c.Ods = true
+		}
+		if strings.Contains(details, "disciplinary process training") || strings.Contains(details, "rdptc") {
+			c.Rdptc = true
+		}
+	}
+	return c
+}
+
+var (
+	reSL   = regexp.MustCompile(`\bsl\b`)
+	rePL   = regexp.MustCompile(`\bpl\b`)
+	reXO   = regexp.MustCompile(`\bxo\b`)
+	reDept = regexp.MustCompile(`\bs[0-9]\b|department|\b1ic\b|\b2ic\b|\baide\b|director|\bncoa\b|\brtc\b|\brrd\b`)
+)
+
+// detectBillet classifies a free-text MILPAC position title into a billet
+// code. Check order matters and mirrors the source: ASL before SL (substring
+// overlap), "platoon commander" (PL) before "commander" (CO).
+func detectBillet(positionTitle string) string {
+	if positionTitle == "" {
+		return ""
+	}
+	t := strings.ToLower(positionTitle)
+	switch {
+	case strings.Contains(t, "platoon sergeant") || strings.Contains(t, "psg"):
+		return "PSG"
+	case strings.Contains(t, "first sergeant") || strings.Contains(t, "1sg"):
+		return "1SG"
+	case strings.Contains(t, "assistant section leader") || strings.Contains(t, "asl"):
+		return "ASL"
+	case strings.Contains(t, "section leader") || reSL.MatchString(t):
+		return "SL"
+	case strings.Contains(t, "platoon leader") || strings.Contains(t, "platoon commander") || rePL.MatchString(t):
+		return "PL"
+	case strings.Contains(t, "executive officer") || reXO.MatchString(t):
+		return "XO"
+	case strings.Contains(t, "commanding officer") || strings.Contains(t, "commander"):
+		return "CO"
+	case reDept.MatchString(t):
+		return "DEPT"
+	case strings.Contains(t, "fire team leader") || strings.Contains(t, "ftl"):
+		return "FTL"
+	case strings.Contains(t, "rto") || strings.Contains(t, "radio"):
+		return "RTO"
+	}
+	return ""
+}
+
+// billetMeetsRequirement reports whether a detected billet satisfies the
+// rank's billet gate. nil gate = always satisfied.
+func billetMeetsRequirement(detected string, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	if detected == "" {
+		return false
+	}
+	for _, b := range required {
+		if b == detected {
+			return true
+		}
+	}
+	return false
+}
+
+// mosMeetsRequirement reports whether the trooper's MOS satisfies the rank's
+// MOS gate. Empty gate = always satisfied. Matching is a case-insensitive
+// prefix test, mirroring how §VII reads the aviation MOS (^15), since the
+// milpac MOS field leads with the code.
+func mosMeetsRequirement(mos string, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	m := strings.ToUpper(strings.TrimSpace(mos))
+	for _, code := range required {
+		if strings.HasPrefix(m, strings.ToUpper(code)) {
+			return true
+		}
+	}
+	return false
+}
+
+// daysBetween returns whole days from dateStr (YYYY-MM-DD) to asOf, or -1 if
+// the date is missing/unparseable/sentinel. Mirrors the source daysSince, with
+// "now" generalized to an arbitrary as-of date per issue #4's date filter.
+func daysBetween(dateStr string, asOf time.Time) int {
+	if dateStr == "" || dateStr == "0" || dateStr == "0001-01-01" {
+		return -1
+	}
+	date, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return -1
+	}
+	if date.Year() < 2000 {
+		return -1
+	}
+	return int(asOf.Sub(date).Hours() / 24)
+}
+
+// promoEligibility is the verdict for one trooper.
+type promoEligibility struct {
+	Eligible       bool
+	NoRequirements bool // rank has no ladder entry (e.g. COL and above)
+	NextRank       string
+	Type           string
+	TigMet         bool
+	TisMet         bool
+	CoursesMet     bool
+	BilletMet      bool
+	DetectedBillet string
+	// RequiredBillets echoes the rank's billet gate for display; nil = none.
+	RequiredBillets []string
+	// MOS gate (COL→BG): MosMet is true when no MOS is required or the
+	// trooper's MOS matches. RequiredMos echoes the gate for display.
+	MosMet         bool
+	DetectedMos    string
+	RequiredMos    []string
+	TigDays        int
+	TisDays        int
+	TigRequired    int
+	TisRequired    int
+	MissingCourses []string
+	// Non-gating courses the trooper hasn't completed (display labels), e.g.
+	// ODS pending for an NCO ladder rank. Informational only.
+	PendingDisplayCourses []string
+	// Days until both time gates are met (0 when met or unknowable). Course
+	// and billet gates are point-in-time facts and are NOT projected.
+	DaysUntilEligible int
+}
+
+// calculatePromotionEligibility evaluates the standard promotion ladder for a
+// trooper as of asOf. Port of the source function of the same name, minus the
+// §VII veteran-retention alternative path (see file header).
+func calculatePromotionEligibility(
+	rankShort, promotionDate, joinDate string,
+	courses courseCompletions,
+	positionTitle, mos string,
+	asOf time.Time,
+) promoEligibility {
+	req, ok := promotionRequirements[rankShort]
+	if !ok {
+		return promoEligibility{NoRequirements: true, NextRank: "--"}
+	}
+
+	tigDays := daysBetween(promotionDate, asOf)
+	tisDays := daysBetween(joinDate, asOf)
+	tigRequired := req.TigMonths * 30
+	tisRequired := req.TisMonths * 30
+
+	tigMet := tigDays >= 0 && tigDays >= tigRequired
+	tisMet := req.TisMonths == 0 || (tisDays >= 0 && tisDays >= tisRequired)
+
+	var missing []string
+	for _, course := range req.Courses {
+		if !courses.has(course) {
+			missing = append(missing, course)
+		}
+	}
+	coursesMet := len(missing) == 0
+
+	var pendingDisplay []string
+	for _, course := range req.DisplayCourses {
+		if !courses.has(course) {
+			pendingDisplay = append(pendingDisplay, courseLabels[course])
+		}
+	}
+
+	detected := detectBillet(positionTitle)
+	billetMet := billetMeetsRequirement(detected, req.Billets)
+
+	mosMet := mosMeetsRequirement(mos, req.MosCodes)
+
+	daysUntilTig := 0
+	if !tigMet && tigDays >= 0 {
+		daysUntilTig = tigRequired - tigDays
+	}
+	daysUntilTis := 0
+	if !tisMet && tisDays >= 0 {
+		daysUntilTis = tisRequired - tisDays
+	}
+	daysUntil := daysUntilTig
+	if daysUntilTis > daysUntil {
+		daysUntil = daysUntilTis
+	}
+
+	return promoEligibility{
+		Eligible:              tigMet && tisMet && coursesMet && billetMet && mosMet,
+		NextRank:              req.NextRank,
+		Type:                  req.Type,
+		TigMet:                tigMet,
+		TisMet:                tisMet,
+		CoursesMet:            coursesMet,
+		BilletMet:             billetMet,
+		DetectedBillet:        detected,
+		RequiredBillets:       req.Billets,
+		MosMet:                mosMet,
+		DetectedMos:           strings.TrimSpace(mos),
+		RequiredMos:           req.MosCodes,
+		TigDays:               tigDays,
+		TisDays:               tisDays,
+		TigRequired:           tigRequired,
+		TisRequired:           tisRequired,
+		MissingCourses:        missing,
+		PendingDisplayCourses: pendingDisplay,
+		DaysUntilEligible:     daysUntil,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lite-roster pre-filter
+// ---------------------------------------------------------------------------
+//
+// A full milpac fetch costs roughly a second and the roster-wide scopes run
+// to hundreds of members, so the expensive call is worth avoiding wherever
+// the lite roster already proves it cannot change the answer. The lite
+// payload carries rank, primary position, join date and promotion date -
+// everything the standard ladder needs except course completions.
+//
+// This mirrors how /afsm narrows on the roster payload before reaching for
+// profiles; /awol and /loa never fetch profiles at all.
+//
+// How much this actually saves depends almost entirely on the type filter.
+// Measured against a representative company (107 members, mixed ranks and
+// billets, half recently promoted):
+//
+//	type=discretionary   93% of fetches skipped
+//	type=lateral         71%
+//	type=automatic       64%
+//	type=vii             17%
+//	no type filter        2%
+//
+// The unfiltered case is close to worthless and that is inherent, not a gap
+// to close later: §VII can only be excluded where the billet ceiling is no
+// more senior than the rank already held, which is rare below the top of a
+// billet, and the lateral path has to open every NCO record to look for
+// flight wings. Anything better for unfiltered runs (the weekly sweep
+// included) needs a profile cache rather than a smarter filter.
+//
+// The one invariant that matters: the pre-filter must never drop somebody
+// evaluatePromoMember would have returned as a candidate. Every check below
+// is therefore written to fail towards fetching: unknown rank, missing
+// date, or absent position title all mean "cannot tell, so fetch".
+
+// promoAllCourses is a course record with everything marked complete. Feeding
+// it to the ladder answers "could this member qualify if their record turns
+// out to be perfect?", which is exactly the question the lite payload can
+// answer without the record itself.
+var promoAllCourses = courseCompletions{
+	NcoaPhase1: true, NcoaPhase2: true, Sac: true, Ods: true, Rdptc: true,
+}
+
+// needsProfile reports whether any promotion path the filter still allows
+// could apply to a member, judging only from lite-roster data. False means the
+// milpac fetch cannot change the output and is skipped.
+//
+// The filter matters a great deal here: an include (type) filter narrows to a
+// single path so whole rank groups can be ruled out before the fetch; an
+// exclude filter keeps every path but the excluded one, which is the same set
+// of predicates OR'd together. An unfiltered run has to keep every path open
+// and saves comparatively little, because §VII can only be ruled out where the
+// billet ceiling is no more senior than the rank already held, and the lateral
+// path has to fetch every NCO to see their wings.
+func (f promoFilter) needsProfile(member utils.LiteProfileResponse, asOf time.Time, rankModel *viiRankModel) bool {
+	// A path is "kept" unless it is the excluded one or (for an include
+	// filter) not the included one.
+	keeps := func(path string) bool {
+		if f.exclude != "" {
+			return path != f.exclude
+		}
+		if f.include != "" {
+			return path == f.include
+		}
+		return true
+	}
+	// For automatic/discretionary the ladder type must also match; §VII and
+	// lateral have their own possibility checks.
+	standardKind := func(kind string) bool {
+		return keeps(kind) && ladderTypeMatches(member, kind) && standardPathPossible(member, asOf)
+	}
+	return standardKind(promoTypeAutomatic) ||
+		standardKind(promoTypeDiscretionary) ||
+		(keeps(promoTypeVii) && viiPathPossible(member, rankModel)) ||
+		(keeps(promoTypeLateral) && lateralPathPossible(member))
+}
+
+// ladderTypeMatches reports whether the member's next rung is of the
+// requested kind. The ladder type is a property of the current rank alone, so
+// a run filtered to automatic promotions need never open a discretionary
+// rank's record. An unknown rank has no rung and cannot match.
+func ladderTypeMatches(member utils.LiteProfileResponse, promoType string) bool {
+	req, ok := promotionRequirements[member.Rank.RankShort]
+	return ok && req.Type == promoType
+}
+
+// standardPathPossible tests the ladder's non-course gates against lite data.
+// Courses are assumed complete because the lite payload cannot see them: if a
+// member fails TIG, TIS or billet even with a perfect course record, no
+// profile fetch can rescue them.
+func standardPathPossible(member utils.LiteProfileResponse, asOf time.Time) bool {
+	// Absent dates or position mean the lite record cannot settle the
+	// question: a milpac with a blank promotion date is a data problem, not
+	// evidence of ineligibility, so defer to the full profile.
+	if member.PromotionDate == "" || member.JoinDate == "" || member.Primary.PositionTitle == "" {
+		return true
+	}
+	// The lite roster carries no MOS, so a MOS-gated step (COL→BG) can't be
+	// judged here: always fetch to check.
+	if len(promotionRequirements[member.Rank.RankShort].MosCodes) > 0 {
+		return true
+	}
+	return calculatePromotionEligibility(
+		member.Rank.RankShort,
+		member.PromotionDate,
+		member.JoinDate,
+		promoAllCourses,
+		member.Primary.PositionTitle,
+		"", // MOS unknown from lite data; ranks needing it are handled above
+		asOf,
+	).Eligible
+}
+
+// lateralPathPossible reports whether the NCO-to-warrant move is even
+// available at this rank. Flight wings and the aviation MOS live on the full
+// profile, so any rank with a warrant equivalent still has to be fetched;
+// this rules out the junior enlisted ranks below CPL, which is most of a
+// roster.
+func lateralPathPossible(member utils.LiteProfileResponse) bool {
+	_, ok := viiE2W[strings.ToUpper(member.Rank.RankShort)]
+	return ok
+}
+
+// viiPathPossible reports whether Veteran Rank Retention could produce a
+// target for this member. §VII restores a previously held rank only up to
+// what the current billet rates, so if the billet ceiling is no more senior
+// than the rank already held, no service history can qualify them and the
+// records fetch is pointless.
+func viiPathPossible(member utils.LiteProfileResponse, m *viiRankModel) bool {
+	if m == nil {
+		return false // ranks fetch failed; the §VII path is off this pass
+	}
+	current := m.byShort[member.Rank.RankShort]
+	if current == nil {
+		return true // unrecognised rank: don't guess
+	}
+	curLvl, ok := m.level(current)
+	if !ok {
+		return true
+	}
+	if member.Primary.PositionTitle == "" {
+		// Without a billet there is no ceiling to compare against, and an
+		// absent title is not the same as a member billet: treating it as
+		// one would silently drop a returning veteran whose real billet
+		// rates well above their current rank.
+		return true
+	}
+
+	ceil := viiBilletCeiling[canonicalBillet(normalizeRole(member.Primary.PositionTitle))]
+	ceilShort := ceil.Enlisted
+	if viiTrackOf(current.Order) == "officer" {
+		ceilShort = ceil.Officer
+	}
+	if ceilShort == "" {
+		// No ceiling defined for this billet on this track: viiAnalyze
+		// cannot produce a restoration target either, so nothing to fetch
+		// for. (It may still flag the billet for manual review, but that
+		// never makes somebody a candidate.)
+		return false
+	}
+	ceilRank := m.byShort[ceilShort]
+	if ceilRank == nil {
+		return true
+	}
+	ceilLvl, ok := m.level(ceilRank)
+	if !ok {
+		return true
+	}
+	// Lower level is more senior; a target can only exist strictly above the
+	// rank currently held.
+	return ceilLvl < curLvl
+}

--- a/commands/promo_eligibility_test.go
+++ b/commands/promo_eligibility_test.go
@@ -1,0 +1,682 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+// promoRefDate pins "as of" for engine tests; same rationale as afsmRefDate.
+var promoRefDate = mustParseDate("2026-05-15")
+
+func rec(details string) utils.Record {
+	return utils.Record{RecordDetails: details, RecordType: "RECORD_TYPE_GRADUATION", RecordDate: "2025-01-01"}
+}
+
+func TestParseCourseCompletions(t *testing.T) {
+	cases := []struct {
+		name    string
+		details []string
+		want    courseCompletions
+	}{
+		{"ncoa phase 1 long form", []string{"Graduated NCOA Warrior Leadership Course Phase I"}, courseCompletions{NcoaPhase1: true}},
+		{"ncoa wlc shorthand", []string{"Graduated NCOA WLC - 01*01-14"}, courseCompletions{NcoaPhase1: true}},
+		{"ncoa phase ii not misread as phase i", []string{"Graduated NCOA Phase II"}, courseCompletions{NcoaPhase2: true}},
+		{"ncoa phase 2 numeric", []string{"Graduated NCOA Phase 2"}, courseCompletions{NcoaPhase2: true}},
+		{"sac", []string{"Attended the Server Administration Course"}, courseCompletions{Sac: true}},
+		{"ods long form", []string{"Graduated Officer Development School"}, courseCompletions{Ods: true}},
+		{"ods abbreviation with leading space", []string{"Graduated ODS class 24-01"}, courseCompletions{Ods: true}},
+		{"rdptc", []string{"Graduated Regimental Disciplinary Process Training Course"}, courseCompletions{Rdptc: true}},
+		{"empty records", nil, courseCompletions{}},
+		{"unrelated record", []string{"Promoted to SGT"}, courseCompletions{}},
+		{
+			"all courses across records",
+			[]string{
+				"Graduated NCOA Phase I",
+				"Graduated NCOA Phase II",
+				"Attended the Server Administration Course",
+				"Graduated ODS",
+				"Graduated RDPTC",
+			},
+			courseCompletions{NcoaPhase1: true, NcoaPhase2: true, Sac: true, Ods: true, Rdptc: true},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			records := make([]utils.Record, 0, len(tc.details))
+			for _, d := range tc.details {
+				records = append(records, rec(d))
+			}
+			got := parseCourseCompletions(records)
+			if got != tc.want {
+				t.Errorf("parseCourseCompletions() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCourseCompletionsHas(t *testing.T) {
+	c := courseCompletions{NcoaPhase1: true, Sac: true, Rdptc: true}
+	for key, want := range map[string]bool{
+		"ncoaPhase1": true, "ncoaPhase2": false, "sac": true,
+		"ods": false, "rdptc": true, "bogus": false,
+	} {
+		if got := c.has(key); got != want {
+			t.Errorf("has(%q) = %v, want %v", key, got, want)
+		}
+	}
+}
+
+func TestDetectBillet(t *testing.T) {
+	cases := []struct {
+		title string
+		want  string
+	}{
+		{"PSG 1/A/ACD", "PSG"},
+		{"Platoon Sergeant 1/A/ACD", "PSG"},
+		{"First Sergeant A/ACD", "1SG"},
+		{"ASL 1/1/A/ACD", "ASL"},
+		// substring overlap: "assistant section leader" must not fall
+		// through to SL
+		{"Assistant Section Leader 1/1/A", "ASL"},
+		{"Section Leader 1/1/A", "SL"},
+		{"SL 2/1/B", "SL"},
+		{"Platoon Leader 1/A", "PL"},
+		// "platoon commander" must resolve PL before the bare "commander"
+		// check resolves CO
+		{"Platoon Commander 1/A", "PL"},
+		{"Executive Officer A/ACD", "XO"},
+		{"XO A/ACD", "XO"},
+		{"Commanding Officer ACD", "CO"},
+		{"S1 Clerk", "DEPT"},
+		{"NCOA Instructor", "DEPT"},
+		{"RRD Recruiter", "DEPT"},
+		{"Fire Team Leader 1/1/1/A", "FTL"},
+		{"RTO 1/1/A", "RTO"},
+		{"Rifleman 1/1/1/A", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			if got := detectBillet(tc.title); got != tc.want {
+				t.Errorf("detectBillet(%q) = %q, want %q", tc.title, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBilletMeetsRequirement(t *testing.T) {
+	cases := []struct {
+		name     string
+		detected string
+		required []string
+		want     bool
+	}{
+		{"no requirement always passes", "", nil, true},
+		{"no requirement passes with billet", "PSG", nil, true},
+		{"required and missing fails", "", []string{"SL", "PSG"}, false},
+		{"required and matching passes", "PSG", []string{"SL", "PSG"}, true},
+		{"required and non-matching fails", "FTL", []string{"SL", "PSG"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := billetMeetsRequirement(tc.detected, tc.required); got != tc.want {
+				t.Errorf("billetMeetsRequirement(%q, %v) = %v, want %v", tc.detected, tc.required, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDaysBetween(t *testing.T) {
+	cases := []struct {
+		name string
+		date string
+		want int
+	}{
+		{"empty", "", -1},
+		{"zero string", "0", -1},
+		{"zero-value date sentinel", "0001-01-01", -1},
+		{"garbage", "not-a-date", -1},
+		{"pre-2000 treated as invalid", "1999-12-31", -1},
+		{"one month back", "2026-04-15", 30},
+		{"same day", "2026-05-15", 0},
+		{"future date is negative", "2026-06-15", -31},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := daysBetween(tc.date, promoRefDate); got != tc.want {
+				t.Errorf("daysBetween(%q) = %d, want %d", tc.date, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCalculatePromotionEligibility(t *testing.T) {
+	allCourses := courseCompletions{NcoaPhase1: true, NcoaPhase2: true, Sac: true, Ods: true, Rdptc: true}
+
+	cases := []struct {
+		name          string
+		rank          string
+		promotionDate string
+		joinDate      string
+		courses       courseCompletions
+		position      string
+		mos           string
+		wantEligible  bool
+		wantNoReq     bool
+		wantNext      string
+		check         func(t *testing.T, v promoEligibility)
+	}{
+		{
+			name: "PVT with 31 days TIG eligible (automatic, no courses, no billet)",
+			rank: "PVT", promotionDate: "2026-04-10", joinDate: "2026-04-10",
+			position: "Rifleman 1/1/1/A", wantEligible: true, wantNext: "PFC",
+			check: func(t *testing.T, v promoEligibility) {
+				if v.Type != "automatic" {
+					t.Errorf("Type = %q, want automatic", v.Type)
+				}
+			},
+		},
+		{
+			name: "PVT with 20 days TIG not eligible, projects days until",
+			rank: "PVT", promotionDate: "2026-04-25", joinDate: "2026-04-25",
+			position: "Rifleman", wantEligible: false, wantNext: "PFC",
+			check: func(t *testing.T, v promoEligibility) {
+				if v.TigMet {
+					t.Error("TigMet = true, want false")
+				}
+				if v.DaysUntilEligible != 10 {
+					t.Errorf("DaysUntilEligible = %d, want 10", v.DaysUntilEligible)
+				}
+			},
+		},
+		{
+			name: "SPC blocked by missing NCOA courses despite TIG",
+			rank: "SPC", promotionDate: "2025-11-01", joinDate: "2025-06-01",
+			courses:  courseCompletions{Sac: true},
+			position: "Rifleman", wantEligible: false, wantNext: "CPL/WO1",
+			check: func(t *testing.T, v promoEligibility) {
+				if v.CoursesMet {
+					t.Error("CoursesMet = true, want false")
+				}
+				if len(v.MissingCourses) != 2 {
+					t.Errorf("MissingCourses = %v, want ncoaPhase1+ncoaPhase2", v.MissingCourses)
+				}
+			},
+		},
+		{
+			name: "SPC with all courses and TIG eligible",
+			rank: "SPC", promotionDate: "2025-11-01", joinDate: "2025-06-01",
+			courses:  allCourses,
+			position: "Rifleman", wantEligible: true, wantNext: "CPL/WO1",
+		},
+		{
+			name: "CPL in SL billet with TIG+TIS eligible; no pending-course noise (ODS dropped per S1)",
+			rank: "CPL", promotionDate: "2025-12-01", joinDate: "2025-05-01",
+			position: "Section Leader 1/1/A", wantEligible: true, wantNext: "SGT",
+			check: func(t *testing.T, v promoEligibility) {
+				if len(v.PendingDisplayCourses) != 0 {
+					t.Errorf("PendingDisplayCourses = %v, want none (ODS is a commissioning concern, not /promo's)", v.PendingDisplayCourses)
+				}
+			},
+		},
+		{
+			name: "CPL without leadership billet blocked",
+			rank: "CPL", promotionDate: "2025-12-01", joinDate: "2025-05-01",
+			position: "Rifleman 1/1/1/A", wantEligible: false, wantNext: "SGT",
+			check: func(t *testing.T, v promoEligibility) {
+				if v.BilletMet {
+					t.Error("BilletMet = true, want false")
+				}
+			},
+		},
+		{
+			name: "CPL TIG met but TIS short blocks",
+			rank: "CPL", promotionDate: "2025-12-01", joinDate: "2025-12-01",
+			position: "Section Leader 1/1/A", wantEligible: false, wantNext: "SGT",
+			check: func(t *testing.T, v promoEligibility) {
+				if !v.TigMet {
+					t.Error("TigMet = false, want true")
+				}
+				if v.TisMet {
+					t.Error("TisMet = true, want false")
+				}
+				// TIS required 270d, ~165d served as of ref date → ~105 left,
+				// and TIS is the binding constraint.
+				if v.DaysUntilEligible <= 0 {
+					t.Errorf("DaysUntilEligible = %d, want > 0", v.DaysUntilEligible)
+				}
+			},
+		},
+		{
+			name: "1LT in PL billet blocked (PL caps at 1LT, CPT needs XO/CO/DEPT)",
+			rank: "1LT", promotionDate: "2025-09-01", joinDate: "2023-01-01",
+			position: "Platoon Leader 1/A", wantEligible: false, wantNext: "CPT",
+		},
+		{
+			name: "2LT in PL billet eligible for 1LT",
+			rank: "2LT", promotionDate: "2025-09-01", joinDate: "2024-01-01",
+			position: "Platoon Leader 1/A", wantEligible: true, wantNext: "1LT",
+		},
+		{
+			name: "CPT without RDPTC blocked despite billet",
+			rank: "CPT", promotionDate: "2025-09-01", joinDate: "2022-01-01",
+			position: "Commanding Officer ACD", wantEligible: false, wantNext: "MAJ",
+		},
+		{
+			name: "CPT with RDPTC in CO billet eligible",
+			rank: "CPT", promotionDate: "2025-09-01", joinDate: "2022-01-01",
+			courses:  allCourses,
+			position: "Commanding Officer ACD", wantEligible: true, wantNext: "MAJ",
+		},
+		{
+			name: "COL without a regiment-HQ MOS is not eligible for BG",
+			rank: "COL", promotionDate: "2020-01-01", joinDate: "2015-01-01",
+			position: "Regimental Commander", mos: "11A", wantEligible: false, wantNext: "BG",
+			check: func(t *testing.T, v promoEligibility) {
+				if v.MosMet {
+					t.Error("MosMet = true, want false (11A is not a regiment-HQ MOS)")
+				}
+			},
+		},
+		{
+			name: "COL with a regiment-HQ MOS is eligible for BG",
+			rank: "COL", promotionDate: "2020-01-01", joinDate: "2015-01-01",
+			position: "Regimental Commander", mos: "00B", wantEligible: true, wantNext: "BG",
+			check: func(t *testing.T, v promoEligibility) {
+				if !v.MosMet {
+					t.Error("MosMet = false, want true (00B is a regiment-HQ MOS)")
+				}
+			},
+		},
+		{
+			name: "COL with the MOS but short of nine months TIG",
+			rank: "COL", promotionDate: "2026-01-01", joinDate: "2015-01-01",
+			position: "Regimental Commander", mos: "00B", wantEligible: false, wantNext: "BG",
+			check: func(t *testing.T, v promoEligibility) {
+				if !v.MosMet {
+					t.Error("MosMet = false, want true")
+				}
+				if v.TigMet {
+					t.Error("TigMet = true, want false (R-023 Ch.2 §III sets nine months at COL)")
+				}
+				if v.TigRequired != 9*30 {
+					t.Errorf("TigRequired = %d, want %d", v.TigRequired, 9*30)
+				}
+			},
+		},
+		{
+			// 00D is Officer Pool, not Regimental Staff: a pool officer is not
+			// in a regiment-HQ billet, so 00D does NOT gate COL→BG.
+			name: "COL on 00D (Officer Pool) is not BG-eligible",
+			rank: "COL", promotionDate: "2015-01-01", joinDate: "2010-01-01",
+			position: "Officer Pool", mos: "00D", wantEligible: false, wantNext: "BG",
+			check: func(t *testing.T, v promoEligibility) {
+				if v.MosMet {
+					t.Error("MosMet = true, want false (00D is Officer Pool, not Regimental Staff)")
+				}
+			},
+		},
+		{
+			name: "COL on 00Z (regimental staff) with 9mo TIG is BG-eligible",
+			rank: "COL", promotionDate: "2015-01-01", joinDate: "2010-01-01",
+			position: "Regimental Command Sergeant Major", mos: "00Z", wantEligible: true, wantNext: "BG",
+			check: func(t *testing.T, v promoEligibility) {
+				if !v.MosMet {
+					t.Error("MosMet = false, want true (00Z is Regimental Staff)")
+				}
+			},
+		},
+		{
+			name: "missing promotion date never eligible",
+			rank: "PVT", promotionDate: "", joinDate: "2026-01-01",
+			position: "Rifleman", wantEligible: false, wantNext: "PFC",
+			check: func(t *testing.T, v promoEligibility) {
+				if v.TigDays != -1 {
+					t.Errorf("TigDays = %d, want -1", v.TigDays)
+				}
+				// Unknowable dates must not project a countdown.
+				if v.DaysUntilEligible != 0 {
+					t.Errorf("DaysUntilEligible = %d, want 0", v.DaysUntilEligible)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := calculatePromotionEligibility(tc.rank, tc.promotionDate, tc.joinDate, tc.courses, tc.position, tc.mos, promoRefDate)
+			if v.Eligible != tc.wantEligible {
+				t.Errorf("Eligible = %v, want %v (verdict %+v)", v.Eligible, tc.wantEligible, v)
+			}
+			if v.NoRequirements != tc.wantNoReq {
+				t.Errorf("NoRequirements = %v, want %v", v.NoRequirements, tc.wantNoReq)
+			}
+			if v.NextRank != tc.wantNext {
+				t.Errorf("NextRank = %q, want %q", v.NextRank, tc.wantNext)
+			}
+			if tc.check != nil {
+				tc.check(t, v)
+			}
+		})
+	}
+}
+
+// TestEligibilityAsOfDateShifts verifies the issue #4 date filter: a trooper
+// short on TIG today becomes eligible when asOf moves past the gate.
+func TestEligibilityAsOfDateShifts(t *testing.T) {
+	// Promoted 2026-04-25: 20d TIG at ref date, needs 30d.
+	now := calculatePromotionEligibility("PVT", "2026-04-25", "2026-04-25", courseCompletions{}, "Rifleman", "", promoRefDate)
+	if now.Eligible {
+		t.Fatal("expected not eligible at ref date")
+	}
+	future := calculatePromotionEligibility("PVT", "2026-04-25", "2026-04-25", courseCompletions{}, "Rifleman", "", mustParseDate("2026-05-25"))
+	if !future.Eligible {
+		t.Fatal("expected eligible when asOf is past the TIG gate")
+	}
+}
+
+// promoLiteFull builds a lite roster entry with the fields the API actually
+// populates. The shared promoLiteProfile helper deliberately leaves them
+// blank, which exercises the pre-filter's "cannot tell, so fetch" path
+// instead; both shapes matter, so the tests use each on purpose.
+func promoLiteFull(username, rankShort, promotionDate, joinDate, position string) utils.LiteProfileResponse {
+	return utils.LiteProfileResponse{
+		User:          utils.User{UserID: "u-" + username, Username: username},
+		Rank:          utils.Rank{RankShort: rankShort},
+		UniformUrl:    "https://7cav.us/data/roster_uniforms/0/101.jpg",
+		Primary:       utils.Position{PositionTitle: position},
+		JoinDate:      joinDate,
+		PromotionDate: promotionDate,
+	}
+}
+
+// servePromoAPICountingProfiles is servePromoAPIWithRanks with a counter on
+// the expensive endpoint, so tests can assert on fetches avoided rather than
+// only on output.
+func servePromoAPICountingProfiles(
+	t *testing.T,
+	roster utils.LiteRosterResponse,
+	profilesByUsername map[string]utils.ProfileResponse,
+	ranks *utils.RanksResponse,
+) *atomic.Int64 {
+	t.Helper()
+	rosterBody, err := json.Marshal(roster)
+	if err != nil {
+		t.Fatalf("marshal roster: %v", err)
+	}
+	ranksBody, err := json.Marshal(ranks)
+	if err != nil {
+		t.Fatalf("marshal ranks: %v", err)
+	}
+	encoded := make(map[string][]byte, len(profilesByUsername))
+	for name, p := range profilesByUsername {
+		b, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal profile %q: %v", name, err)
+		}
+		encoded[name] = b
+	}
+
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/milpacs/ranks"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(ranksBody)
+		case strings.HasPrefix(r.URL.Path, "/milpacs/position/search/"),
+			strings.HasPrefix(r.URL.Path, "/roster/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(rosterBody)
+		case strings.HasPrefix(r.URL.Path, "/milpacs/profile/username/"):
+			hits.Add(1)
+			name := strings.TrimPrefix(r.URL.Path, "/milpacs/profile/username/")
+			body, ok := encoded[name]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+	return &hits
+}
+
+func TestPromoNeedsProfileUnfiltered(t *testing.T) {
+	m := viiModel()
+	cases := []struct {
+		name   string
+		member utils.LiteProfileResponse
+		want   bool
+		why    string
+	}{
+		{
+			name:   "junior enlisted below the billet ceiling still needs fetching",
+			member: promoLiteFull("Fresh.F", "PVT", "2026-05-10", "2026-05-10", "Rifleman 1/1/1/A"),
+			want:   true,
+			why:    "TIG is short, but MEMBER rates CPL (above PVT), so §VII could restore a previously held rank",
+		},
+		{
+			name:   "PVT past TIG",
+			member: promoLiteFull("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman 1/1/1/A"),
+			want:   true,
+			why:    "the standard ladder could complete once courses are known",
+		},
+		{
+			name:   "NCO fetched for the lateral path",
+			member: promoLiteFull("Nco.N", "CPL", "2026-05-14", "2026-05-14", "Rifleman 1/1/1/A"),
+			want:   true,
+			why:    "wings and MOS live on the full profile, so every rank with a warrant equivalent is opened",
+		},
+		{
+			name:   "at the billet ceiling with no other path",
+			member: promoLiteFull("Top.T", "MSG", "2026-05-14", "2020-01-01", "Platoon Sergeant 1/A"),
+			want:   true,
+			why:    "MSG has a warrant equivalent (CW5), so the lateral path keeps it in",
+		},
+		{
+			name:   "missing promotion date defers to the profile",
+			member: promoLiteFull("Blank.B", "PVT", "", "2026-01-01", "Rifleman"),
+			want:   true,
+			why:    "a blank date is a data problem, not evidence of ineligibility",
+		},
+		{
+			name:   "missing position defers to the profile",
+			member: promoLiteFull("NoPos.N", "PVT", "2026-05-14", "2026-05-14", ""),
+			want:   true,
+			why:    "billet unknown, so neither the ladder nor the ceiling can be judged",
+		},
+		{
+			name:   "unrecognised rank defers to the profile",
+			member: promoLiteFull("Odd.O", "XYZ", "2026-05-14", "2026-05-14", "Rifleman"),
+			want:   true,
+			why:    "no ladder and no rank-model entry; do not guess",
+		},
+		{
+			name:   "skeletal lite record defers to the profile",
+			member: promoLiteProfile("Sparse.S", "PVT", "101"),
+			want:   true,
+			why:    "nothing to judge on",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (promoFilter{}).needsProfile(tc.member, promoRefDate, m); got != tc.want {
+				t.Errorf("promoNeedsProfile() = %v, want %v (%s)", got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+func TestPromoNeedsProfileByType(t *testing.T) {
+	m := viiModel()
+	freshPVT := promoLiteFull("Fresh.F", "PVT", "2026-05-10", "2026-05-10", "Rifleman 1/1/1/A")
+	readyPVT := promoLiteFull("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman 1/1/1/A")
+	readySL := promoLiteFull("Lead.L", "SGT", "2024-06-01", "2023-01-01", "Section Leader 1/1/A")
+	specSL := promoLiteFull("Spec.S", "SPC", "2026-05-14", "2026-01-01", "Section Leader 1/1/A")
+	topPSG := promoLiteFull("Top.T", "MSG", "2026-05-14", "2020-01-01", "Platoon Sergeant 1/A")
+
+	cases := []struct {
+		promoType string
+		member    utils.LiteProfileResponse
+		want      bool
+		why       string
+	}{
+		{promoTypeAutomatic, readyPVT, true, "PVT's rung is automatic and TIG is met"},
+		{promoTypeAutomatic, freshPVT, false, "automatic rung, but TIG cannot be met by any course record"},
+		{promoTypeAutomatic, readySL, false, "SGT's rung is discretionary, so it can never satisfy an automatic filter"},
+		{promoTypeDiscretionary, readySL, true, "discretionary rung in a rating billet with time served"},
+		{promoTypeDiscretionary, readyPVT, false, "PVT's rung is automatic"},
+		{promoTypeLateral, readySL, true, "SGT has a warrant equivalent"},
+		{promoTypeLateral, readyPVT, false, "no warrant equivalent below CPL"},
+		{promoTypeVii, specSL, true, "SL rates SSG, well above SPC"},
+		{promoTypeVii, topPSG, false, "MSG already sits at the PSG ceiling, so nothing can be restored"},
+		{promoTypeVii, readyPVT, true, "MEMBER rates CPL, above PVT"},
+		// Regression: a blank position is not a member billet. Reading it as
+		// one ruled a returning veteran out of a type:vii run before their
+		// real billet could be seen.
+		{promoTypeVii, promoLiteFull("NoPos.N", "CPL", "2026-05-14", "2020-01-01", ""), true,
+			"billet unknown, so the ceiling cannot be judged"},
+		{promoTypeVii, promoLiteProfile("Sparse.S", "CPL", "101"), true,
+			"skeletal lite record carries no billet"},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s/%s", tc.promoType, tc.member.User.Username), func(t *testing.T) {
+			if got := (promoFilter{include: tc.promoType}).needsProfile(tc.member, promoRefDate, m); got != tc.want {
+				t.Errorf("promoNeedsProfile(type=%s) = %v, want %v (%s)", tc.promoType, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+func TestViiPathPossibleWithoutRankModel(t *testing.T) {
+	// A failed ranks fetch disables §VII for the pass, so it cannot be a
+	// reason to open anybody's record.
+	member := promoLiteFull("Spec.S", "SPC", "2026-05-14", "2026-01-01", "Section Leader 1/1/A")
+	if viiPathPossible(member, nil) {
+		t.Error("viiPathPossible with a nil model = true, want false")
+	}
+	if (promoFilter{}).needsProfile(member, promoRefDate, nil) {
+		t.Error("SPC short on TIG with §VII disabled should not be fetched")
+	}
+}
+
+// The invariant that matters: anyone the pre-filter drops must be someone
+// evaluatePromoMember would have returned nil for anyway. This runs the real
+// evaluator against a served profile for every dropped fixture.
+func TestPreFilterNeverDropsACandidate(t *testing.T) {
+	m := viiModel()
+	fixtures := []struct {
+		lite utils.LiteProfileResponse
+		full utils.ProfileResponse
+	}{
+		{promoLiteFull("Fresh.F", "PVT", "2026-05-10", "2026-05-10", "Rifleman 1/1/1/A"),
+			promoFullProfile("Fresh.F", "PVT", "2026-05-10", "2026-05-10", "Rifleman 1/1/1/A")},
+		{promoLiteFull("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman 1/1/1/A"),
+			promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman 1/1/1/A")},
+		{promoLiteFull("Spec.S", "SPC", "2026-05-14", "2026-01-01", "Rifleman 1/1/1/A"),
+			promoFullProfile("Spec.S", "SPC", "2026-05-14", "2026-01-01", "Rifleman 1/1/1/A")},
+		{promoLiteFull("Course.C", "SPC", "2025-11-01", "2025-01-01", "Rifleman 1/1/1/A"),
+			promoFullProfile("Course.C", "SPC", "2025-11-01", "2025-01-01", "Rifleman 1/1/1/A",
+				"Graduated NCOA Phase I", "Graduated NCOA Phase II", "Attended the Server Administration Course")},
+		{promoLiteFull("Top.T", "MSG", "2026-05-14", "2020-01-01", "Platoon Sergeant 1/A"),
+			promoFullProfile("Top.T", "MSG", "2026-05-14", "2020-01-01", "Platoon Sergeant 1/A")},
+		{promoLiteFull("Lead.L", "SGT", "2024-06-01", "2023-01-01", "Section Leader 1/1/A"),
+			promoFullProfile("Lead.L", "SGT", "2024-06-01", "2023-01-01", "Section Leader 1/1/A")},
+	}
+
+	profiles := make(map[string]utils.ProfileResponse, len(fixtures))
+	for _, f := range fixtures {
+		profiles[f.full.User.Username] = f.full
+	}
+	servePromoAPIWithRanks(t, utils.LiteRosterResponse{}, profiles, viiTestRanks())
+
+	for _, promoType := range []string{"", promoTypeAutomatic, promoTypeDiscretionary, promoTypeVii, promoTypeLateral} {
+		for _, f := range fixtures {
+			name := f.lite.User.Username
+			if (promoFilter{include: promoType}).needsProfile(f.lite, promoRefDate, m) {
+				continue // fetched anyway; nothing to prove
+			}
+			got, err := evaluatePromoMember(t.Context(), f.lite, promoRefDate, m)
+			if err != nil {
+				t.Fatalf("evaluatePromoMember(%s): %v", name, err)
+			}
+			if got == nil {
+				continue // correctly dropped
+			}
+			// Dropped, but the evaluator produced a candidate: only allowed
+			// if the type filter would have discarded it after the fetch.
+			if len(filterPromoCandidates([]promoCandidate{*got}, promoType)) > 0 {
+				t.Errorf("type=%q dropped %s before fetching, but it survives the post-fetch filter: %+v",
+					promoType, name, got)
+			}
+		}
+	}
+}
+
+// End to end: a scope filtered to discretionary promotions must not open the
+// records of ranks whose next rung is automatic.
+func TestRunPromoPreFilterSkipsFetches(t *testing.T) {
+	lite := map[string]utils.LiteProfileResponse{}
+	profiles := map[string]utils.ProfileResponse{}
+	for idx := 0; idx < 10; idx++ {
+		name := fmt.Sprintf("Junior.%02d", idx)
+		lite[name] = promoLiteFull(name, "PFC", "2026-01-01", "2025-06-01", "Rifleman 1/1/1/A")
+		profiles[name] = promoFullProfile(name, "PFC", "2026-01-01", "2025-06-01", "Rifleman 1/1/1/A")
+	}
+	// One discretionary-rung NCO in a rating billet.
+	lite["Lead.L"] = promoLiteFull("Lead.L", "SGT", "2024-06-01", "2023-01-01", "Section Leader 1/1/A")
+	profiles["Lead.L"] = promoFullProfile("Lead.L", "SGT", "2024-06-01", "2023-01-01", "Section Leader 1/1/A")
+
+	hits := servePromoAPICountingProfiles(t, utils.LiteRosterResponse{LiteProfiles: lite}, profiles, viiTestRanks())
+
+	i := promoInteraction("ACD", "")
+	data := i.Data.(discordgo.ApplicationCommandInteractionData)
+	data.Options = append(data.Options, &discordgo.ApplicationCommandInteractionDataOption{
+		Name: "type", Type: discordgo.ApplicationCommandOptionString, Value: promoTypeDiscretionary,
+	})
+	i.Data = data
+
+	f := &fakeResponder{}
+	runPromo(f, i, afsmRefDate)
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("profile fetches = %d, want 1 (the ten automatic-rung PFCs should never be opened)", got)
+	}
+	if !strings.Contains(lastEditContent(f.Calls()), "Lead.L") {
+		t.Errorf("the discretionary candidate is missing from the output: %q", lastEditContent(f.Calls()))
+	}
+}
+
+// The unfiltered path keeps every route open, so it must still fetch the
+// members a typed run would skip. Guards against the pre-filter quietly
+// over-reaching into the default case.
+func TestRunPromoUnfilteredStillFetchesBroadly(t *testing.T) {
+	lite := map[string]utils.LiteProfileResponse{}
+	profiles := map[string]utils.ProfileResponse{}
+	for idx := 0; idx < 5; idx++ {
+		name := fmt.Sprintf("Junior.%02d", idx)
+		lite[name] = promoLiteFull(name, "PFC", "2026-05-14", "2026-05-14", "Rifleman 1/1/1/A")
+		profiles[name] = promoFullProfile(name, "PFC", "2026-05-14", "2026-05-14", "Rifleman 1/1/1/A")
+	}
+	hits := servePromoAPICountingProfiles(t, utils.LiteRosterResponse{LiteProfiles: lite}, profiles, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("ACD", ""), afsmRefDate)
+
+	if got := hits.Load(); got != 5 {
+		t.Errorf("profile fetches = %d, want 5 (§VII keeps sub-ceiling ranks in play when unfiltered)", got)
+	}
+}

--- a/commands/promo_sweep.go
+++ b/commands/promo_sweep.go
@@ -1,0 +1,166 @@
+package commands
+
+// Scheduled promotion sweep: the issue #4 "Notify" requirement. A weekly
+// background pass posts the promotion-eligible candidate list for the
+// configured position scopes to a configured channel, so S1 gets told
+// rather than having to remember to ask.
+//
+// Pattern mirrors the Star Citizen joiner-report scheduler
+// (star_citizen_joiners.go): sleep-until-fire loop, per-fire panic recovery
+// (a panic in one sweep must not kill the loop; see issue #119 rationale
+// there), a narrow session interface for testability, and a `now` seam.
+//
+// The target channel, swept scope, and the kill switch are all compile-time
+// constants, not environment variables: tenant-specific 7Cav config the bot
+// keeps in code, matching the joiner report (hardcoded Discord IDs) and
+// /warden (role name). Environment variables here are reserved for secrets and
+// deployment identity. Disabling the sweep or moving its channel is a code
+// change and redeploy, the same as the joiner report.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+// 7Cav-specific identifiers, hardcoded rather than env-configured because
+// they are tenant-specific (matching the joiner report and /warden).
+const (
+	promoSweepChannelID = "1529633362275471531"
+
+	// promoSweepScope is the scope swept each week. "activeduty" is the whole
+	// ROSTER_TYPE_COMBAT roster, which is what S1 asked for; see the API load
+	// note on promoSweepFilter.
+	promoSweepScope = "activeduty"
+
+	// promoSweepDisabled is the kill switch. Flip to true and redeploy to
+	// silence the weekly sweep.
+	promoSweepDisabled = false
+)
+
+// TODO(S1 follow-up): Monday 09:00 UTC is a placeholder cadence chosen by
+// engineering, not by the consumer. Before this leaves the test guild, ask
+// S1 when and how often they actually want the reminder (weekly vs
+// fortnightly vs monthly, day, and hour) and update this constant.
+var promoSweepFireSchedule = mustWeeklyFireTime(time.Monday, 9, 0)
+
+// promoSweepSession is the Discord REST surface the sweep needs;
+// *discordgo.Session satisfies it. The complex send rather than the plain one
+// so a large sweep can carry the full report as an attachment.
+type promoSweepSession interface {
+	ChannelMessageSendComplex(channelID string, data *discordgo.MessageSend, options ...discordgo.RequestOption) (*discordgo.Message, error)
+}
+
+type promoSweepConfig struct {
+	ChannelID string
+	Positions []string
+}
+
+// newPromoSweepConfig builds the sweep config from the compile-time constants.
+func newPromoSweepConfig() promoSweepConfig {
+	return promoSweepConfig{
+		ChannelID: promoSweepChannelID,
+		Positions: []string{promoSweepScope},
+	}
+}
+
+// StartPromoSweepScheduler launches the weekly sweep goroutine. Called from
+// main after the gateway opens, alongside StartJoinerReportScheduler.
+func StartPromoSweepScheduler(s *discordgo.Session) {
+	if promoSweepDisabled {
+		utils.Info("Promotion sweep scheduler disabled (promoSweepDisabled)")
+		return
+	}
+	cfg := newPromoSweepConfig()
+	utils.Info("Starting promotion sweep scheduler",
+		"cadence", "weekly Monday 09:00 UTC",
+		"channel_id", cfg.ChannelID,
+		"positions", strings.Join(cfg.Positions, ","))
+	go runPromoSweepSchedulerLoop(s, cfg, time.Now)
+}
+
+// runPromoSweepSchedulerLoop is the goroutine body; split out for the `now`
+// seam. Per-fire panic recovery keeps the loop alive across a bad sweep; no
+// in-cycle retry; next Monday is the retry.
+func runPromoSweepSchedulerLoop(s promoSweepSession, cfg promoSweepConfig, now func() time.Time) {
+	for {
+		fire := nextPromoSweepFire(now())
+		utils.Info("Promotion sweep scheduled", "next_fire_utc", fire.Format(time.RFC3339))
+		time.Sleep(time.Until(fire))
+		func() {
+			defer utils.RecoverPanic("promo-sweep")
+			// Anchor eligibility to the scheduled fire time, not wall clock
+			// at wakeup, for the same drift reason as the joiner report.
+			if err := runPromoSweep(s, cfg, fire); err != nil {
+				utils.CaptureError("Promotion sweep failed", err,
+					"channel_id", cfg.ChannelID, "fire_utc", fire.Format(time.RFC3339))
+			}
+		}()
+	}
+}
+
+// nextPromoSweepFire returns the next scheduled fire strictly after now.
+// The schedule is UTC-anchored regardless of the host's timezone, matching
+// the joiner report scheduler; only the caller's clock is local. Strict
+// "after" avoids a double-fire at exact-boundary starts.
+func nextPromoSweepFire(now time.Time) time.Time {
+	n := now.UTC()
+	candidate := time.Date(n.Year(), n.Month(), n.Day(),
+		promoSweepFireSchedule.hour, promoSweepFireSchedule.minute, 0, 0, time.UTC)
+	daysUntilWeekday := (int(promoSweepFireSchedule.weekday) - int(candidate.Weekday()) + 7) % 7
+	candidate = candidate.AddDate(0, 0, daysUntilWeekday)
+	if !candidate.After(n) {
+		candidate = candidate.AddDate(0, 0, 7)
+	}
+	return candidate
+}
+
+// runPromoSweep executes one sweep: an eligibility pass per configured
+// position, one message per position. A failed position is reported and the
+// sweep continues to the next; the first send failure aborts (if the channel
+// is unreachable every subsequent send fails identically).
+func runPromoSweep(s promoSweepSession, cfg promoSweepConfig, asOf time.Time) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	for _, position := range cfg.Positions {
+		scan, err := collectPromoCandidates(ctx, position, "", asOf, promoFilter{})
+		if err != nil {
+			utils.CaptureError("Promotion sweep position pass failed", err, "position", position)
+			continue
+		}
+		scopeLabel := scopeDisplay(position)
+		msg := &discordgo.MessageSend{}
+		if scan.EmptyRoster {
+			// A configured (fixed-input) position returning empty is
+			// structurally a bug, not a user typo; Sentry per ADR 0002.
+			utils.CaptureError(
+				"Promotion sweep roster lookup returned zero members",
+				fmt.Errorf("empty roster for configured position %q", position),
+				"position", position,
+			)
+			msg.Content = fmt.Sprintf("⚠️ Promotion sweep: the %s roster came back empty. This shouldn't happen for a configured scope; the issue has been reported.", position)
+		} else {
+			// Same rule as the slash command: the post keeps the inline list
+			// (and its "…and N more" notice), and anything longer rides the
+			// full detail as attached CSV + HTML reports.
+			body, omitted := formatPromoMessage(scopeLabel, promoFilter{}, asOf, scan.Candidates, scan.SkippedCount, scan.ViiActive)
+			if omitted > 0 {
+				msg.Files = []*discordgo.File{
+					promoCSVFile(scopeLabel, promoFilter{}, asOf, scan),
+					promoReportFile(scopeLabel, promoFilter{}, asOf, scan),
+				}
+			}
+			msg.Content = "📋 **Weekly promotion sweep**\n" + body
+		}
+		if _, err := s.ChannelMessageSendComplex(cfg.ChannelID, msg); err != nil {
+			return fmt.Errorf("send sweep message for %s: %w", position, err)
+		}
+		utils.Info("Promotion sweep posted", "position", position, "eligible", len(scan.Candidates))
+	}
+	return nil
+}

--- a/commands/promo_sweep_test.go
+++ b/commands/promo_sweep_test.go
@@ -1,0 +1,248 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+var errBoom = errors.New("boom")
+
+// fakeChannelSender records ChannelMessageSend calls; optional error queue.
+type fakeChannelSender struct {
+	mu       sync.Mutex
+	channels []string
+	bodies   []string
+	files    [][]*discordgo.File
+	errs     []error
+}
+
+func (f *fakeChannelSender) ChannelMessageSendComplex(channelID string, data *discordgo.MessageSend, _ ...discordgo.RequestOption) (*discordgo.Message, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.channels = append(f.channels, channelID)
+	f.bodies = append(f.bodies, data.Content)
+	f.files = append(f.files, data.Files)
+	return &discordgo.Message{}, popErr(&f.errs)
+}
+
+func TestPromoSweepConfig(t *testing.T) {
+	// Channel, scope, and the kill switch are all constants; nothing is read
+	// from the environment, so a stray variable can't redirect the sweep.
+	t.Setenv("PROMO_SWEEP_CHANNEL_ID", "999")
+	t.Setenv("PROMO_SWEEP_POSITIONS", "S6")
+	cfg := newPromoSweepConfig()
+	if cfg.ChannelID != promoSweepChannelID {
+		t.Errorf("ChannelID = %q, want the constant to win over the env", cfg.ChannelID)
+	}
+	if len(cfg.Positions) != 1 || cfg.Positions[0] != promoSweepScope {
+		t.Errorf("Positions = %v, want [%s]", cfg.Positions, promoSweepScope)
+	}
+	if promoSweepDisabled {
+		t.Error("sweep should be enabled by default (kill switch off)")
+	}
+}
+
+func TestNextPromoSweepFire(t *testing.T) {
+	// From a Wednesday, next fire is the following Monday 09:00 UTC.
+	wednesday := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	fire := nextPromoSweepFire(wednesday)
+	if fire.Weekday() != time.Monday || fire.Hour() != 9 || fire.Minute() != 0 {
+		t.Errorf("fire = %v, want Monday 09:00 UTC", fire)
+	}
+	if !fire.After(wednesday) {
+		t.Error("fire must be strictly after now")
+	}
+	// Exactly at a fire moment → strictly the NEXT week (double-fire guard).
+	atFire := time.Date(2026, 5, 18, 9, 0, 0, 0, time.UTC) // a Monday 09:00
+	next := nextPromoSweepFire(atFire)
+	if !next.Equal(atFire.AddDate(0, 0, 7)) {
+		t.Errorf("fire at boundary = %v, want exactly one week later", next)
+	}
+}
+
+func TestRunPromoSweepPostsPerPosition(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+	}
+	servePromoAPIWithRanks(t, roster, profiles, viiTestRanks())
+
+	sender := &fakeChannelSender{}
+	cfg := promoSweepConfig{ChannelID: "chan-1", Positions: []string{"ACD", "1-7"}}
+	if err := runPromoSweep(sender, cfg, afsmRefDate); err != nil {
+		t.Fatalf("runPromoSweep: %v", err)
+	}
+	if len(sender.bodies) != 2 {
+		t.Fatalf("posted %d messages, want 2 (one per position)", len(sender.bodies))
+	}
+	for idx, ch := range sender.channels {
+		if ch != "chan-1" {
+			t.Errorf("message %d sent to %q, want chan-1", idx, ch)
+		}
+	}
+	if !strings.Contains(sender.bodies[0], "Weekly promotion sweep") {
+		t.Errorf("sweep header missing: %q", sender.bodies[0])
+	}
+	if !strings.Contains(sender.bodies[0], "Ready.R") {
+		t.Errorf("candidate missing from sweep body: %q", sender.bodies[0])
+	}
+}
+
+// A long candidate list posts one message with what fits and attaches the
+// full report, rather than paging the channel.
+func TestRunPromoSweepAttachesReportForLongLists(t *testing.T) {
+	roster, profiles := manyEligiblePVTs(60)
+	servePromoAPIWithRanks(t, roster, profiles, viiTestRanks())
+
+	sender := &fakeChannelSender{}
+	cfg := promoSweepConfig{ChannelID: "chan-1", Positions: []string{"ACD"}}
+	if err := runPromoSweep(sender, cfg, afsmRefDate); err != nil {
+		t.Fatalf("runPromoSweep: %v", err)
+	}
+	if len(sender.bodies) != 1 {
+		t.Fatalf("expected a single post, got %d", len(sender.bodies))
+	}
+	if len(sender.bodies[0]) >= 2000 {
+		t.Errorf("message length %d exceeds Discord limit", len(sender.bodies[0]))
+	}
+	if !strings.Contains(sender.bodies[0], "Weekly promotion sweep") {
+		t.Errorf("sweep header missing: %q", sender.bodies[0])
+	}
+	if !strings.Contains(sender.bodies[0], "more. Full list in the attached report") {
+		t.Errorf("overflow notice missing: %q", sender.bodies[0])
+	}
+	if !strings.Contains(sender.bodies[0], "Member.000") {
+		t.Errorf("inline list should show the first candidates: %q", sender.bodies[0])
+	}
+	if len(sender.files) != 1 || len(sender.files[0]) != 2 {
+		t.Fatalf("expected CSV + HTML attachments, got %+v", sender.files)
+	}
+	// Every candidate reaches the reader via both reports.
+	var htmlReport, csvReport string
+	for _, fl := range sender.files[0] {
+		if strings.HasSuffix(fl.Name, ".html") {
+			htmlReport = readFileBody(t, fl)
+		} else if strings.HasSuffix(fl.Name, ".csv") {
+			csvReport = readFileBody(t, fl)
+		}
+	}
+	if htmlReport == "" || csvReport == "" {
+		t.Fatalf("missing csv or html attachment: %+v", sender.files[0])
+	}
+	for i := 0; i < 60; i++ {
+		name := fmt.Sprintf("Member.%03d", i)
+		if !strings.Contains(htmlReport, name) || !strings.Contains(csvReport, name) {
+			t.Fatalf("candidate %s missing from a report", name)
+		}
+	}
+}
+
+// readFileBody drains a discordgo file attachment.
+func readFileBody(t *testing.T, f *discordgo.File) string {
+	t.Helper()
+	var sb strings.Builder
+	if _, err := io.Copy(&sb, f.Reader); err != nil {
+		t.Fatalf("read attachment: %v", err)
+	}
+	return sb.String()
+}
+
+func TestRunPromoSweepEmptyConfiguredRosterReportsBug(t *testing.T) {
+	// A configured position is fixed input: empty roster → Sentry + a
+	// warning post, per ADR 0002 (contrast with the slash command's
+	// user-typed position).
+	servePromoAPIWithRanks(t, utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{}}, nil, viiTestRanks())
+
+	sender := &fakeChannelSender{}
+	cfg := promoSweepConfig{ChannelID: "chan-1", Positions: []string{"GHOST"}}
+	if err := runPromoSweep(sender, cfg, afsmRefDate); err != nil {
+		t.Fatalf("runPromoSweep: %v", err)
+	}
+	if len(sender.bodies) != 1 || !strings.Contains(sender.bodies[0], "shouldn't happen") {
+		t.Errorf("expected empty-roster bug warning, got %+v", sender.bodies)
+	}
+}
+
+func TestRunPromoSweepSendFailureAborts(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+	}
+	servePromoAPIWithRanks(t, roster, profiles, viiTestRanks())
+
+	sender := &fakeChannelSender{errs: []error{errBoom}}
+	cfg := promoSweepConfig{ChannelID: "chan-1", Positions: []string{"ACD", "1-7"}}
+	err := runPromoSweep(sender, cfg, afsmRefDate)
+	if err == nil {
+		t.Fatal("expected error when channel send fails")
+	}
+	if len(sender.bodies) != 1 {
+		t.Errorf("sends after failure = %d, want abort after first", len(sender.bodies))
+	}
+}
+
+func TestCollectPromoCandidatesActiveDutyScope(t *testing.T) {
+	// "active-duty" must hit /roster/ROSTER_TYPE_COMBAT/lite, not the fuzzy
+	// position search.
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+	}
+	rosterBody, _ := json.Marshal(roster)
+	ranksBody, _ := json.Marshal(viiTestRanks())
+	profileBody, _ := json.Marshal(profiles["Ready.R"])
+	var combatHits, fuzzyHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/roster/ROSTER_TYPE_COMBAT/lite"):
+			combatHits++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(rosterBody)
+		case strings.HasPrefix(r.URL.Path, "/milpacs/position/search/"):
+			fuzzyHits++
+			w.WriteHeader(http.StatusNotFound)
+		case strings.HasPrefix(r.URL.Path, "/milpacs/ranks"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(ranksBody)
+		case strings.HasPrefix(r.URL.Path, "/milpacs/profile/username/Ready.R"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(profileBody)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+
+	// Canonical spelling and the legacy hyphenated one must both route to the
+	// combat roster.
+	for _, scopeSpelling := range []string{"activeduty", "Active-Duty"} {
+		scan, err := collectPromoCandidates(t.Context(), scopeSpelling, "", afsmRefDate, promoFilter{})
+		if err != nil {
+			t.Fatalf("collectPromoCandidates(%q): %v", scopeSpelling, err)
+		}
+		if len(scan.Candidates) != 1 || scan.Candidates[0].Username != "Ready.R" {
+			t.Errorf("candidates for %q = %+v", scopeSpelling, scan.Candidates)
+		}
+	}
+	if combatHits != 2 || fuzzyHits != 0 {
+		t.Errorf("combat=%d fuzzy=%d, want 2/0", combatHits, fuzzyHits)
+	}
+}

--- a/commands/promo_test.go
+++ b/commands/promo_test.go
@@ -1,0 +1,1195 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/7cav/cavbot2/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+// promoInteraction builds an InteractionCreate carrying the /promo options.
+func promoInteraction(position, asOf string) *discordgo.InteractionCreate {
+	opts := []*discordgo.ApplicationCommandInteractionDataOption{
+		{Name: "position", Type: discordgo.ApplicationCommandOptionString, Value: position},
+	}
+	if asOf != "" {
+		opts = append(opts, &discordgo.ApplicationCommandInteractionDataOption{
+			Name: "as_of", Type: discordgo.ApplicationCommandOptionString, Value: asOf,
+		})
+	}
+	return &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{
+				Name:    "promo",
+				Options: opts,
+			},
+			Member: &discordgo.Member{User: &discordgo.User{ID: "42", Username: "tester"}},
+		},
+	}
+}
+
+func promoLiteProfile(username, rankShort, uniformID string) utils.LiteProfileResponse {
+	return utils.LiteProfileResponse{
+		User:       utils.User{UserID: "u-" + username, Username: username},
+		Rank:       utils.Rank{RankShort: rankShort},
+		UniformUrl: "https://7cav.us/data/roster_uniforms/0/" + uniformID + ".jpg",
+	}
+}
+
+func promoFullProfile(username, rankShort, promotionDate, joinDate, position string, courseRecords ...string) utils.ProfileResponse {
+	records := make([]utils.Record, 0, len(courseRecords))
+	for _, d := range courseRecords {
+		records = append(records, utils.Record{RecordDetails: d, RecordType: "RECORD_TYPE_GRADUATION", RecordDate: "2025-01-01"})
+	}
+	return utils.ProfileResponse{
+		User:          utils.User{UserID: "u-" + username, Username: username},
+		Rank:          utils.Rank{RankShort: rankShort},
+		Primary:       utils.Position{PositionTitle: position},
+		Records:       records,
+		JoinDate:      joinDate,
+		PromotionDate: promotionDate,
+	}
+}
+
+func TestRunPromoHappyPath(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		// Eligible: PVT past 30d TIG.
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+		// Not eligible: PVT short on TIG.
+		"2": promoLiteProfile("Fresh.F", "PVT", "102"),
+		// Skipped cheaply: no ladder for SGM, no profile fetch attempted.
+		"3": promoLiteProfile("Topout.T", "SGM", "103"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman 1/1/1/A"),
+		"Fresh.F": promoFullProfile("Fresh.F", "PVT", "2026-05-10", "2026-05-10", "Rifleman 1/1/1/A"),
+		// Deliberately no profile for Topout.T; a fetch would 404 and turn
+		// into a skip, so a clean output also proves the cheap pre-filter (SGM
+		// has no ladder and §VII is unavailable this run).
+	}
+	serveRosterAndProfiles(t, roster, 200, profiles)
+
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("ACD", ""), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "Ready.R") {
+		t.Errorf("output missing eligible member: %q", content)
+	}
+	if !strings.Contains(content, "PVT → PFC") {
+		t.Errorf("output missing rank transition: %q", content)
+	}
+	if strings.Contains(content, "Fresh.F") {
+		t.Errorf("output includes ineligible member: %q", content)
+	}
+	if strings.Contains(content, "Topout.T") {
+		t.Errorf("output includes ladderless member: %q", content)
+	}
+	if strings.Contains(content, "skipped") {
+		t.Errorf("unexpected skip warning (COL should be pre-filtered): %q", content)
+	}
+	if !strings.Contains(content, "⚠️") {
+		t.Errorf("disclaimer missing: %q", content)
+	}
+}
+
+func TestRunPromoAsOfDateExpandsEligibility(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Fresh.F", "PVT", "102"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		// 5d TIG at ref date; 30d gate clears 2026-06-09.
+		"Fresh.F": promoFullProfile("Fresh.F", "PVT", "2026-05-10", "2026-05-10", "Rifleman"),
+	}
+	serveRosterAndProfiles(t, roster, 200, profiles)
+
+	f := &fakeResponder{}
+	// as_of in the org's DDMMMYY format, lowercase to prove case-insensitivity.
+	runPromo(f, promoInteraction("ACD", "01jul26"), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "Fresh.F") {
+		t.Errorf("member should be eligible as of 01JUL26: %q", content)
+	}
+	if !strings.Contains(content, "01JUL26") {
+		t.Errorf("as-of date missing from header (want DDMMMYY): %q", content)
+	}
+}
+
+func TestParsePromoDate(t *testing.T) {
+	for _, ok := range []string{"30JUL26", "30jul26", "30Jul26", "2026-07-30"} {
+		got, err := parsePromoDate(ok)
+		if err != nil || got.Format("2006-01-02") != "2026-07-30" {
+			t.Errorf("parsePromoDate(%q) = %v, %v; want 2026-07-30", ok, got, err)
+		}
+	}
+	for _, bad := range []string{"julyish", "30JULY26", "2026/07/30", ""} {
+		if _, err := parsePromoDate(bad); err == nil {
+			t.Errorf("parsePromoDate(%q) should fail", bad)
+		}
+	}
+}
+
+// §VII is always discretionary; a candidate eligible via standard-automatic
+// AND §VII reads "automatic & discretionary" with paths "standard, §VII".
+func TestPromoCandidateTypesAndPaths(t *testing.T) {
+	rk := &viiRank{Short: "SGT"}
+	cases := []struct {
+		name      string
+		c         promoCandidate
+		wantTypes string
+		wantPaths string
+	}{
+		{
+			"automatic standard only",
+			promoCandidate{Verdict: promoEligibility{Eligible: true, Type: "automatic"}},
+			"automatic", "standard",
+		},
+		{
+			"standard automatic + §VII → automatic & discretionary",
+			promoCandidate{Verdict: promoEligibility{Eligible: true, Type: "automatic"}, ViaVII: true, Vii: &viiResult{Target: rk}},
+			"automatic & discretionary", "standard, §VII",
+		},
+		{
+			"§VII only is discretionary",
+			promoCandidate{Verdict: promoEligibility{Eligible: false}, ViaVII: true, Vii: &viiResult{Target: rk}},
+			"discretionary", "§VII",
+		},
+		{
+			"discretionary standard only",
+			promoCandidate{Verdict: promoEligibility{Eligible: true, Type: "discretionary"}},
+			"discretionary", "standard",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := strings.Join(promoCandidateTypes(tc.c), " & "); got != tc.wantTypes {
+				t.Errorf("types = %q, want %q", got, tc.wantTypes)
+			}
+			if got := strings.Join(promoCandidatePaths(tc.c), ", "); got != tc.wantPaths {
+				t.Errorf("paths = %q, want %q", got, tc.wantPaths)
+			}
+		})
+	}
+}
+
+// A position/unit scope displays upper-cased regardless of input casing;
+// activeduty stays the readable phrase.
+func TestScopeDisplayCasing(t *testing.T) {
+	for in, want := range map[string]string{
+		"acd": "ACD", "Acd": "ACD", "ACD": "ACD", "s1": "S1",
+		"activeduty": "active duty", "active-duty": "active duty",
+	} {
+		if got := scopeDisplay(in); got != want {
+			t.Errorf("scopeDisplay(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRunPromoInvalidAsOfDate(t *testing.T) {
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("ACD", "julyish"), afsmRefDate)
+
+	found := false
+	for _, call := range f.Calls() {
+		if call.Method == "Respond" && call.Response != nil && call.Response.Data != nil &&
+			strings.Contains(call.Response.Data.Content, "Invalid as_of") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected invalid-date error response, calls: %+v", f.Calls())
+	}
+}
+
+func TestRunPromoEmptyRoster(t *testing.T) {
+	// User-supplied position: empty roster is a message-only outcome routed
+	// through HandleError with the shared search-format hint (ADR 0002).
+	serveRosterAndProfiles(t, utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{}}, 200, nil)
+
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("XYZZY", ""), afsmRefDate)
+
+	found := false
+	for _, call := range f.Calls() {
+		if call.Method == "Respond" && call.Response != nil && call.Response.Data != nil &&
+			strings.Contains(call.Response.Data.Content, "No troopers found") &&
+			strings.Contains(call.Response.Data.Content, "XYZZY") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected shared empty-roster message, calls: %+v", f.Calls())
+	}
+}
+
+func TestRunPromoRosterFetchError(t *testing.T) {
+	serveRosterAndProfiles(t, utils.LiteRosterResponse{}, 500, nil)
+
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("ACD", ""), afsmRefDate)
+
+	// HandleError delivers errors via Respond (ephemeral), not Edit.
+	found := false
+	for _, call := range f.Calls() {
+		if call.Method == "Respond" && call.Response != nil && call.Response.Data != nil &&
+			strings.Contains(call.Response.Data.Content, "Failed to fetch roster") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected roster fetch error, calls: %+v", f.Calls())
+	}
+}
+
+func TestRunPromoMemberFetchFailureSkipsAndReports(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+		"2": promoLiteProfile("Ghost.G", "PVT", "102"), // no profile → 404 → skip
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+	}
+	serveRosterAndProfiles(t, roster, 200, profiles)
+
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("ACD", ""), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "Ready.R") {
+		t.Errorf("eligible member missing despite unrelated skip: %q", content)
+	}
+	if !strings.Contains(content, "1 member skipped") {
+		t.Errorf("skip warning missing: %q", content)
+	}
+}
+
+// A long list fills one message and reports the remainder for the attached
+// report: the message never exceeds Discord's cap.
+func TestFormatPromoMessageOverflows(t *testing.T) {
+	candidates := make([]promoCandidate, 80)
+	for idx := range candidates {
+		candidates[idx] = promoCandidate{
+			Username:  fmt.Sprintf("Member.%03d", idx),
+			MilpacURL: "https://7cav.us/rosters/profile/1",
+			RankShort: "PVT",
+			Verdict:   promoEligibility{Eligible: true, NextRank: "PFC", Type: "automatic"},
+		}
+	}
+	msg, omitted := formatPromoMessage("ACD", promoFilter{}, mustParseDate("2026-05-15"), candidates, 1, false)
+	if omitted <= 0 {
+		t.Fatalf("80 candidates should overflow one message, omitted = %d", omitted)
+	}
+	if len(msg) >= 2000 {
+		t.Errorf("message length %d exceeds Discord limit", len(msg))
+	}
+	if !strings.Contains(msg, fmt.Sprintf("…and %d more", omitted)) {
+		t.Errorf("overflow notice missing or miscounted: %q", msg)
+	}
+	if !strings.Contains(msg, "members eligible for promotion") {
+		t.Errorf("header missing: %q", msg)
+	}
+	// Footer notes survive alongside the overflow notice.
+	if !strings.Contains(msg, "standard ladder only") || !strings.Contains(msg, "1 member skipped") {
+		t.Errorf("footer notes missing: %q", msg)
+	}
+	// The listed names are a prefix of the candidate order.
+	if !strings.Contains(msg, "Member.000") {
+		t.Errorf("first candidate missing: %q", msg)
+	}
+}
+
+// A list that fits needs no attachment.
+func TestFormatPromoMessageFitsWithoutOverflow(t *testing.T) {
+	candidates := []promoCandidate{{
+		Username:  "Ready.R",
+		MilpacURL: "https://7cav.us/rosters/profile/1",
+		RankShort: "PVT",
+		Verdict:   promoEligibility{Eligible: true, NextRank: "PFC", Type: "automatic"},
+	}}
+	msg, omitted := formatPromoMessage("ACD", promoFilter{}, mustParseDate("2026-05-15"), candidates, 0, true)
+	if omitted != 0 {
+		t.Errorf("omitted = %d, want 0", omitted)
+	}
+	if strings.Contains(msg, "attached report") {
+		t.Errorf("overflow notice should not render: %q", msg)
+	}
+}
+
+// manyEligiblePVTs builds a roster and profile set of n eligible PVTs; long
+// enough scopes force multi-message output.
+func manyEligiblePVTs(n int) (utils.LiteRosterResponse, map[string]utils.ProfileResponse) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{}}
+	profiles := make(map[string]utils.ProfileResponse, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("Member.%03d", i)
+		roster.LiteProfiles[name] = promoLiteProfile(name, "PVT", "101")
+		profiles[name] = promoFullProfile(name, "PVT", "2026-04-01", "2026-04-01", "Rifleman")
+	}
+	return roster, profiles
+}
+
+// A scope whose list exceeds one message posts what fits and attaches the
+// full report: every candidate still reaches the reader.
+func TestRunPromoLongListAttachesReport(t *testing.T) {
+	roster, profiles := manyEligiblePVTs(60)
+	servePromoAPIWithRanks(t, roster, profiles, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("ACD", ""), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if len(content) >= 2000 {
+		t.Errorf("message length %d exceeds Discord limit", len(content))
+	}
+	// The message keeps the inline list and the "…and N more" overflow notice.
+	if !strings.Contains(content, "more. Full list in the attached report") {
+		t.Errorf("overflow notice missing: %q", content)
+	}
+	if !strings.Contains(content, "Member.000") {
+		t.Errorf("inline list should show the first candidates: %q", content)
+	}
+	// The full detail is still attached as both CSV and HTML.
+	csvBody, htmlBody := lastAttachments(t, f)
+	for i := 0; i < 60; i++ {
+		who := fmt.Sprintf("Member.%03d", i)
+		if !strings.Contains(htmlBody, who) {
+			t.Fatalf("candidate %s missing from HTML report", who)
+		}
+		if !strings.Contains(csvBody, who) {
+			t.Fatalf("candidate %s missing from CSV report", who)
+		}
+	}
+	if !strings.Contains(csvBody, "username,current_rank,primary_billet") {
+		t.Errorf("CSV header missing billet column: %q", csvBody[:min(120, len(csvBody))])
+	}
+}
+
+func TestFormatPromoMessageNoCandidates(t *testing.T) {
+	msg, omitted := formatPromoMessage("ACD", promoFilter{}, mustParseDate("2026-05-15"), nil, 0, true)
+	if omitted != 0 {
+		t.Errorf("omitted = %d, want 0", omitted)
+	}
+	if !strings.Contains(msg, "No ACD members eligible") {
+		t.Errorf("expected no-candidates message, got %q", msg)
+	}
+}
+
+func TestPromoDefinition(t *testing.T) {
+	cmd := Promo()
+	if cmd.Definition.Name != "promo" {
+		t.Errorf("command name = %q, want promo", cmd.Definition.Name)
+	}
+	if len(cmd.Definition.Options) != 7 {
+		t.Fatalf("options = %d, want 7 (position, user, rank, type, exclude, as_of, force_file_output)", len(cmd.Definition.Options))
+	}
+	for _, opt := range cmd.Definition.Options {
+		if opt.Required {
+			t.Errorf("option %q should be optional (mode validated at runtime)", opt.Name)
+		}
+	}
+	if cmd.Handler == nil {
+		t.Error("handler is nil")
+	}
+	// Registry wiring.
+	if _, ok := NewRegistry().GetHandler("promo"); !ok {
+		t.Error("promo not registered in NewRegistry")
+	}
+}
+
+// Guard against clock drift in default as-of handling: runPromo must use the
+// injected now, not the wall clock.
+func TestRunPromoUsesInjectedNow(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+	}
+	serveRosterAndProfiles(t, roster, 200, profiles)
+
+	f := &fakeResponder{}
+	injected := mustParseDate("2030-01-01")
+	runPromo(f, promoInteraction("ACD", ""), injected)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "01JAN30") {
+		t.Errorf("header should show injected date, got %q", content)
+	}
+}
+
+// servePromoAPIWithRanks extends the AFSM test-server pattern with the
+// /milpacs/ranks endpoint the §VII path needs.
+func servePromoAPIWithRanks(
+	t *testing.T,
+	roster utils.LiteRosterResponse,
+	profilesByUsername map[string]utils.ProfileResponse,
+	ranks *utils.RanksResponse,
+) {
+	t.Helper()
+	rosterBody, err := json.Marshal(roster)
+	if err != nil {
+		t.Fatalf("marshal roster: %v", err)
+	}
+	ranksBody, err := json.Marshal(ranks)
+	if err != nil {
+		t.Fatalf("marshal ranks: %v", err)
+	}
+	encodedProfiles := make(map[string][]byte, len(profilesByUsername))
+	for name, p := range profilesByUsername {
+		b, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal profile %q: %v", name, err)
+		}
+		encodedProfiles[name] = b
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/milpacs/ranks"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(ranksBody)
+		case strings.HasPrefix(r.URL.Path, "/milpacs/position/search/"),
+			strings.HasPrefix(r.URL.Path, "/roster/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(rosterBody)
+		case strings.HasPrefix(r.URL.Path, "/milpacs/profile/username/"):
+			name := strings.TrimPrefix(r.URL.Path, "/milpacs/profile/username/")
+			body, ok := encodedProfiles[name]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+}
+
+func TestRunPromoViiPath(t *testing.T) {
+	vet := viiVetProfile() // CPL, previously held SSG as Section Leader
+	vet.UniformUrl = "https://7cav.us/data/roster_uniforms/0/301.jpg"
+
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": {
+			User:       vet.User,
+			Rank:       vet.Rank,
+			UniformUrl: vet.UniformUrl,
+		},
+	}}
+	servePromoAPIWithRanks(t, roster, map[string]utils.ProfileResponse{"Vet.V": *vet}, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("ACD", ""), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "Vet.V") {
+		t.Fatalf("§VII veteran missing from output: %q", content)
+	}
+	if !strings.Contains(content, "§VII veteran retention") {
+		t.Errorf("§VII path not labeled: %q", content)
+	}
+	if !strings.Contains(content, "CPL → SSG") {
+		t.Errorf("restoration target missing: %q", content)
+	}
+	if !strings.Contains(content, "held 2021-01-01") {
+		t.Errorf("held-date evidence missing: %q", content)
+	}
+	if strings.Contains(content, "§VII veteran-retention check unavailable") {
+		t.Errorf("degradation notice should not render when ranks fetch succeeds: %q", content)
+	}
+}
+
+func TestRunPromoViiDegradationNotice(t *testing.T) {
+	// The plain server (no /milpacs/ranks route) 404s the ranks fetch -
+	// output must carry the standard-only notice.
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+	}
+	serveRosterAndProfiles(t, roster, 200, profiles)
+
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("ACD", ""), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "standard ladder only") {
+		t.Errorf("degradation notice missing: %q", content)
+	}
+	if !strings.Contains(content, "Ready.R") {
+		t.Errorf("standard path should still work: %q", content)
+	}
+}
+
+// --- rank ordering -----------------------------------------------------------
+
+func TestPromoRankIndex(t *testing.T) {
+	// Most-senior-first: officer < warrant < enlisted; alphabetic ties broken
+	// elsewhere. Unknown ranks sort after every known one.
+	ordered := []string{"COL", "2LT", "CW5", "WO1", "CSM", "SGT", "PVT"}
+	for i := 1; i < len(ordered); i++ {
+		if promoRankIndex(ordered[i-1]) >= promoRankIndex(ordered[i]) {
+			t.Errorf("%s should sort before %s", ordered[i-1], ordered[i])
+		}
+	}
+	if promoRankIndex("pfc") != promoRankIndex("PFC") {
+		t.Error("rank index must be case-insensitive")
+	}
+	if promoRankIndex("XYZ") <= promoRankIndex("PVT") {
+		t.Error("unknown rank must sort after every known rank")
+	}
+}
+
+// The HTML "Next" column sorts by seniority; a compound target (SPC's
+// "CPL/WO1") sorts as its first rank.
+func TestPromoNextRankIndex(t *testing.T) {
+	if promoNextRankIndex("CPL/WO1") != promoRankIndex("CPL") {
+		t.Error("compound next rank should sort as its first rank")
+	}
+	if promoNextRankIndex("BG") >= promoNextRankIndex("SGT") {
+		t.Error("BG (senior) should sort before SGT")
+	}
+}
+
+func TestPromoCandidatesSortedByRankThenName(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Bravo.B", "PVT", "101"),
+		"2": promoLiteProfile("Alpha.A", "PVT", "102"),
+		"3": promoLiteProfile("Sarge.S", "SGT", "103"),
+		"4": promoLiteProfile("Fresh.F", "PFC", "104"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Bravo.B": promoFullProfile("Bravo.B", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+		"Alpha.A": promoFullProfile("Alpha.A", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+		"Sarge.S": promoFullProfile("Sarge.S", "SGT", "2025-01-01", "2024-01-01", "Platoon Sergeant 1/1/A"),
+		"Fresh.F": promoFullProfile("Fresh.F", "PFC", "2026-01-01", "2026-01-01", "Rifleman"),
+	}
+	serveRosterAndProfiles(t, roster, 200, profiles)
+
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("ACD", ""), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	iS, iF := strings.Index(content, "Sarge.S"), strings.Index(content, "Fresh.F")
+	iA, iB := strings.Index(content, "Alpha.A"), strings.Index(content, "Bravo.B")
+	for name, idx := range map[string]int{"Sarge.S": iS, "Fresh.F": iF, "Alpha.A": iA, "Bravo.B": iB} {
+		if idx < 0 {
+			t.Fatalf("%s missing from output: %q", name, content)
+		}
+	}
+	if iS >= iF || iF >= iA || iA >= iB {
+		t.Errorf("want SGT before PFC before PVTs (alphabetical), got order S=%d F=%d A=%d B=%d in %q", iS, iF, iA, iB, content)
+	}
+}
+
+// --- rank mode ---------------------------------------------------------------
+
+func promoRankInteraction(rank string) *discordgo.InteractionCreate {
+	return &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type: discordgo.InteractionApplicationCommand,
+		Data: discordgo.ApplicationCommandInteractionData{Name: "promo", Options: []*discordgo.ApplicationCommandInteractionDataOption{
+			{Name: "rank", Type: discordgo.ApplicationCommandOptionString, Value: rank},
+		}},
+		Member: &discordgo.Member{User: &discordgo.User{ID: "42", Username: "tester"}},
+	}}
+}
+
+// DEVCOM scope merges the HQ search and the D/DEVCOM sub-unit search,
+// deduplicating a member returned by both.
+func TestResolvePositionRosterDevcomMerge(t *testing.T) {
+	hq := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Hq.H", "SGT", "101"),
+		"2": promoLiteProfile("Both.B", "SSG", "102"), // also in the sub-unit search
+	}}
+	sub := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Sub.S", "CPL", "201"),
+		"2": promoLiteProfile("Both.B", "SSG", "102"),
+	}}
+	hqBody, _ := json.Marshal(hq)
+	subBody, _ := json.Marshal(sub)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/D/DEVCOM"):
+			_, _ = w.Write(subBody)
+		case strings.HasSuffix(r.URL.Path, "/DEVCOM"):
+			_, _ = w.Write(hqBody)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(utils.SetAPIBaseURLForTest(srv.URL))
+
+	roster, err := resolvePositionRoster(t.Context(), "devcom")
+	if err != nil {
+		t.Fatalf("resolvePositionRoster: %v", err)
+	}
+	names := map[string]bool{}
+	for _, p := range roster.LiteProfiles {
+		names[p.User.Username] = true
+	}
+	for _, want := range []string{"Hq.H", "Sub.S", "Both.B"} {
+		if !names[want] {
+			t.Errorf("DEVCOM merge missing %s; got %v", want, names)
+		}
+	}
+	if len(roster.LiteProfiles) != 3 {
+		t.Errorf("expected 3 deduplicated members, got %d (%v)", len(roster.LiteProfiles), names)
+	}
+}
+
+func TestRunPromoRankMode(t *testing.T) {
+	// The active-duty roster carries a PVT (eligible), a PVT (not eligible),
+	// and an eligible PFC that the rank filter must exclude.
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+		"2": promoLiteProfile("Fresh.F", "PVT", "102"),
+		"3": promoLiteProfile("Other.O", "PFC", "103"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+		"Fresh.F": promoFullProfile("Fresh.F", "PVT", "2026-05-10", "2026-05-10", "Rifleman"),
+		"Other.O": promoFullProfile("Other.O", "PFC", "2026-01-01", "2026-01-01", "Rifleman"),
+	}
+	servePromoAPIWithRanks(t, roster, profiles, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, promoRankInteraction("pvt"), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "PVT members eligible") {
+		t.Errorf("header should carry the canonical rank scope: %q", content)
+	}
+	if !strings.Contains(content, "Ready.R") {
+		t.Errorf("eligible PVT missing: %q", content)
+	}
+	if strings.Contains(content, "Fresh.F") {
+		t.Errorf("ineligible PVT should not render: %q", content)
+	}
+	if strings.Contains(content, "Other.O") {
+		t.Errorf("PFC must be excluded by the rank filter: %q", content)
+	}
+}
+
+func TestRunPromoRankModeNoHolders(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+	}}
+	servePromoAPIWithRanks(t, roster, nil, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, promoRankInteraction("XYZ"), afsmRefDate)
+
+	found := false
+	for _, call := range f.Calls() {
+		if call.Method == "Respond" && call.Response != nil && call.Response.Data != nil &&
+			strings.Contains(call.Response.Data.Content, "No active-duty troopers hold rank") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected no-holders message, calls: %+v", f.Calls())
+	}
+}
+
+// --- type filter -------------------------------------------------------------
+
+// wingedCPL is a lateral-only candidate: CPL, too fresh for the standard
+// ladder, no prior higher rank for §VII, but flight-qualified (Aviator Badge
+// + 15-series MOS) → lateral WO1.
+func wingedCPL(username string) utils.ProfileResponse {
+	p := promoFullProfile(username, "CPL", "2026-05-01", "2026-05-01", "Pilot 1/C/1-7")
+	p.Mos = "15A"
+	p.Awards = []utils.Award{{AwardName: "Army Aviator Badge"}}
+	return p
+}
+
+// promoTypeInteraction builds /promo position:ACD type:<promoType>.
+func promoTypeInteraction(promoType string) *discordgo.InteractionCreate {
+	i := promoInteraction("ACD", "")
+	data := i.Data.(discordgo.ApplicationCommandInteractionData)
+	data.Options = append(data.Options, &discordgo.ApplicationCommandInteractionDataOption{
+		Name: "type", Type: discordgo.ApplicationCommandOptionString, Value: promoType,
+	})
+	i.Data = data
+	return i
+}
+
+// servePromoTypeFixture serves a roster carrying one candidate per path:
+// automatic (PVT), discretionary (SGT), §VII-only (vet CPL), lateral-only
+// (winged CPL).
+func servePromoTypeFixture(t *testing.T) {
+	t.Helper()
+	vet := viiVetProfile() // §VII-only: CPL, previously held SSG
+	vet.UniformUrl = "https://7cav.us/data/roster_uniforms/0/301.jpg"
+	wings := wingedCPL("Wings.W")
+
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+		"2": promoLiteProfile("Sarge.S", "SGT", "102"),
+		"3": {User: vet.User, Rank: vet.Rank, UniformUrl: vet.UniformUrl},
+		"4": promoLiteProfile("Wings.W", "CPL", "302"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+		"Sarge.S": promoFullProfile("Sarge.S", "SGT", "2025-01-01", "2024-01-01", "Platoon Sergeant 1/1/A"),
+		"Vet.V":   *vet,
+		"Wings.W": wings,
+	}
+	servePromoAPIWithRanks(t, roster, profiles, viiTestRanks())
+}
+
+func TestRunPromoTypeFilters(t *testing.T) {
+	// For each path: the one candidate that must render and, implicitly, the
+	// three that must not.
+	cases := []struct {
+		promoType string
+		want      string
+	}{
+		{"automatic", "Ready.R"},
+		{"discretionary", "Sarge.S"},
+		{"vii", "Vet.V"},
+		{"lateral", "Wings.W"},
+	}
+	all := []string{"Ready.R", "Sarge.S", "Vet.V", "Wings.W"}
+	for _, tc := range cases {
+		t.Run(tc.promoType, func(t *testing.T) {
+			servePromoTypeFixture(t)
+			f := &fakeResponder{}
+			runPromo(f, promoTypeInteraction(tc.promoType), afsmRefDate)
+
+			content := lastEditContent(f.Calls())
+			if !strings.Contains(content, tc.want) {
+				t.Errorf("%s candidate missing: %q", tc.promoType, content)
+			}
+			for _, other := range all {
+				if other != tc.want && strings.Contains(content, other) {
+					t.Errorf("%s must be filtered out of type:%s: %q", other, tc.promoType, content)
+				}
+			}
+			if !strings.Contains(content, "eligible for "+promoPhrase(tc.promoType)) {
+				t.Errorf("header should carry the type phrase: %q", content)
+			}
+		})
+	}
+}
+
+func promoExcludeInteraction(excludeType string) *discordgo.InteractionCreate {
+	i := promoInteraction("ACD", "")
+	data := i.Data.(discordgo.ApplicationCommandInteractionData)
+	data.Options = append(data.Options, &discordgo.ApplicationCommandInteractionDataOption{
+		Name: "exclude", Type: discordgo.ApplicationCommandOptionString, Value: excludeType,
+	})
+	i.Data = data
+	return i
+}
+
+// exclude:X hides the candidate whose only path is X and keeps the other three.
+func TestRunPromoExcludeFilters(t *testing.T) {
+	cases := []struct {
+		excludeType string
+		gone        string // the candidate that must disappear
+	}{
+		{"automatic", "Ready.R"},
+		{"discretionary", "Sarge.S"},
+		{"vii", "Vet.V"},
+		{"lateral", "Wings.W"},
+	}
+	all := []string{"Ready.R", "Sarge.S", "Vet.V", "Wings.W"}
+	for _, tc := range cases {
+		t.Run(tc.excludeType, func(t *testing.T) {
+			servePromoTypeFixture(t)
+			f := &fakeResponder{}
+			runPromo(f, promoExcludeInteraction(tc.excludeType), afsmRefDate)
+
+			content := lastEditContent(f.Calls())
+			if strings.Contains(content, tc.gone) {
+				t.Errorf("%s should be excluded by exclude:%s: %q", tc.gone, tc.excludeType, content)
+			}
+			for _, other := range all {
+				if other != tc.gone && !strings.Contains(content, other) {
+					t.Errorf("%s should survive exclude:%s: %q", other, tc.excludeType, content)
+				}
+			}
+			if !strings.Contains(content, "excluding "+promoTypeWord(tc.excludeType)) {
+				t.Errorf("header should note the exclusion: %q", content)
+			}
+		})
+	}
+}
+
+// A candidate eligible via BOTH standard and §VII survives exclude:vii,
+// because §VII is not their only path.
+func TestFilterPromoExcludingKeepsMultiPath(t *testing.T) {
+	both := promoCandidate{Verdict: promoEligibility{Eligible: true, Type: "automatic"}, ViaVII: true, Vii: &viiResult{Target: &viiRank{Short: "SGT"}}}
+	viiOnly := promoCandidate{Verdict: promoEligibility{Eligible: false}, ViaVII: true, Vii: &viiResult{Target: &viiRank{Short: "SGT"}}}
+	got := filterPromoExcluding([]promoCandidate{both, viiOnly}, promoTypeVii)
+	if len(got) != 1 || !got[0].Verdict.Eligible {
+		t.Errorf("exclude:vii should keep only the standard+§VII candidate, got %+v", got)
+	}
+}
+
+// type and exclude cannot be combined.
+func TestRunPromoTypeAndExcludeConflict(t *testing.T) {
+	i := promoTypeInteraction("automatic")
+	data := i.Data.(discordgo.ApplicationCommandInteractionData)
+	data.Options = append(data.Options, &discordgo.ApplicationCommandInteractionDataOption{
+		Name: "exclude", Type: discordgo.ApplicationCommandOptionString, Value: "vii",
+	})
+	i.Data = data
+
+	f := &fakeResponder{}
+	runPromo(f, i, afsmRefDate)
+	found := false
+	for _, call := range f.Calls() {
+		if call.Method == "Respond" && call.Response != nil && call.Response.Data != nil &&
+			strings.Contains(call.Response.Data.Content, "not both") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected type+exclude conflict error, calls: %+v", f.Calls())
+	}
+}
+
+// Unfiltered lists must include the lateral-only candidate with the lateral
+// rendering.
+func TestRunPromoLateralInUnfilteredList(t *testing.T) {
+	servePromoTypeFixture(t)
+	f := &fakeResponder{}
+	runPromo(f, promoInteraction("ACD", ""), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "Wings.W") {
+		t.Fatalf("lateral candidate missing from unfiltered list: %q", content)
+	}
+	if !strings.Contains(content, "CPL → WO1 (lateral, flight wings)") {
+		t.Errorf("lateral line rendering wrong: %q", content)
+	}
+}
+
+// Wings without an aviation MOS (or the reverse) is NOT lateral-eligible.
+func TestLateralRequiresWingsAndAviationMos(t *testing.T) {
+	badgeOnly := promoFullProfile("Badge.B", "CPL", "2026-05-01", "2026-05-01", "Rifleman")
+	badgeOnly.Awards = []utils.Award{{AwardName: "Army Aviator Badge"}}
+
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Badge.B", "CPL", "101"),
+	}}
+	servePromoAPIWithRanks(t, roster, map[string]utils.ProfileResponse{"Badge.B": badgeOnly}, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, promoTypeInteraction("lateral"), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if strings.Contains(content, "Badge.B") {
+		t.Errorf("badge without aviation MOS must not be lateral-eligible: %q", content)
+	}
+}
+
+// --- single-user mode --------------------------------------------------------
+
+func TestRunPromoUserModeVerdict(t *testing.T) {
+	// Not-yet-eligible PVT: verdict must show the failing TIG gate and the
+	// countdown, and §VII inapplicability.
+	profiles := map[string]utils.ProfileResponse{
+		"Fresh.F": promoFullProfile("Fresh.F", "PVT", "2026-05-10", "2026-05-10", "Rifleman"),
+	}
+	servePromoAPIWithRanks(t, utils.LiteRosterResponse{}, profiles, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, promoUserInteraction("Fresh.F", ""), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "not yet eligible for PFC") {
+		t.Errorf("verdict header wrong: %q", content)
+	}
+	if !strings.Contains(content, "❌ TIG") {
+		t.Errorf("failing TIG gate not shown: %q", content)
+	}
+	if !strings.Contains(content, "day(s) until time requirements met") {
+		t.Errorf("countdown missing: %q", content)
+	}
+	if !strings.Contains(content, "§VII): not applicable") {
+		t.Errorf("§VII verdict missing: %q", content)
+	}
+}
+
+// A recognized rank with no TIG/TIS ladder entry (1SG) reads as billet-based
+// advancement, NOT "topped out" (1SG can still make SGM/CSM) and not the
+// bug-like "no ladder defined", and carries the shared S6 disclaimer.
+func TestRunPromoUserModeNoLadderRank(t *testing.T) {
+	profiles := map[string]utils.ProfileResponse{
+		"Top.T": promoFullProfile("Top.T", "1SG", "2024-01-01", "2022-01-01", "First Sergeant A/ACD"),
+	}
+	servePromoAPIWithRanks(t, utils.LiteRosterResponse{}, profiles, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, promoUserInteraction("Top.T", ""), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "billet-based") {
+		t.Errorf("billet-based advancement message missing: %q", content)
+	}
+	if strings.Contains(content, "top of the standard ladder") {
+		t.Errorf("must not claim 1SG is topped out: %q", content)
+	}
+	if !strings.Contains(content, "report inaccurate outputs to S6") {
+		t.Errorf("shared disclaimer missing from verdict: %q", content)
+	}
+}
+
+func TestRunPromoUserModeViiVeteran(t *testing.T) {
+	vet := viiVetProfile()
+	profiles := map[string]utils.ProfileResponse{"Vet.V": *vet}
+	servePromoAPIWithRanks(t, utils.LiteRosterResponse{}, profiles, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, promoUserInteraction("Vet.V", ""), afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "eligible for SSG") {
+		t.Errorf("§VII eligibility missing: %q", content)
+	}
+	if !strings.Contains(content, "held 2021-01-01 as Section Leader") {
+		t.Errorf("held evidence missing: %q", content)
+	}
+}
+
+func TestRunPromoUserModeUnknownUser(t *testing.T) {
+	servePromoAPIWithRanks(t, utils.LiteRosterResponse{}, nil, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, promoUserInteraction("Nobody.N", ""), afsmRefDate)
+
+	found := false
+	for _, call := range f.Calls() {
+		if call.Method == "Respond" && call.Response != nil && call.Response.Data != nil &&
+			strings.Contains(call.Response.Data.Content, "No milpac found") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected not-found message, calls: %+v", f.Calls())
+	}
+}
+
+// No mode option at all → the whole Active Duty roster, not an error.
+func TestRunPromoDefaultsToActiveDuty(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+	}
+	servePromoAPIWithRanks(t, roster, profiles, viiTestRanks())
+
+	f := &fakeResponder{}
+	runPromo(f, &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type:   discordgo.InteractionApplicationCommand,
+		Data:   discordgo.ApplicationCommandInteractionData{Name: "promo"},
+		Member: &discordgo.Member{User: &discordgo.User{ID: "42", Username: "tester"}},
+	}}, afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "Active duty members eligible") {
+		t.Errorf("bare /promo should default to the active duty scope: %q", content)
+	}
+	if !strings.Contains(content, "Ready.R") {
+		t.Errorf("default scan missing candidate: %q", content)
+	}
+}
+
+// user is a single-trooper check and can't be combined with position/rank.
+func TestRunPromoUserExclusive(t *testing.T) {
+	for _, combineWith := range []string{"position", "rank"} {
+		f := &fakeResponder{}
+		i := promoInteraction("", "")
+		data := i.Data.(discordgo.ApplicationCommandInteractionData)
+		data.Options = []*discordgo.ApplicationCommandInteractionDataOption{
+			{Name: "user", Type: discordgo.ApplicationCommandOptionString, Value: "Someone.S"},
+			{Name: combineWith, Type: discordgo.ApplicationCommandOptionString, Value: "ACD"},
+		}
+		i.Data = data
+		runPromo(f, i, afsmRefDate)
+
+		found := false
+		for _, call := range f.Calls() {
+			if call.Method == "Respond" && call.Response != nil && call.Response.Data != nil &&
+				strings.Contains(call.Response.Data.Content, "don't combine it with") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("user + %s should error, calls: %+v", combineWith, f.Calls())
+		}
+	}
+}
+
+// position and rank combine: position scopes the roster, rank narrows it.
+func TestRunPromoPositionAndRankCombine(t *testing.T) {
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+		"2": promoLiteProfile("Other.O", "PFC", "103"),
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+		"Other.O": promoFullProfile("Other.O", "PFC", "2026-01-01", "2026-01-01", "Rifleman"),
+	}
+	servePromoAPIWithRanks(t, roster, profiles, viiTestRanks())
+
+	i := promoInteraction("ACD", "")
+	data := i.Data.(discordgo.ApplicationCommandInteractionData)
+	data.Options = append(data.Options, &discordgo.ApplicationCommandInteractionDataOption{
+		Name: "rank", Type: discordgo.ApplicationCommandOptionString, Value: "PVT",
+	})
+	i.Data = data
+
+	f := &fakeResponder{}
+	runPromo(f, i, afsmRefDate)
+
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "ACD PVT members eligible") {
+		t.Errorf("header should combine position and rank: %q", content)
+	}
+	if !strings.Contains(content, "Ready.R") {
+		t.Errorf("PVT in ACD should be listed: %q", content)
+	}
+	if strings.Contains(content, "Other.O") {
+		t.Errorf("PFC must be filtered out by rank:PVT: %q", content)
+	}
+}
+
+func promoUserInteraction(username, asOf string) *discordgo.InteractionCreate {
+	opts := []*discordgo.ApplicationCommandInteractionDataOption{
+		{Name: "user", Type: discordgo.ApplicationCommandOptionString, Value: username},
+	}
+	if asOf != "" {
+		opts = append(opts, &discordgo.ApplicationCommandInteractionDataOption{
+			Name: "as_of", Type: discordgo.ApplicationCommandOptionString, Value: asOf,
+		})
+	}
+	return &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type:   discordgo.InteractionApplicationCommand,
+		Data:   discordgo.ApplicationCommandInteractionData{Name: "promo", Options: opts},
+		Member: &discordgo.Member{User: &discordgo.User{ID: "42", Username: "tester"}},
+	}}
+}
+
+// --- file report -------------------------------------------------------------
+
+func TestRunPromoForceFileOutput(t *testing.T) {
+	vet := viiVetProfile()
+	vet.UniformUrl = "https://7cav.us/data/roster_uniforms/0/301.jpg"
+	roster := utils.LiteRosterResponse{LiteProfiles: map[string]utils.LiteProfileResponse{
+		"1": promoLiteProfile("Ready.R", "PVT", "101"),
+		"2": {User: vet.User, Rank: vet.Rank, UniformUrl: vet.UniformUrl},
+	}}
+	profiles := map[string]utils.ProfileResponse{
+		"Ready.R": promoFullProfile("Ready.R", "PVT", "2026-04-01", "2026-04-01", "Rifleman"),
+		"Vet.V":   *vet,
+	}
+	servePromoAPIWithRanks(t, roster, profiles, viiTestRanks())
+
+	i := promoInteraction("ACD", "")
+	data := i.Data.(discordgo.ApplicationCommandInteractionData)
+	data.Options = append(data.Options, &discordgo.ApplicationCommandInteractionDataOption{
+		Name: "force_file_output", Type: discordgo.ApplicationCommandOptionBoolean, Value: true,
+	})
+	i.Data = data
+
+	f := &fakeResponder{}
+	runPromo(f, i, afsmRefDate)
+
+	csvBody, htmlBody := lastAttachments(t, f)
+	if !strings.Contains(htmlBody, "<table") || !strings.Contains(htmlBody, "eligibility") {
+		t.Errorf("HTML report structure missing: %q", htmlBody)
+	}
+	if !strings.Contains(htmlBody, "Ready.R") || !strings.Contains(htmlBody, "Vet.V") {
+		t.Errorf("HTML report missing candidates: %q", htmlBody)
+	}
+	if !strings.Contains(htmlBody, "§VII") {
+		t.Errorf("HTML report missing §VII path data: %q", htmlBody)
+	}
+	if !strings.Contains(csvBody, "Ready.R") || !strings.Contains(csvBody, "Vet.V") {
+		t.Errorf("CSV report missing candidates: %q", csvBody)
+	}
+	// A short list forced to file still renders the inline list too.
+	content := lastEditContent(f.Calls())
+	if !strings.Contains(content, "Ready.R") {
+		t.Errorf("forced file should still show the inline list: %q", content)
+	}
+	// Primary billet now appears in both reports.
+	if !strings.Contains(csvBody, "primary_billet") || !strings.Contains(htmlBody, "Billet") {
+		t.Errorf("billet column missing from reports")
+	}
+}
+
+// Milpac text is user-entered and must not break out of the report markup.
+func TestPromoReportEscapesMilpacData(t *testing.T) {
+	scan := promoScan{ViiActive: true, Candidates: []promoCandidate{{
+		Username:  `Evil<script>alert("x")</script>`,
+		MilpacURL: "https://7cav.us/rosters/profile/1",
+		RankShort: "PVT",
+		Verdict:   promoEligibility{Eligible: true, NextRank: "PFC", Type: "automatic"},
+	}}}
+	file := promoReportFile("ACD", promoFilter{}, mustParseDate("2026-05-15"), scan)
+	var sb strings.Builder
+	if _, err := io.Copy(&sb, file.Reader); err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	// The report carries its own sort/filter <script> block; what must never
+	// appear is the injected payload unescaped.
+	if strings.Contains(sb.String(), "<script>alert") {
+		t.Errorf("unescaped injected markup reached the report: %q", sb.String())
+	}
+	if !strings.Contains(sb.String(), "&lt;script&gt;") {
+		t.Errorf("expected escaped markup: %q", sb.String())
+	}
+}
+
+// lastAttachments returns the CSV and HTML report bodies from the last Edit
+// call: /promo attaches both when a list ships as files.
+func lastAttachments(t *testing.T, f *fakeResponder) (csvBody, htmlBody string) {
+	t.Helper()
+	var edit *discordgo.WebhookEdit
+	for _, call := range f.Calls() {
+		if call.Method == "Edit" && call.Edit != nil {
+			edit = call.Edit
+		}
+	}
+	if edit == nil || len(edit.Files) != 2 {
+		t.Fatalf("expected CSV + HTML attachments, calls: %+v", f.Calls())
+	}
+	for _, fl := range edit.Files {
+		var sb strings.Builder
+		if _, err := io.Copy(&sb, fl.Reader); err != nil {
+			t.Fatalf("read attachment %s: %v", fl.Name, err)
+		}
+		switch {
+		case strings.HasSuffix(fl.Name, ".csv"):
+			csvBody = sb.String()
+		case strings.HasSuffix(fl.Name, ".html"):
+			htmlBody = sb.String()
+		default:
+			t.Fatalf("unexpected attachment %q", fl.Name)
+		}
+	}
+	if csvBody == "" || htmlBody == "" {
+		t.Fatalf("missing csv or html attachment; files: %+v", edit.Files)
+	}
+	return csvBody, htmlBody
+}

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -20,6 +20,7 @@ func NewRegistry() *Registry {
 		AFSM(),
 		GamertagSearch(),
 		S3AAR(),
+		Promo(),
 	)
 	return r
 }

--- a/commands/report.go
+++ b/commands/report.go
@@ -1,0 +1,84 @@
+package commands
+
+// Shared report scaffolding.
+//
+// /promo and /billetaudit both attach a self-contained HTML table and a CSV
+// of the same rows, and had grown their own copy of the document shell, the
+// base stylesheet and the csv.Writer boilerplate. The two reports differ in
+// their columns and in whether the table is interactive, so what is shared
+// here is only the part that was genuinely identical: the document frame and
+// the mechanical CSV write.
+
+import (
+	"encoding/csv"
+	"fmt"
+	"html"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// reportBaseCSS is the shared look: readable table, sticky header, striped
+// rows. Callers append their own rules for anything beyond that.
+const reportBaseCSS = `body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:1.5rem;color:#1a1a1a}
+h1{font-size:1.25rem;margin:0 0 .25rem}
+p.meta{color:#555;margin:0 0 1rem;font-size:.9rem}
+table{border-collapse:collapse;width:100%;font-size:.875rem}
+th,td{border:1px solid #ddd;padding:.4rem .6rem;text-align:left;vertical-align:top}
+th{background:#f4f4f4;position:sticky;top:0}
+tr:nth-child(even) td{background:#fafafa}
+.note{margin-top:1.5rem;padding:.75rem;background:#fff8e1;border-left:3px solid #e6a700;font-size:.875rem}`
+
+// writeReportHead opens an HTML document with the shared stylesheet plus any
+// caller-specific rules, and emits the page heading. The title is escaped
+// here so callers cannot forget: report titles carry scope names that come
+// from user input.
+func writeReportHead(b *strings.Builder, title, extraCSS string) {
+	b.WriteString("<!DOCTYPE html>\n<html lang=\"en\"><head><meta charset=\"utf-8\">\n")
+	fmt.Fprintf(b, "<title>%s</title>\n", html.EscapeString(title))
+	b.WriteString("<style>\n")
+	b.WriteString(reportBaseCSS)
+	if extraCSS != "" {
+		b.WriteString("\n")
+		b.WriteString(extraCSS)
+	}
+	b.WriteString("\n</style>\n</head><body>\n")
+	fmt.Fprintf(b, "<h1>%s</h1>\n", html.EscapeString(title))
+}
+
+// writeReportFoot closes the document, optionally emitting a trailing note
+// and a script block. The note is escaped; the script is not, since it is
+// always a package constant rather than anything derived from a record.
+func writeReportFoot(b *strings.Builder, note, script string) {
+	if note != "" {
+		fmt.Fprintf(b, "<p class=\"note\">%s</p>\n", html.EscapeString(note))
+	}
+	if script != "" {
+		b.WriteString(script)
+	}
+	b.WriteString("</body></html>\n")
+}
+
+// csvReport renders a header and rows to CSV text. Writing to a
+// strings.Builder cannot fail, so the per-write errors are discarded and only
+// the deferred Flush error would be meaningful; it too can only surface an
+// underlying writer failure that a Builder never produces.
+func csvReport(header []string, rows [][]string) string {
+	var sb strings.Builder
+	w := csv.NewWriter(&sb)
+	_ = w.Write(header)
+	for _, row := range rows {
+		_ = w.Write(row)
+	}
+	w.Flush()
+	return sb.String()
+}
+
+// reportFile wraps report text as a Discord attachment.
+func reportFile(name, contentType, body string) *discordgo.File {
+	return &discordgo.File{
+		Name:        name,
+		ContentType: contentType,
+		Reader:      strings.NewReader(body),
+	}
+}

--- a/commands/vii.go
+++ b/commands/vii.go
@@ -1,0 +1,979 @@
+package commands
+
+// Veteran Rank Retention (Ch.4 §VII) analysis engine.
+//
+// Ported from the author's internal veteran-rank-retention audit tool
+// (private). Thresholds and billet tables follow 7CAV-R-023 and the wiki
+// Rank Promotion & Reduction Guidelines billet/rank tables. Determines whether a member is
+// eligible to be restored to a previously-held rank in an appropriate billet,
+// as an ALTERNATIVE path to the standard promotion ladder: standard TIG/TIS
+// is waived, the proposal process still applies.
+//
+// The source engine's display-only extras (ops/class counts, service-medal lists,
+// retirement eligibility check, secondary-billet retirement credit) are not
+// ported; this file covers the eligibility determination only.
+//
+// Behavioral fidelity notes: regexes, check ordering, and threshold constants
+// are transcribed 1:1 from the source; where the source had quirks (e.g. the
+// rank-parse regex only matching single-digit grades, so "(O-11)" never
+// parses) those quirks are preserved deliberately, since this engine's outputs
+// were validated against real milpac records in production use, and "fixing"
+// a quirk here would desync the two implementations.
+//
+// Two deliberate deviations from the source, per S1 clarification of the
+// policy (2026-07-23, smoke-test review):
+//   - Eligibility is GATED on a qualifying departure: an actual retirement,
+//     or a reserve transfer made while retirement-eligible. The source
+//     computed this ("Qualifies") but surfaced it as context only, which
+//     flagged members who never departed or who left to reserves before
+//     reaching retirement eligibility.
+//   - Departmental (staff) service counts toward the retirement timer,
+//     including service rendered while in the Reserves (see computeService).
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/7cav/cavbot2/utils"
+)
+
+const (
+	viiConsecDays = 730  // 2y consecutive TIS for a qualifying reserve departure
+	viiTotalDays  = 1095 // or 3y total
+)
+
+// billetCeiling is the authorised maximum rank for a billet, transcribed
+// from the "Billet Minimum / Maximum Rank Tables" (Ch.4 §II) and "Department
+// Staff" (Ch.4 §III) tables of 7CAV-R-023:
+// https://wiki.7cav.us/wiki/Rank_Promotion_and_Reduction_Guidelines
+// Verified against revision 17274 (last modified 24OCT24). An empty string
+// means R-023 defines no ceiling for that track, which is different from a
+// ceiling of zero: the §VII engine treats it as "cannot rate anyone here".
+//
+// Only Enlisted and Officer are read. Warrant is carried because R-023 states
+// the maxima as pairs ("SGT / CW2", "SSG / CW3") and dropping half the table
+// would make it harder to check against the source, but the engine never
+// consults it: viiW2E normalises a warrant rank to its NCO equivalent before
+// any comparison, so a warrant officer is measured against the Enlisted
+// ceiling. Correcting a Warrant value therefore changes nothing, since the
+// behaviour lives in viiW2E and the Enlisted column.
+//
+// Minimum ranks are deliberately not modelled. R-023 gives them, but they
+// govern whether someone may be *assigned* a billet, which is S1's business
+// at assignment time, not whether an already-assigned member is promotable.
+type billetCeiling struct {
+	Enlisted string
+	Warrant  string
+	Officer  string
+}
+
+var viiBilletCeiling = map[string]billetCeiling{
+	// line NCO/warrant
+	"MEMBER":    {Enlisted: "CPL", Warrant: "WO1"},
+	"ASL":       {Enlisted: "SGT", Warrant: "CW2"},
+	"SL":        {Enlisted: "SSG", Warrant: "CW3"},
+	"PSG":       {Enlisted: "MSG", Warrant: "CW5"},
+	"FIRST_SGT": {Enlisted: "1SG"},
+	"BN_SGM":    {Enlisted: "SGM"},
+	// staff / department
+	"SUBDEPT_CLERK":  {Enlisted: "CPL"},
+	"SUBDEPT_SENIOR": {Enlisted: "SGT"},
+	"SUBDEPT_LEAD":   {Enlisted: "SSG", Warrant: "CW3"},
+	"DEVCOM_LEAD":    {Enlisted: "MSG", Officer: "CPT"},
+	"DEPT2IC":        {Enlisted: "SFC", Warrant: "CW4", Officer: "CPT"},
+	"DEPT1IC":        {Enlisted: "MSG", Warrant: "CW5", Officer: "MAJ"},
+	// R-023 lists Regimental Aide as MSG/LTC with no warrant grade; the
+	// unread Warrant column is left empty here to match the source exactly.
+	"REGT_AIDE": {Enlisted: "MSG", Officer: "LTC"},
+	// officer command
+	"PL":    {Officer: "1LT"},
+	"CO_XO": {Officer: "MAJ"},
+	"CO":    {Officer: "MAJ"},
+	"BN_XO": {Officer: "LTC"},
+	"BN_CO": {Officer: "COL"},
+}
+
+// Warrant ⇄ NCO interchangeability: a warrant rank is the same LEVEL as its
+// NCO equivalent, so all rank math runs on the unified enlisted scale.
+var viiW2E = map[string]string{"WO1": "CPL", "CW2": "SGT", "CW3": "SSG", "CW4": "SFC", "CW5": "MSG"}
+var viiE2W = map[string]string{"CPL": "WO1", "SGT": "CW2", "SSG": "CW3", "SFC": "CW4", "MSG": "CW5"}
+
+var (
+	viiStaffRe     = regexp.MustCompile(`(?i)\bS\d\b|\bRRD\b|\bSPD\b|\bRTC\b|Recruit Training Command|NCOA|\bMP\b|Military Police|\bAide\b|\bClerk\b|Analyst|Investigator|Recruiter|Instructor|Coordinator|\b1IC\b|\b2IC\b|Operations|Department|Center of Excellence|Forum|Social Media|Publisher|Public Relations|\bStaff\b|\bLead\b|\bSenior\b|Technical|\bWAG\b`)
+	viiNonBilletRe = regexp.MustCompile(`(?i)\bBoot Camp\b|\bReserves?\b|\bReservist\b|\bELOA\b`)
+	viiAviatorRe   = regexp.MustCompile(`(?i)Aviator Badge`)
+	viiMosAvnRe    = regexp.MustCompile(`^15`)
+)
+
+// viiBilletType classifies a role into "staff" or "line"; "" means the role
+// is not a billet at all (Boot Camp / Reserves / ELOA) and doesn't count as
+// holding a rank in any billet type.
+func viiBilletType(role string) string {
+	if role == "" {
+		return ""
+	}
+	if viiNonBilletRe.MatchString(role) {
+		return ""
+	}
+	if viiStaffRe.MatchString(role) {
+		return "staff"
+	}
+	return "line"
+}
+
+func viiIsAviation(profile *utils.ProfileResponse) bool {
+	return viiMosAvnRe.MatchString(strings.TrimSpace(profile.Mos))
+}
+
+func viiHasWings(profile *utils.ProfileResponse) bool {
+	for _, a := range profile.Awards {
+		if viiAviatorRe.MatchString(a.AwardName) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Rank model
+// ---------------------------------------------------------------------------
+
+type viiRank struct {
+	Short string
+	Full  string
+	Order int
+}
+
+type viiRankModel struct {
+	byShort  map[string]*viiRank
+	byNameLc map[string]*viiRank
+	// names sorted longest-first for suffix matching in resolveName
+	sortedNames []string
+	nameAliases map[string]string
+	all         []*viiRank
+}
+
+// buildRankModel indexes the /milpacs/ranks reference list. Mirrors the source
+// buildRankModel: filters the Tester rank, aliases 1st/2nd lieutenant, and
+// exposes level() on the unified enlisted scale.
+func buildRankModel(resp *utils.RanksResponse) *viiRankModel {
+	m := &viiRankModel{
+		byShort:     map[string]*viiRank{},
+		byNameLc:    map[string]*viiRank{},
+		nameAliases: map[string]string{"1st lieutenant": "first lieutenant", "2nd lieutenant": "second lieutenant"},
+	}
+	for _, r := range resp.Ranks {
+		if r.RankShort == "Tester" {
+			continue
+		}
+		o := &viiRank{Short: r.RankShort, Full: r.RankFull, Order: r.RankDisplayOrder}
+		m.byShort[o.Short] = o
+		m.byNameLc[strings.ToLower(o.Full)] = o
+		m.all = append(m.all, o)
+	}
+	for n := range m.byNameLc {
+		m.sortedNames = append(m.sortedNames, n)
+	}
+	for a := range m.nameAliases {
+		m.sortedNames = append(m.sortedNames, a)
+	}
+	sort.Slice(m.sortedNames, func(a, b int) bool { return len(m.sortedNames[a]) > len(m.sortedNames[b]) })
+	return m
+}
+
+// resolveName resolves a rank phrase to a rank by longest-suffix match, the
+// same way the source resolveName does.
+func (m *viiRankModel) resolveName(phrase string) *viiRank {
+	p := strings.ToLower(strings.TrimSpace(phrase))
+	for _, n := range m.sortedNames {
+		if p == n || strings.HasSuffix(p, " "+n) || strings.HasSuffix(p, n) {
+			canonical := n
+			if alias, ok := m.nameAliases[n]; ok {
+				canonical = alias
+			}
+			return m.byNameLc[canonical]
+		}
+	}
+	return nil
+}
+
+// enlEquiv maps a warrant rank to its NCO equivalent (else unchanged).
+func (m *viiRankModel) enlEquiv(rk *viiRank) *viiRank {
+	if rk == nil {
+		return nil
+	}
+	if e, ok := viiW2E[rk.Short]; ok {
+		if er, ok := m.byShort[e]; ok {
+			return er
+		}
+	}
+	return rk
+}
+
+// level is the unified (enlisted-scale) display order used for ALL
+// comparisons; lower = more senior. Returns (0, false) when unknown.
+func (m *viiRankModel) level(rk *viiRank) (int, bool) {
+	e := m.enlEquiv(rk)
+	if e == nil {
+		return 0, false
+	}
+	return e.Order, true
+}
+
+// viiTrackOf classifies a display order: officer <=110, warrant <=140, else
+// enlisted. Thresholds match the production display-order spacing the source tool
+// was built against.
+func viiTrackOf(order int) string {
+	if order <= 110 {
+		return "officer"
+	}
+	if order <= 140 {
+		return "warrant"
+	}
+	return "enlisted"
+}
+
+// ---------------------------------------------------------------------------
+// Record parsing
+// ---------------------------------------------------------------------------
+
+// viiRankRecordRe extracts "<Rank Name> (E-6)"-style rank mentions. Grade
+// suffix is a single digit, as in the source (see fidelity note in file header).
+var viiRankRecordRe = regexp.MustCompile(`([A-Za-z][A-Za-z0-9 ]*?)\s*\([EOW]-?\d\)`)
+var viiEligibleSplitRe = regexp.MustCompile(`(?i)\beligible\b`)
+
+// rankFromRecord returns the LAST resolvable rank mentioned before any
+// "eligible" clause, because promotion records read "Promoted to X (E-n)".
+func rankFromRecord(text string, m *viiRankModel) *viiRank {
+	if loc := viiEligibleSplitRe.FindStringIndex(text); loc != nil {
+		text = text[:loc[0]]
+	}
+	var last *viiRank
+	for _, match := range viiRankRecordRe.FindAllStringSubmatch(text, -1) {
+		if r := m.resolveName(match[1]); r != nil {
+			last = r
+		}
+	}
+	return last
+}
+
+var (
+	// Unit path = uppercase/digit codes only (e.g. A/1/A/1-7) so a role name
+	// containing a slash ("Pilot/Gunner") is NOT mistaken for a unit.
+	viiUnitPathRe = regexp.MustCompile(`\b[A-Z0-9]+(?:/[A-Z0-9-]+)+\b`)
+	viiTrailRe    = regexp.MustCompile(`(?i)\s+(?:Reserves?|Reservist|Boot Camp|RTC(?: DCS)?|DCS RTC|DEVCOM)\.?$`)
+	viiTrailOfRe  = regexp.MustCompile(`(?i)\s+of$`)
+	viiSpacesRe   = regexp.MustCompile(`\s{2,}`)
+
+	viiAddlDutyRe    = regexp.MustCompile(`(?i)as Additional Duty`)
+	viiTransAssignRe = regexp.MustCompile(`(?i)Transferred and Assigned\s+(.+)$`)
+	viiReassignRe    = regexp.MustCompile(`(?i)Reassigned to\s+(.+)$`)
+	viiAssignRe      = regexp.MustCompile(`(?i)\bAssigned\s+(.+)$`)
+	viiBilletSplitRe = regexp.MustCompile(`(?i),| in Lieu| as Additional Duty`)
+	viiPrimaryMoveRe = regexp.MustCompile(`(?i)Transferred and Assigned|Reassigned to`)
+	viiRelievedRe    = regexp.MustCompile(`(?i)Relieved of Duties`)
+)
+
+func normalizeRole(t string) string {
+	if t == "" {
+		return ""
+	}
+	t = strings.TrimSpace(t)
+	t = strings.TrimSuffix(t, ".")
+	if loc := viiUnitPathRe.FindStringIndex(t); loc != nil {
+		t = strings.TrimSpace(t[:loc[0]])
+	} else {
+		t = strings.TrimSpace(viiTrailRe.ReplaceAllString(t, ""))
+	}
+	t = viiTrailOfRe.ReplaceAllString(t, "")
+	t = strings.TrimSuffix(t, ",")
+	t = viiSpacesRe.ReplaceAllString(t, " ")
+	return strings.TrimSpace(t)
+}
+
+// capturedBillet extracts the assigned role from any assignment record,
+// additional-duty or not. Used directly by the retirement-timer walk, where a
+// secondary departmental duty still counts as departmental service.
+func capturedBillet(t string) string {
+	var captured string
+	if m := viiTransAssignRe.FindStringSubmatch(t); m != nil {
+		captured = m[1]
+	} else if m := viiReassignRe.FindStringSubmatch(t); m != nil {
+		captured = m[1]
+	} else if m := viiAssignRe.FindStringSubmatch(t); m != nil {
+		captured = m[1]
+	} else {
+		return ""
+	}
+	if loc := viiBilletSplitRe.FindStringIndex(captured); loc != nil {
+		captured = captured[:loc[0]]
+	}
+	return normalizeRole(strings.TrimSpace(captured))
+}
+
+// billetFromRecord extracts the PRIMARY billet from a record. Pure
+// additional-duty assignments don't change the primary billet.
+func billetFromRecord(t string) string {
+	if viiAddlDutyRe.MatchString(t) && !regexp.MustCompile(`(?i)Transferred and Assigned`).MatchString(t) {
+		return ""
+	}
+	return capturedBillet(t)
+}
+
+var viiBattalionRe = regexp.MustCompile(`(?i)battalion|\b\d-7\b`)
+
+type canonRule struct {
+	re  *regexp.Regexp
+	key string
+}
+
+// Ordered: 1IC/2IC before generic Senior/Lead; ASL before SL; "platoon
+// commander" resolves PL before the bare "commander" check resolves CO.
+var viiCanonRules = []canonRule{
+	{regexp.MustCompile(`(?i)sergeant major`), "BN_SGM"},
+	{regexp.MustCompile(`(?i)first sergeant`), "FIRST_SGT"},
+	{regexp.MustCompile(`(?i)platoon sergeant`), "PSG"},
+	{regexp.MustCompile(`(?i)assistant (?:section|squad) leader`), "ASL"},
+	{regexp.MustCompile(`(?i)(?:section|squad) leader`), "SL"},
+	{regexp.MustCompile(`(?i)platoon (?:leader|commander)`), "PL"},
+	{regexp.MustCompile(`(?i)\b1ic\b|1 ?ic`), "DEPT1IC"},
+	{regexp.MustCompile(`(?i)\b2ic\b`), "DEPT2IC"},
+	{regexp.MustCompile(`(?i)regimental aide|\baide\b`), "REGT_AIDE"},
+	{regexp.MustCompile(`(?i)devcom lead`), "DEVCOM_LEAD"},
+	{regexp.MustCompile(`(?i)\bsenior\b`), "SUBDEPT_SENIOR"},
+	{regexp.MustCompile(`(?i)\blead\b`), "SUBDEPT_LEAD"},
+	{regexp.MustCompile(`(?i)\bclerk\b`), "SUBDEPT_CLERK"},
+}
+
+var (
+	viiXORe = regexp.MustCompile(`(?i)executive officer|company xo|\bxo\b`)
+	viiCORe = regexp.MustCompile(`(?i)commander|commanding officer|company co\b`)
+)
+
+// canonicalBillet maps a normalized role to a billet-ceiling key.
+func canonicalBillet(role string) string {
+	if role == "" {
+		return "MEMBER"
+	}
+	bn := viiBattalionRe.MatchString(role)
+	for _, rule := range viiCanonRules {
+		if rule.re.MatchString(role) {
+			return rule.key
+		}
+	}
+	if viiXORe.MatchString(role) {
+		if bn {
+			return "BN_XO"
+		}
+		return "CO_XO"
+	}
+	if viiCORe.MatchString(role) {
+		if bn {
+			return "BN_CO"
+		}
+		return "CO"
+	}
+	if viiStaffRe.MatchString(role) {
+		return "SUBDEPT_CLERK"
+	}
+	return "MEMBER"
+}
+
+// ---------------------------------------------------------------------------
+// Service + discipline history
+// ---------------------------------------------------------------------------
+
+var (
+	viiRetiredRe   = regexp.MustCompile(`(?i)Retired from the .*?(?:Cavalry|Calvary)`)
+	viiDowngradeRe = regexp.MustCompile(`(?i)Retirement (?:status )?downgraded`)
+	viiInLieuRe    = regexp.MustCompile(`(?i)in Lieu of Retirement`)
+	// viiMemorialRe matches death/memorial departures (RIP, Arlington, Wall of
+	// Honor). Like retirement and discharge, these drop all billets and end
+	// service. Shared with /billetaudit.
+	viiMemorialRe   = regexp.MustCompile(`(?i)Wall of Honor|Arlington|Rest in Peace|\bRIP\b|Killed in Action|\bKIA\b|In Memoriam|passed away`)
+	viiEnlistRe     = regexp.MustCompile(`(?i)Enlisted in the .*?(?:Cavalry|Calvary)`)
+	viiReinstateRe  = regexp.MustCompile(`(?i)Reinstated`)
+	viiDischargeRe  = regexp.MustCompile(`(?i)Discharge`)
+	viiUpgradeRe    = regexp.MustCompile(`(?i)Upgrade`)
+	viiEloaStartRe  = regexp.MustCompile(`(?i)Placed on ELOA`)
+	viiEloaEndRe    = regexp.MustCompile(`(?i)Returned from ELOA`)
+	viiReserveRe    = regexp.MustCompile(`(?i)Reserv`)
+	viiToReservesRe = regexp.MustCompile(`(?i)Transferred (?:and|to).*Reserv|Assigned Reserv`)
+)
+
+type viiRecord struct {
+	Date string // YYYY-MM-DD
+	Text string
+	Type string
+}
+
+type viiDeparture struct {
+	Date       string
+	Type       string // "retire" | "reserve"
+	ConsecDays int
+	TotalDays  int
+	Text       string
+}
+
+type viiService struct {
+	Departures   []viiDeparture
+	TotalActive  int
+	CurrentConse int
+}
+
+func daysBetweenISO(a, b string) int {
+	ta, errA := time.Parse("2006-01-02", a)
+	tb, errB := time.Parse("2006-01-02", b)
+	if errA != nil || errB != nil {
+		return 0
+	}
+	return int(tb.Sub(ta).Hours() / 24)
+}
+
+func addDaysISO(d string, n int) string {
+	t, err := time.Parse("2006-01-02", d)
+	if err != nil {
+		return d
+	}
+	return t.AddDate(0, 0, n).Format("2006-01-02")
+}
+
+// computeService replays the record stream through the enlistment state
+// machine (active / eloa / reserve / out), accumulating service spans (ELOA
+// time paused) and recording departures with the TIS held at that moment.
+//
+// Departmental service counts toward the retirement timer (S1 clarification,
+// 2026-07-23): a reserve transfer while holding a departmental (staff) duty
+// records a departure snapshot but leaves the span running; the deferred
+// departure is recorded when the departmental duty ends. A staff duty picked
+// up while already in the Reserves opens a fresh span. Staff tracking uses
+// capturedBillet (not billetFromRecord): secondary departmental duties count.
+func computeService(recs []viiRecord, asOf string) viiService {
+	status := "out"
+	enlistStart := ""
+	eloaPause := 0
+	eloaStart := ""
+	totalPrior := 0
+	staffRole := ""
+	var departures []viiDeparture
+
+	// peekSpan reports (consecutive, total) days as of d without closing the
+	// open span; closeSpan folds the span into totalPrior and resets.
+	peekSpan := func(d string) (int, int) {
+		if enlistStart == "" {
+			return 0, totalPrior
+		}
+		p := eloaPause
+		if status == "eloa" && eloaStart != "" {
+			p += daysBetweenISO(eloaStart, d)
+		}
+		c := daysBetweenISO(enlistStart, d) - p
+		if c < 0 {
+			c = 0
+		}
+		return c, totalPrior + c
+	}
+	closeSpan := func(d string) int {
+		c, _ := peekSpan(d)
+		if enlistStart == "" {
+			return 0
+		}
+		totalPrior += c
+		enlistStart, eloaPause, eloaStart = "", 0, ""
+		return c
+	}
+
+	for _, r := range recs {
+		t, d := r.Text, r.Date
+		toReserve := viiReserveRe.MatchString(t)
+		deptActive := viiBilletType(staffRole) == "staff"
+		switch {
+		case viiEnlistRe.MatchString(t) || (viiReinstateRe.MatchString(t) && !toReserve):
+			if status != "active" {
+				status = "active"
+				// A span already open (reserve + departmental duty) continues
+				// uninterrupted, because departmental service was still service.
+				if enlistStart == "" {
+					enlistStart = d
+					eloaPause, eloaStart = 0, ""
+				}
+			}
+		case viiReinstateRe.MatchString(t) && toReserve:
+			closeSpan(d)
+			status = "reserve"
+		case viiEloaStartRe.MatchString(t):
+			if status == "active" {
+				status = "eloa"
+				eloaStart = d
+			}
+		case viiEloaEndRe.MatchString(t):
+			if status == "eloa" && eloaStart != "" {
+				eloaPause += daysBetweenISO(eloaStart, d)
+				eloaStart = ""
+			}
+			status = "active"
+			if enlistStart == "" {
+				enlistStart = d
+			}
+		case viiRetiredRe.MatchString(t) && !viiInLieuRe.MatchString(t):
+			c := closeSpan(d)
+			departures = append(departures, viiDeparture{Date: d, Type: "retire", ConsecDays: c, TotalDays: totalPrior, Text: t})
+			status = "out"
+		case viiToReservesRe.MatchString(t):
+			c, tot := peekSpan(d)
+			departures = append(departures, viiDeparture{Date: d, Type: "reserve", ConsecDays: c, TotalDays: tot, Text: t})
+			if !deptActive {
+				closeSpan(d)
+			}
+			status = "reserve"
+		case viiDischargeRe.MatchString(t) && !viiDowngradeRe.MatchString(t) && !viiUpgradeRe.MatchString(t):
+			closeSpan(d)
+			status = "out"
+		case viiMemorialRe.MatchString(t):
+			closeSpan(d)
+			status = "out"
+		}
+
+		// Staff-duty tracking (after the state switch: the transfer cases read
+		// the pre-record duty state). Only real billets update the single duty
+		// slot; a non-billet capture like "Reserves" leaves a continuing
+		// departmental duty in place (dept members are routinely reservists).
+		// A relief clears the slot; so does any billet-dropping departure
+		// (retirement, discharge, death); otherwise a pre-departure duty
+		// would leak into a later reserve span and inflate the timer.
+		switch {
+		case viiRetiredRe.MatchString(t) && !viiInLieuRe.MatchString(t),
+			viiDischargeRe.MatchString(t) && !viiDowngradeRe.MatchString(t) && !viiUpgradeRe.MatchString(t),
+			viiMemorialRe.MatchString(t),
+			viiRelievedRe.MatchString(t):
+			staffRole = ""
+		default:
+			if b := capturedBillet(t); b != "" && viiBilletType(b) != "" {
+				staffRole = b
+			}
+		}
+		// While in the Reserves, departmental service keeps the timer running:
+		// picking up a staff duty opens a span, losing it closes the span and
+		// records the deferred reserve departure.
+		nowDept := viiBilletType(staffRole) == "staff"
+		if status == "reserve" {
+			if nowDept && enlistStart == "" {
+				enlistStart, eloaPause, eloaStart = d, 0, ""
+			} else if !nowDept && enlistStart != "" {
+				c := closeSpan(d)
+				departures = append(departures, viiDeparture{Date: d, Type: "reserve", ConsecDays: c, TotalDays: totalPrior, Text: t})
+			}
+		}
+	}
+
+	cur := 0
+	if enlistStart != "" {
+		p := eloaPause
+		if status == "eloa" && eloaStart != "" {
+			p += daysBetweenISO(eloaStart, asOf)
+		}
+		cur = daysBetweenISO(enlistStart, asOf) - p
+		if cur < 0 {
+			cur = 0
+		}
+	}
+	return viiService{Departures: departures, TotalActive: totalPrior + cur, CurrentConse: cur}
+}
+
+var (
+	viiDiscRe       = regexp.MustCompile(`(?i)Letter of Reprimand|Negative Counsell?ing|No Favorable Action|\bNFA\b|Article\s*\d`)
+	viiArticleRe    = regexp.MustCompile(`(?i)Article\s*(?:15|32|\d+)`)
+	viiNoNFARe      = regexp.MustCompile(`(?i)No(?:t)?\s+(?:Additional\s+)?NFA|No Favorable Action`)
+	viiNFADaysRe    = regexp.MustCompile(`(?i)(\d+)\s*Days?\s*(?:NFA|No Favorable Action)`)
+	viiNFAForRe     = regexp.MustCompile(`(?i)No Favorable Action for\s*(\d+)\s*Days?`)
+	viiHasNFADaysRe = regexp.MustCompile(`(?i)\d+\s*Days?\s*NFA`)
+	viiDeferredRe   = regexp.MustCompile(`(?i)to be served on re-?enlistment`)
+)
+
+type viiDiscipline struct {
+	Date      string
+	NFADays   int
+	IsArticle bool
+	Deferred  bool
+	Text      string
+}
+
+func parseDiscipline(recs []viiRecord) []viiDiscipline {
+	var out []viiDiscipline
+	for _, r := range recs {
+		t := r.Text
+		isDisc := r.Type == "RECORD_TYPE_DISCIPLINARY" || viiDiscRe.MatchString(t)
+		if !isDisc {
+			continue
+		}
+		nfaDays := 0
+		// "No NFA" / bare "No Favorable Action" (without a day count) = zero;
+		// Go's regexp has no lookahead, so the source (?!\s+for) is expressed as
+		// "matches the no-NFA phrasing AND has no explicit day count".
+		bareNoNFA := viiNoNFARe.MatchString(t) && !viiNFAForRe.MatchString(t) && !viiHasNFADaysRe.MatchString(t)
+		if !bareNoNFA {
+			if m := viiNFADaysRe.FindStringSubmatch(t); m != nil {
+				nfaDays, _ = strconv.Atoi(m[1]) // regex guarantees digits
+			} else if m := viiNFAForRe.FindStringSubmatch(t); m != nil {
+				nfaDays, _ = strconv.Atoi(m[1]) // regex guarantees digits
+			}
+		}
+		out = append(out, viiDiscipline{
+			Date:      r.Date,
+			NFADays:   nfaDays,
+			IsArticle: viiArticleRe.MatchString(t),
+			Deferred:  viiDeferredRe.MatchString(t),
+			Text:      t,
+		})
+	}
+	return out
+}
+
+func activeNFAAt(dl []viiDiscipline, date string) bool {
+	for _, d := range dl {
+		if d.NFADays > 0 && !d.Deferred && d.Date <= date && date < addDaysISO(d.Date, d.NFADays) {
+			return true
+		}
+	}
+	return false
+}
+
+func articleWithinYear(dl []viiDiscipline, date string) bool {
+	for _, d := range dl {
+		diff := daysBetweenISO(d.Date, date)
+		if d.IsArticle && diff >= 0 && diff <= 365 {
+			return true
+		}
+	}
+	return false
+}
+
+func viiMeetsTIS(consec, total int) bool {
+	return consec >= viiConsecDays || total >= viiTotalDays
+}
+
+func retEligibleAt(consec, total int, dl []viiDiscipline, date string) bool {
+	return viiMeetsTIS(consec, total) && !activeNFAAt(dl, date) && !articleWithinYear(dl, date)
+}
+
+// ---------------------------------------------------------------------------
+// Eligibility walk
+// ---------------------------------------------------------------------------
+
+// viiResult is the eligibility verdict for one member. Trimmed to the fields
+// the bot needs; the source analyze also returns display-only context (ops/class
+// counts, medal lists, TIG/TIS strings) that has no consumer here.
+type viiResult struct {
+	// EligibleNow: the member has a qualifying departure (retirement, or a
+	// reserve transfer while retirement-eligible) AND a previously-held,
+	// more-senior rank fits the current billet's ceiling in the same billet
+	// type, with clean standing and no retirement downgrade.
+	EligibleNow bool
+	// Target is the restorable rank (warrant/NCO display equivalence
+	// applied). Nil unless a candidate rank was found.
+	Target *viiRank
+	// TargetHeldDate/Role: evidence of where/when the target rank was held.
+	TargetHeldDate     string
+	TargetHeldRole     string
+	TargetHeldSameRole bool
+	// PotentiallyEligible: a grantable rank exists but is held up by a
+	// retirement downgrade or standing block, or the billet has no ceiling
+	// in the table (manual review).
+	PotentiallyEligible bool
+	PotentialRank       *viiRank
+	Reasons             []string
+	// Qualifies: the member has a qualifying departure (retirement, or a
+	// reserve transfer while retirement-eligible). Gates EligibleNow and
+	// PotentiallyEligible, a deliberate deviation from the source, which
+	// carried this as context only (S1 clarification, 2026-07-23).
+	Qualifies  bool
+	Downgraded bool
+	Blocked    bool
+}
+
+// Reason joins Reasons for display.
+func (v viiResult) Reason() string { return strings.Join(v.Reasons, " ") }
+
+type viiHeld struct {
+	rank       *viiRank
+	types      map[string]bool
+	dateByType map[string]string
+	roleDate   map[string]string
+}
+
+// viiAnalyze ports the source analyze() eligibility path. asOf pins "today" for
+// standing checks, mirroring the /promo date filter.
+func viiAnalyze(profile *utils.ProfileResponse, m *viiRankModel, asOf time.Time) viiResult {
+	asOfISO := asOf.Format("2006-01-02")
+
+	recs := make([]viiRecord, 0, len(profile.Records))
+	for _, r := range profile.Records {
+		date := r.RecordDate
+		if len(date) > 10 {
+			date = date[:10]
+		}
+		if date == "" || r.RecordDetails == "" {
+			continue
+		}
+		recs = append(recs, viiRecord{Date: date, Text: r.RecordDetails, Type: r.RecordType})
+	}
+	// ISO dates sort lexically.
+	for i := 1; i < len(recs); i++ {
+		for j := i; j > 0 && recs[j].Date < recs[j-1].Date; j-- {
+			recs[j], recs[j-1] = recs[j-1], recs[j]
+		}
+	}
+
+	service := computeService(recs, asOfISO)
+	discipline := parseDiscipline(recs)
+
+	downgraded := false
+	downgradeText := ""
+	for _, r := range recs {
+		if viiDowngradeRe.MatchString(r.Text) {
+			downgraded = true
+			downgradeText = r.Text
+			break
+		}
+	}
+
+	// Qualifying departures gate §VII outright (S1 clarification, 2026-07-23):
+	// an actual retirement, or a reserve transfer made while
+	// retirement-eligible (reserves in lieu of retirement). No qualifying
+	// departure (including a "Returned from Retirement" with no parseable
+	// departure, where the held ranks can't be trusted either) means the
+	// veteran-retention path simply does not apply.
+	var qDeps []viiDeparture
+	for _, d := range service.Departures {
+		if d.Type == "retire" || (d.Type == "reserve" && retEligibleAt(d.ConsecDays, d.TotalDays, discipline, d.Date)) {
+			qDeps = append(qDeps, d)
+		}
+	}
+	qualifies := len(qDeps) > 0
+
+	// Walk records (billet BEFORE rank). Build held: for each rank LEVEL the
+	// member ever held, the set of billet TYPES it was held in. A rank counts
+	// as "earned in" a type if held in that type AT ANY TIME (CoC rule:
+	// promoted in staff but later serving at that rank in a line billet =
+	// line).
+	var running *viiRank
+	curRole := ""
+	held := map[int]*viiHeld{}
+
+	stamp := func(rk *viiRank, billetT, role, date string) {
+		if rk == nil || billetT == "" {
+			return
+		}
+		lvl, ok := m.level(rk)
+		if !ok {
+			return
+		}
+		h, exists := held[lvl]
+		if !exists {
+			h = &viiHeld{rank: rk, types: map[string]bool{}, dateByType: map[string]string{}, roleDate: map[string]string{}}
+			held[lvl] = h
+		}
+		h.types[billetT] = true
+		if date != "" {
+			if prev, ok := h.dateByType[billetT]; !ok || date < prev {
+				h.dateByType[billetT] = date // earliest at that rank in that type
+			}
+			if role != "" {
+				if prev, ok := h.roleDate[role]; !ok || date < prev {
+					h.roleDate[role] = date // ...and per billet role
+				}
+			}
+		}
+	}
+
+	for _, r := range recs {
+		b := billetFromRecord(r.Text)
+		// A primary billet changes only via "Transferred and Assigned" /
+		// "Reassigned to"; a bare "Assigned <staff role>" is a secondary
+		// department duty layered on the existing primary (a bare assign to a
+		// LINE billet, like boot-camp Trooper or First Sergeant, is still primary).
+		if b != "" {
+			if viiPrimaryMoveRe.MatchString(r.Text) || viiBilletType(b) == "line" {
+				curRole = b
+			}
+		} else if viiRelievedRe.MatchString(r.Text) && !viiAddlDutyRe.MatchString(r.Text) {
+			curRole = ""
+		}
+		if rk := rankFromRecord(r.Text, m); rk != nil {
+			running = rk
+		}
+		if running != nil {
+			stamp(running, viiBilletType(curRole), curRole, r.Date)
+		}
+	}
+
+	// Current rank; unknown shorts get a sentinel order that classifies as
+	// enlisted and outranks nothing (matches the source's order:999 fallback).
+	current := m.byShort[profile.Rank.RankShort]
+	if current == nil {
+		current = &viiRank{Short: profile.Rank.RankShort, Full: profile.Rank.RankFull, Order: 999}
+	}
+	aviation := viiIsAviation(profile)
+	wings := viiHasWings(profile)
+	isOfficer := viiTrackOf(current.Order) == "officer"
+	sameGroup := func(rk *viiRank) bool { return (viiTrackOf(rk.Order) == "officer") == isOfficer }
+	curLvl, curLvlOK := m.level(current)
+	if !curLvlOK {
+		curLvl = current.Order
+	}
+	role := normalizeRole(profile.Primary.PositionTitle)
+	key := canonicalBillet(role)
+	curType := viiBilletType(role)
+	if curType == "" {
+		curType = "line"
+	}
+	ceil := viiBilletCeiling[key]
+	ceilShort := ceil.Enlisted
+	if isOfficer {
+		ceilShort = ceil.Officer
+	}
+	ceilLvl := -1
+	if ceilShort != "" {
+		if cr, ok := m.byShort[ceilShort]; ok {
+			if l, ok := m.level(cr); ok {
+				ceilLvl = l
+			}
+		}
+	}
+
+	// Display a rank as a warrant rank when the member is CURRENTLY a warrant
+	// officer, or is an aviator with wings; otherwise the NCO equivalent.
+	expressWarrant := viiTrackOf(current.Order) == "warrant" || (aviation && wings)
+	dispRank := func(rk *viiRank) *viiRank {
+		if rk == nil {
+			return nil
+		}
+		e := m.enlEquiv(rk)
+		if expressWarrant {
+			if w, ok := viiE2W[e.Short]; ok {
+				if wr, ok := m.byShort[w]; ok {
+					return wr
+				}
+			}
+		}
+		return e
+	}
+
+	// Eligible rank = the most senior rank ACTUALLY HELD in the same billet
+	// type that the CURRENT billet rates (level between ceiling and current).
+	// No capping of a too-high rank; they must have held it; if the billet
+	// can't rate any held rank above their current one, they're INELIGIBLE.
+	type lvlEntry struct {
+		lvl int
+		h   *viiHeld
+	}
+	var higherSameType []lvlEntry
+	for lvl, h := range held {
+		if sameGroup(h.rank) && lvl < curLvl && h.types[curType] {
+			higherSameType = append(higherSameType, lvlEntry{lvl, h})
+		}
+	}
+	minBy := func(entries []lvlEntry) *lvlEntry {
+		if len(entries) == 0 {
+			return nil
+		}
+		best := &entries[0]
+		for i := range entries[1:] {
+			if entries[i+1].lvl < best.lvl {
+				best = &entries[i+1]
+			}
+		}
+		return best
+	}
+	hasHigherSameType := len(higherSameType) > 0
+
+	var targetRank *viiRank
+	targetHeldDate, targetHeldRole := "", ""
+	targetHeldSameRole := false
+	if ceilLvl >= 0 {
+		var withinCeil []lvlEntry
+		for _, e := range higherSameType {
+			if e.lvl >= ceilLvl {
+				withinCeil = append(withinCeil, e)
+			}
+		}
+		if fit := minBy(withinCeil); fit != nil {
+			targetRank = fit.h.rank
+			if d, ok := fit.h.roleDate[role]; ok {
+				targetHeldDate, targetHeldRole, targetHeldSameRole = d, role, true
+			} else {
+				bestRole, bestDate := "", ""
+				for rr, dd := range fit.h.roleDate {
+					if viiBilletType(rr) == curType && (bestDate == "" || dd < bestDate) {
+						bestRole, bestDate = rr, dd
+					}
+				}
+				targetHeldRole = bestRole
+				if bestDate != "" {
+					targetHeldDate = bestDate
+				} else {
+					targetHeldDate = fit.h.dateByType[curType]
+				}
+			}
+		}
+	}
+
+	blocked := activeNFAAt(discipline, asOfISO) || articleWithinYear(discipline, asOfISO)
+	eligibleNow := qualifies && targetRank != nil && !downgraded && !blocked
+
+	// Without a qualifying departure the member is not a returning veteran at
+	// all, with no "potentially eligible" reasons either.
+	var reasons []string
+	if qualifies && targetRank != nil && !eligibleNow {
+		if downgraded {
+			r := "Retirement was downgraded to an Honorable Discharge"
+			if downgradeText != "" {
+				r += fmt.Sprintf(" (%q)", downgradeText)
+			}
+			reasons = append(reasons, r+". Per CoC, eligibility is decided case-by-case.")
+		}
+		if blocked {
+			var parts []string
+			if activeNFAAt(discipline, asOfISO) {
+				parts = append(parts, "active NFA")
+			}
+			if articleWithinYear(discipline, asOfISO) {
+				parts = append(parts, "Article 15/32 within the last year")
+			}
+			reasons = append(reasons, fmt.Sprintf("Promotion blocked by %s; eligible once standing clears.", strings.Join(parts, " + ")))
+		}
+	} else if qualifies && targetRank == nil && ceilLvl < 0 && hasHigherSameType {
+		displayRole := role
+		if displayRole == "" {
+			displayRole = "unknown"
+		}
+		reasons = append(reasons, fmt.Sprintf("Current billet (%s) has no defined rank rating in the billet table; needs manual review.", displayRole))
+	}
+	potentiallyEligible := len(reasons) > 0
+	var potentialRank *viiRank
+	if potentiallyEligible {
+		pr := targetRank
+		if pr == nil {
+			pr = minBy(higherSameType).h.rank
+		}
+		potentialRank = dispRank(pr)
+	}
+
+	return viiResult{
+		EligibleNow:         eligibleNow,
+		Target:              dispRank(targetRank),
+		TargetHeldDate:      targetHeldDate,
+		TargetHeldRole:      targetHeldRole,
+		TargetHeldSameRole:  targetHeldSameRole,
+		PotentiallyEligible: potentiallyEligible,
+		PotentialRank:       potentialRank,
+		Reasons:             reasons,
+		Qualifies:           qualifies,
+		Downgraded:          downgraded,
+		Blocked:             blocked,
+	}
+}

--- a/commands/vii_test.go
+++ b/commands/vii_test.go
@@ -1,0 +1,551 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/7cav/cavbot2/utils"
+)
+
+// viiTestRanks builds a rank fixture with display orders consistent with the
+// production spacing viiTrackOf is tuned to: officers <=110, warrants
+// 111-140, enlisted >140.
+func viiTestRanks() *utils.RanksResponse {
+	return &utils.RanksResponse{Ranks: []utils.RankInfo{
+		{RankShort: "COL", RankFull: "Colonel", RankDisplayOrder: 60},
+		{RankShort: "LTC", RankFull: "Lieutenant Colonel", RankDisplayOrder: 70},
+		{RankShort: "MAJ", RankFull: "Major", RankDisplayOrder: 80},
+		{RankShort: "CPT", RankFull: "Captain", RankDisplayOrder: 90},
+		{RankShort: "1LT", RankFull: "First Lieutenant", RankDisplayOrder: 100},
+		{RankShort: "2LT", RankFull: "Second Lieutenant", RankDisplayOrder: 110},
+		{RankShort: "CW5", RankFull: "Chief Warrant Officer 5", RankDisplayOrder: 115},
+		{RankShort: "CW4", RankFull: "Chief Warrant Officer 4", RankDisplayOrder: 120},
+		{RankShort: "CW3", RankFull: "Chief Warrant Officer 3", RankDisplayOrder: 125},
+		{RankShort: "CW2", RankFull: "Chief Warrant Officer 2", RankDisplayOrder: 130},
+		{RankShort: "WO1", RankFull: "Warrant Officer 1", RankDisplayOrder: 135},
+		{RankShort: "MSG", RankFull: "Master Sergeant", RankDisplayOrder: 150},
+		{RankShort: "SFC", RankFull: "Sergeant First Class", RankDisplayOrder: 160},
+		{RankShort: "SSG", RankFull: "Staff Sergeant", RankDisplayOrder: 170},
+		{RankShort: "SGT", RankFull: "Sergeant", RankDisplayOrder: 180},
+		{RankShort: "CPL", RankFull: "Corporal", RankDisplayOrder: 190},
+		{RankShort: "SPC", RankFull: "Specialist", RankDisplayOrder: 195},
+		{RankShort: "PFC", RankFull: "Private First Class", RankDisplayOrder: 200},
+		{RankShort: "PVT", RankFull: "Private", RankDisplayOrder: 210},
+		{RankShort: "Tester", RankFull: "Tester", RankDisplayOrder: 999},
+	}}
+}
+
+func viiModel() *viiRankModel { return buildRankModel(viiTestRanks()) }
+
+func viiRec(date, details string) utils.Record {
+	return utils.Record{RecordDate: date, RecordDetails: details, RecordType: "RECORD_TYPE_SERVICE"}
+}
+
+func TestBuildRankModel(t *testing.T) {
+	m := viiModel()
+	if _, ok := m.byShort["Tester"]; ok {
+		t.Error("Tester rank should be filtered")
+	}
+	if r := m.resolveName("Staff Sergeant"); r == nil || r.Short != "SSG" {
+		t.Errorf("resolveName(Staff Sergeant) = %+v", r)
+	}
+	// Longest-suffix matching: "Sergeant First Class" must not resolve as
+	// bare "Sergeant".
+	if r := m.resolveName("Sergeant First Class"); r == nil || r.Short != "SFC" {
+		t.Errorf("resolveName(Sergeant First Class) = %+v", r)
+	}
+	// Alias resolution.
+	if r := m.resolveName("1st Lieutenant"); r == nil || r.Short != "1LT" {
+		t.Errorf("resolveName(1st Lieutenant) = %+v", r)
+	}
+	if r := m.resolveName("Grand Poobah"); r != nil {
+		t.Errorf("resolveName(Grand Poobah) = %+v, want nil", r)
+	}
+	// Warrant/NCO unified level: CW3 sits at SSG's level.
+	cw3, ssg := m.byShort["CW3"], m.byShort["SSG"]
+	lvlW, _ := m.level(cw3)
+	lvlE, _ := m.level(ssg)
+	if lvlW != lvlE {
+		t.Errorf("level(CW3)=%d != level(SSG)=%d", lvlW, lvlE)
+	}
+}
+
+func TestRankFromRecord(t *testing.T) {
+	m := viiModel()
+	cases := []struct {
+		text string
+		want string // "" = nil
+	}{
+		{"Promoted to Staff Sergeant (E-6)", "SSG"},
+		{"Promoted to the rank of Corporal (E-4)", "CPL"},
+		{"Reduced to Private (E-2)", "PVT"},
+		// Last rank mentioned wins.
+		{"Reduced from Sergeant (E-5) to Corporal (E-4)", "CPL"},
+		// Text after "eligible" is ignored.
+		{"Promoted to Corporal (E-4), eligible for Sergeant (E-5)", "CPL"},
+		{"Assigned Rifleman 1/1/1/A", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.text, func(t *testing.T) {
+			got := rankFromRecord(tc.text, m)
+			gotShort := ""
+			if got != nil {
+				gotShort = got.Short
+			}
+			if gotShort != tc.want {
+				t.Errorf("rankFromRecord(%q) = %q, want %q", tc.text, gotShort, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeRoleAndBilletFromRecord(t *testing.T) {
+	if got := normalizeRole("Section Leader 1/1/A/ACD"); got != "Section Leader" {
+		t.Errorf("normalizeRole unit strip = %q", got)
+	}
+	if got := normalizeRole("S1 Clerk Reserves"); got != "S1 Clerk" {
+		t.Errorf("normalizeRole trail strip = %q", got)
+	}
+	// A slash inside a role name is not a unit path.
+	if got := normalizeRole("Pilot/Gunner"); got != "Pilot/Gunner" {
+		t.Errorf("normalizeRole role-slash = %q", got)
+	}
+
+	cases := []struct {
+		text string
+		want string
+	}{
+		{"Transferred and Assigned Section Leader 1/1/A/ACD", "Section Leader"},
+		{"Reassigned to Platoon Sergeant 1/A/ACD", "Platoon Sergeant"},
+		{"Assigned Rifleman 1/1/1/A", "Rifleman"},
+		// Pure additional duty doesn't change the primary billet.
+		{"Assigned S1 Clerk as Additional Duty", ""},
+		{"Promoted to Corporal (E-4)", ""},
+	}
+	for _, tc := range cases {
+		if got := billetFromRecord(tc.text); got != tc.want {
+			t.Errorf("billetFromRecord(%q) = %q, want %q", tc.text, got, tc.want)
+		}
+	}
+}
+
+func TestCanonicalBilletAndType(t *testing.T) {
+	cases := []struct {
+		role string
+		want string
+	}{
+		{"", "MEMBER"},
+		{"Rifleman", "MEMBER"},
+		{"Assistant Section Leader", "ASL"},
+		{"Section Leader", "SL"},
+		{"Squad Leader", "SL"},
+		{"Platoon Sergeant", "PSG"},
+		{"First Sergeant", "FIRST_SGT"},
+		{"Battalion Sergeant Major", "BN_SGM"},
+		{"Platoon Leader", "PL"},
+		{"Platoon Commander", "PL"}, // must not fall through to CO
+		{"Company Commander", "CO"},
+		{"Battalion Commander", "BN_CO"},
+		{"Executive Officer", "CO_XO"},
+		{"Battalion Executive Officer", "BN_XO"},
+		{"S6 1IC", "DEPT1IC"},
+		{"S1 2IC", "DEPT2IC"},
+		{"Regimental Aide", "REGT_AIDE"},
+		{"S7 Senior Instructor", "SUBDEPT_SENIOR"},
+		{"S3 Lead", "SUBDEPT_LEAD"},
+		{"S1 Clerk", "SUBDEPT_CLERK"},
+		{"S5 Analyst", "SUBDEPT_CLERK"}, // generic staff → clerk tier
+	}
+	for _, tc := range cases {
+		if got := canonicalBillet(tc.role); got != tc.want {
+			t.Errorf("canonicalBillet(%q) = %q, want %q", tc.role, got, tc.want)
+		}
+	}
+
+	if got := viiBilletType("S1 Clerk"); got != "staff" {
+		t.Errorf("viiBilletType(S1 Clerk) = %q, want staff", got)
+	}
+	if got := viiBilletType("Section Leader"); got != "line" {
+		t.Errorf("viiBilletType(Section Leader) = %q, want line", got)
+	}
+	if got := viiBilletType("Reservist"); got != "" {
+		t.Errorf("viiBilletType(Reservist) = %q, want empty (non-billet)", got)
+	}
+	if got := viiBilletType("Boot Camp"); got != "" {
+		t.Errorf("viiBilletType(Boot Camp) = %q, want empty (non-billet)", got)
+	}
+}
+
+func TestComputeService(t *testing.T) {
+	// Enlist 2020-01-01, 6mo ELOA in 2021, retire 2023-01-01 (3y calendar −
+	// ~181d ELOA), re-enlist 2025-01-01, still active at asOf 2026-01-01.
+	recs := []viiRecord{
+		{Date: "2020-01-01", Text: "Enlisted in the 7th Cavalry"},
+		{Date: "2021-01-01", Text: "Placed on ELOA"},
+		{Date: "2021-07-01", Text: "Returned from ELOA"},
+		{Date: "2023-01-01", Text: "Retired from the 7th Cavalry"},
+		{Date: "2025-01-01", Text: "Enlisted in the 7th Cavalry"},
+	}
+	s := computeService(recs, "2026-01-01")
+	if len(s.Departures) != 1 || s.Departures[0].Type != "retire" {
+		t.Fatalf("departures = %+v, want one retirement", s.Departures)
+	}
+	dep := s.Departures[0]
+	// 2020-01-01→2023-01-01 = 1096d minus 181d ELOA = 915d.
+	if dep.ConsecDays != 915 {
+		t.Errorf("retirement ConsecDays = %d, want 915", dep.ConsecDays)
+	}
+	if s.CurrentConse != 365 {
+		t.Errorf("CurrentConse = %d, want 365", s.CurrentConse)
+	}
+	if s.TotalActive != 915+365 {
+		t.Errorf("TotalActive = %d, want %d", s.TotalActive, 915+365)
+	}
+
+	// Reserve transfer records a "reserve" departure.
+	recs2 := []viiRecord{
+		{Date: "2020-01-01", Text: "Enlisted in the 7th Cavalry"},
+		{Date: "2022-06-01", Text: "Transferred and Assigned Reserves"},
+	}
+	s2 := computeService(recs2, "2026-01-01")
+	if len(s2.Departures) != 1 || s2.Departures[0].Type != "reserve" {
+		t.Fatalf("departures = %+v, want one reserve transfer", s2.Departures)
+	}
+}
+
+// Departmental service while in the Reserves keeps the retirement timer
+// running: the reserve transfer snapshots a departure, and losing the staff
+// duty later records the deferred departure with the dept months included.
+func TestComputeServiceDeptReserveTimer(t *testing.T) {
+	recs := []viiRecord{
+		{Date: "2023-01-01", Text: "Enlisted in the 7th Cavalry"},
+		{Date: "2023-06-01", Text: "Transferred and Assigned S6 Clerk"},
+		{Date: "2024-06-01", Text: "Transferred and Assigned Reserves"},
+		{Date: "2025-06-01", Text: "Relieved of Duties"},
+	}
+	s := computeService(recs, "2026-01-01")
+	if len(s.Departures) != 2 {
+		t.Fatalf("departures = %+v, want snapshot + deferred", s.Departures)
+	}
+	// Snapshot at the transfer: 2023-01-01→2024-06-01 = 517d (< 730, not yet
+	// retirement-eligible).
+	if s.Departures[0].ConsecDays != 517 || s.Departures[0].TotalDays != 517 {
+		t.Errorf("snapshot departure = %+v, want 517/517", s.Departures[0])
+	}
+	// Deferred at the relief: 2023-01-01→2025-06-01 = 882d, since the dept year in
+	// the Reserves counted, pushing past the 730d threshold.
+	if s.Departures[1].ConsecDays != 882 || s.Departures[1].Type != "reserve" {
+		t.Errorf("deferred departure = %+v, want reserve/882", s.Departures[1])
+	}
+	if s.TotalActive != 882 || s.CurrentConse != 0 {
+		t.Errorf("TotalActive/CurrentConse = %d/%d, want 882/0", s.TotalActive, s.CurrentConse)
+	}
+
+	// A line member (no staff duty) transferring to the Reserves stops the
+	// timer at the transfer, with no dept credit.
+	recsLine := []viiRecord{
+		{Date: "2023-01-01", Text: "Enlisted in the 7th Cavalry"},
+		{Date: "2023-06-01", Text: "Transferred and Assigned Rifleman 1/1/1/A"},
+		{Date: "2024-06-01", Text: "Transferred and Assigned Reserves"},
+	}
+	sLine := computeService(recsLine, "2026-01-01")
+	if len(sLine.Departures) != 1 {
+		t.Fatalf("line departures = %+v, want one", sLine.Departures)
+	}
+	if sLine.TotalActive != 517 {
+		t.Errorf("line TotalActive = %d, want 517 (timer stopped at transfer)", sLine.TotalActive)
+	}
+}
+
+// A departure (retirement/discharge/death) drops all billets: a staff duty
+// held before retirement must NOT leak into a later reserve span and keep the
+// timer running. Regression for the staff-duty-drop-on-departure rule.
+func TestComputeServiceDepartureDropsStaffDuty(t *testing.T) {
+	recs := []viiRecord{
+		{Date: "2020-01-01", Text: "Enlisted in the 7th Cavalry"},
+		{Date: "2020-02-01", Text: "Assigned S6 Clerk"},
+		{Date: "2023-01-01", Text: "Retired from the 7th Cavalry"},
+		// Returns with no new assignment; the S6 duty must NOT persist.
+		{Date: "2023-06-01", Text: "Enlisted in the 7th Cavalry"},
+		{Date: "2024-01-01", Text: "Transferred and Assigned Reserves"},
+	}
+	s := computeService(recs, "2026-01-01")
+	// Second span closes AT the reserve transfer (no dept duty to continue
+	// it), so nothing accrues after 2024-01-01.
+	if s.CurrentConse != 0 {
+		t.Errorf("CurrentConse = %d, want 0 (stale staff duty leaked past retirement)", s.CurrentConse)
+	}
+	// 1096 (first span) + 214 (return→reserve) = 1310; a leak would inflate
+	// this past 2000.
+	if s.TotalActive != 1310 {
+		t.Errorf("TotalActive = %d, want 1310", s.TotalActive)
+	}
+}
+
+func TestParseDisciplineAndStandingChecks(t *testing.T) {
+	recs := []viiRecord{
+		{Date: "2026-01-01", Text: "Letter of Reprimand issued, 90 Days NFA"},
+		{Date: "2024-01-01", Text: "Article 15 proceedings concluded"},
+		{Date: "2026-02-01", Text: "Negative Counselling, No Additional NFA"},
+		{Date: "2026-03-01", Text: "Letter of Reprimand, 30 Days NFA to be served on re-enlistment"},
+	}
+	dl := parseDiscipline(recs)
+	if len(dl) != 4 {
+		t.Fatalf("parsed %d discipline records, want 4", len(dl))
+	}
+	if dl[0].NFADays != 90 {
+		t.Errorf("NFADays = %d, want 90", dl[0].NFADays)
+	}
+	if !dl[1].IsArticle {
+		t.Error("Article 15 not flagged")
+	}
+	if dl[2].NFADays != 0 {
+		t.Errorf("'No Additional NFA' NFADays = %d, want 0", dl[2].NFADays)
+	}
+	if !dl[3].Deferred {
+		t.Error("deferred NFA not flagged")
+	}
+
+	// Active NFA window: [start, start+days).
+	if !activeNFAAt(dl, "2026-01-15") {
+		t.Error("expected active NFA on 2026-01-15")
+	}
+	if activeNFAAt(dl, "2026-04-01") {
+		t.Error("expected NFA expired by 2026-04-01")
+	}
+	// Deferred NFA never blocks.
+	if activeNFAAt([]viiDiscipline{dl[3]}, "2026-03-15") {
+		t.Error("deferred NFA should not be active")
+	}
+	if !articleWithinYear(dl, "2024-06-01") {
+		t.Error("expected article within a year of 2024-06-01")
+	}
+	if articleWithinYear(dl, "2026-01-01") {
+		t.Error("article from 2024 should be outside the 1y window in 2026")
+	}
+	// "No Favorable Action for N Days" phrasing also parses.
+	dl2 := parseDiscipline([]viiRecord{{Date: "2026-01-01", Text: "No Favorable Action for 45 Days"}})
+	if len(dl2) != 1 || dl2[0].NFADays != 45 {
+		t.Errorf("NFA-for phrasing parsed as %+v, want 45 days", dl2)
+	}
+}
+
+// --- analyze scenarios -----------------------------------------------------
+
+// viiVetProfile: enlisted 2019, made SSG as a line Section Leader, retired
+// with 2y+ TIS, returned 2026 as CPL in a Section Leader billet (SL rates
+// SSG). The §VII textbook case.
+func viiVetProfile() *utils.ProfileResponse {
+	return &utils.ProfileResponse{
+		User: utils.User{Username: "Vet.V"},
+		Rank: utils.Rank{RankShort: "CPL", RankFull: "Corporal"},
+		Primary: utils.Position{
+			PositionTitle: "Section Leader 1/1/A/ACD",
+		},
+		Records: []utils.Record{
+			viiRec("2019-01-01", "Enlisted in the 7th Cavalry"),
+			viiRec("2019-02-01", "Assigned Rifleman 1/1/1/A"),
+			viiRec("2020-01-01", "Promoted to Sergeant (E-5)"),
+			viiRec("2020-06-01", "Transferred and Assigned Section Leader 1/1/A/ACD"),
+			viiRec("2021-01-01", "Promoted to Staff Sergeant (E-6)"),
+			viiRec("2021-06-01", "Retired from the 7th Cavalry"),
+			viiRec("2026-01-01", "Returned from Retirement"),
+			viiRec("2026-01-01", "Enlisted in the 7th Cavalry"),
+			viiRec("2026-01-02", "Promoted to Corporal (E-4)"),
+			viiRec("2026-01-03", "Transferred and Assigned Section Leader 1/1/A/ACD"),
+		},
+	}
+}
+
+func TestViiAnalyzeEligibleVeteran(t *testing.T) {
+	a := viiAnalyze(viiVetProfile(), viiModel(), promoRefDate.UTC())
+	if !a.EligibleNow {
+		t.Fatalf("EligibleNow = false, want true (result %+v)", a)
+	}
+	if a.Target == nil || a.Target.Short != "SSG" {
+		t.Errorf("Target = %+v, want SSG", a.Target)
+	}
+	if !a.Qualifies {
+		t.Error("Qualifies = false, want true (retirement departure + return)")
+	}
+	if !a.TargetHeldSameRole {
+		t.Error("TargetHeldSameRole = false, want true (held SSG as Section Leader)")
+	}
+	if a.TargetHeldDate != "2021-01-01" {
+		t.Errorf("TargetHeldDate = %q, want 2021-01-01", a.TargetHeldDate)
+	}
+}
+
+// A member who never departed (rank reduction, continuous service) is not a
+// returning veteran, so §VII must not fire despite a held higher rank.
+// Regression: smoke test flagged a continuously-serving SGT who had held SSG.
+func TestViiAnalyzeNoDepartureNotEligible(t *testing.T) {
+	p := &utils.ProfileResponse{
+		User:    utils.User{Username: "Steady.S"},
+		Rank:    utils.Rank{RankShort: "SGT", RankFull: "Sergeant"},
+		Primary: utils.Position{PositionTitle: "Section Leader 1/1/A/ACD"},
+		Records: []utils.Record{
+			viiRec("2024-01-01", "Enlisted in the 7th Cavalry"),
+			viiRec("2024-02-01", "Transferred and Assigned Section Leader 1/1/A/ACD"),
+			viiRec("2024-08-03", "Promoted to Staff Sergeant (E-6)"),
+			viiRec("2025-06-01", "Reduced to Sergeant (E-5)"),
+		},
+	}
+	a := viiAnalyze(p, viiModel(), promoRefDate.UTC())
+	if a.EligibleNow || a.PotentiallyEligible || a.Qualifies {
+		t.Errorf("continuous service must not qualify for §VII: %+v", a)
+	}
+}
+
+// A reserve transfer made BEFORE reaching retirement eligibility is not a
+// qualifying departure. Regression: smoke test flagged a member who left to
+// the Reserves with ~5 months TIS.
+func TestViiAnalyzeIneligibleReserveDepartureNotQualifying(t *testing.T) {
+	p := &utils.ProfileResponse{
+		User:    utils.User{Username: "Early.E"},
+		Rank:    utils.Rank{RankShort: "CPL", RankFull: "Corporal"},
+		Primary: utils.Position{PositionTitle: "Section Leader 1/1/A/ACD"},
+		Records: []utils.Record{
+			viiRec("2024-01-01", "Enlisted in the 7th Cavalry"),
+			viiRec("2024-02-01", "Transferred and Assigned Section Leader 1/1/A/ACD"),
+			viiRec("2024-03-12", "Promoted to Staff Sergeant (E-6)"),
+			viiRec("2024-06-01", "Transferred and Assigned Reserves"),
+			viiRec("2026-01-01", "Reinstated to Active Duty"),
+			viiRec("2026-01-02", "Promoted to Corporal (E-4)"),
+			viiRec("2026-01-03", "Transferred and Assigned Section Leader 1/1/A/ACD"),
+		},
+	}
+	a := viiAnalyze(p, viiModel(), promoRefDate.UTC())
+	if a.EligibleNow || a.PotentiallyEligible || a.Qualifies {
+		t.Errorf("pre-eligibility reserve departure must not qualify for §VII: %+v", a)
+	}
+}
+
+// Departmental service in the Reserves pushing the timer past the threshold
+// makes the (deferred) reserve departure qualifying: the veteran is §VII
+// eligible on return where they wouldn't be without the dept credit.
+func TestViiAnalyzeDeptReserveVeteranEligible(t *testing.T) {
+	p := &utils.ProfileResponse{
+		User:    utils.User{Username: "Dept.D"},
+		Rank:    utils.Rank{RankShort: "CPL", RankFull: "Corporal"},
+		Primary: utils.Position{PositionTitle: "Section Leader 1/1/A/ACD"},
+		Records: []utils.Record{
+			viiRec("2023-01-01", "Enlisted in the 7th Cavalry"),
+			viiRec("2023-02-01", "Transferred and Assigned Section Leader 1/1/A/ACD"),
+			viiRec("2023-06-01", "Promoted to Staff Sergeant (E-6)"),
+			viiRec("2023-08-01", "Assigned S7 Instructor as Additional Duty"),
+			// 517d TIS at transfer (not yet eligible), but the S7 duty keeps
+			// the timer running through the Reserves…
+			viiRec("2024-06-01", "Transferred and Assigned Reserves"),
+			// …to 882d at relief: past the 730d threshold, qualifying.
+			viiRec("2025-06-01", "Relieved of Duties"),
+			viiRec("2026-01-01", "Reinstated to Active Duty"),
+			viiRec("2026-01-02", "Promoted to Corporal (E-4)"),
+			viiRec("2026-01-03", "Transferred and Assigned Section Leader 1/1/A/ACD"),
+		},
+	}
+	a := viiAnalyze(p, viiModel(), promoRefDate.UTC())
+	if !a.Qualifies {
+		t.Fatalf("dept-extended reserve departure should qualify: %+v", a)
+	}
+	if !a.EligibleNow || a.Target == nil || a.Target.Short != "SSG" {
+		t.Errorf("EligibleNow/Target = %v/%+v, want true/SSG", a.EligibleNow, a.Target)
+	}
+}
+
+func TestViiAnalyzeBilletCeilingCaps(t *testing.T) {
+	// Same history but returning into a MEMBER billet (Rifleman rates CPL):
+	// no held rank fits between ceiling and current CPL → ineligible.
+	p := viiVetProfile()
+	p.Primary.PositionTitle = "Rifleman 1/1/1/A"
+	p.Records[len(p.Records)-1] = viiRec("2026-01-03", "Transferred and Assigned Rifleman 1/1/1/A")
+	a := viiAnalyze(p, viiModel(), promoRefDate.UTC())
+	if a.EligibleNow {
+		t.Errorf("EligibleNow = true, want false (MEMBER billet caps at CPL): %+v", a)
+	}
+	if a.PotentiallyEligible {
+		t.Errorf("PotentiallyEligible = true, want false (billet-too-low is a hard no)")
+	}
+}
+
+func TestViiAnalyzeWrongBilletType(t *testing.T) {
+	// Held SSG in a LINE billet only; returns into a STAFF billet → the rank
+	// wasn't earned in this billet type → ineligible.
+	p := viiVetProfile()
+	p.Primary.PositionTitle = "S3 Lead"
+	p.Records[len(p.Records)-1] = viiRec("2026-01-03", "Transferred and Assigned S3 Lead")
+	a := viiAnalyze(p, viiModel(), promoRefDate.UTC())
+	if a.EligibleNow {
+		t.Errorf("EligibleNow = true, want false (SSG held in line, billet is staff): %+v", a)
+	}
+}
+
+func TestViiAnalyzeDowngradeIsPotential(t *testing.T) {
+	p := viiVetProfile()
+	p.Records = append(p.Records, viiRec("2025-06-01", "Retirement status downgraded to Honorable Discharge"))
+	a := viiAnalyze(p, viiModel(), promoRefDate.UTC())
+	if a.EligibleNow {
+		t.Error("EligibleNow = true, want false (downgraded retirement)")
+	}
+	if !a.PotentiallyEligible {
+		t.Fatalf("PotentiallyEligible = false, want true: %+v", a)
+	}
+	if a.PotentialRank == nil || a.PotentialRank.Short != "SSG" {
+		t.Errorf("PotentialRank = %+v, want SSG", a.PotentialRank)
+	}
+	if !strings.Contains(a.Reason(), "case-by-case") {
+		t.Errorf("Reason = %q, want downgrade explanation", a.Reason())
+	}
+}
+
+func TestViiAnalyzeStandingBlocks(t *testing.T) {
+	p := viiVetProfile()
+	// NFA active at the ref date (2026-05-15).
+	p.Records = append(p.Records, viiRec("2026-05-01", "Letter of Reprimand issued, 90 Days NFA"))
+	a := viiAnalyze(p, viiModel(), promoRefDate.UTC())
+	if a.EligibleNow {
+		t.Error("EligibleNow = true, want false (active NFA)")
+	}
+	if !a.Blocked || !a.PotentiallyEligible {
+		t.Errorf("Blocked=%v PotentiallyEligible=%v, want true/true", a.Blocked, a.PotentiallyEligible)
+	}
+	if !strings.Contains(a.Reason(), "standing clears") {
+		t.Errorf("Reason = %q, want standing-block explanation", a.Reason())
+	}
+}
+
+func TestViiAnalyzeWarrantDisplayForAviator(t *testing.T) {
+	// Aviator with wings held CW3 (unified level = SSG); returning into an SL
+	// billet the target should DISPLAY as CW3, not SSG.
+	p := viiVetProfile()
+	p.Mos = "155F"
+	p.Awards = []utils.Award{{AwardName: "Army Aviator Badge"}}
+	for i, r := range p.Records {
+		if r.RecordDetails == "Promoted to Staff Sergeant (E-6)" {
+			p.Records[i].RecordDetails = "Promoted to Chief Warrant Officer 3 (W-3)"
+		}
+	}
+	a := viiAnalyze(p, viiModel(), promoRefDate.UTC())
+	if !a.EligibleNow {
+		t.Fatalf("EligibleNow = false, want true: %+v", a)
+	}
+	if a.Target == nil || a.Target.Short != "CW3" {
+		t.Errorf("Target = %+v, want CW3 (warrant display for winged aviator)", a.Target)
+	}
+}
+
+func TestViiAnalyzeNoHistoryIneligible(t *testing.T) {
+	p := &utils.ProfileResponse{
+		User:    utils.User{Username: "New.N"},
+		Rank:    utils.Rank{RankShort: "PVT"},
+		Primary: utils.Position{PositionTitle: "Rifleman 1/1/1/A"},
+		Records: []utils.Record{
+			viiRec("2026-01-01", "Enlisted in the 7th Cavalry"),
+			viiRec("2026-01-02", "Assigned Rifleman 1/1/1/A"),
+		},
+	}
+	a := viiAnalyze(p, viiModel(), promoRefDate.UTC())
+	if a.EligibleNow || a.PotentiallyEligible || a.Qualifies {
+		t.Errorf("fresh trooper should be fully ineligible: %+v", a)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -166,6 +166,7 @@ func main() {
 	}
 
 	commands.StartJoinerReportScheduler(dg, GuildID)
+	commands.StartPromoSweepScheduler(dg)
 
 	utils.Info("Bot is now running. Press CTRL-C to exit")
 	sc := make(chan os.Signal, 1)

--- a/utils/milpacs.go
+++ b/utils/milpacs.go
@@ -22,6 +22,7 @@ type ProfileResponse struct {
 	Secondary         []Position `json:"secondaries"`
 	Records           []Record   `json:"records"`
 	Awards            []Award    `json:"awards"`
+	Mos               string     `json:"mos"`
 	JoinDate          string     `json:"joinDate"`
 	PromotionDate     string     `json:"promotionDate"`
 	DiscordID         string     `json:"discordId"`
@@ -142,6 +143,23 @@ func makeAPIRequest[T any](ctx context.Context, path string, identifier string) 
 	return nil, fmt.Errorf("%s API returned %d %s", pathPrefix, status, http.StatusText(status))
 }
 
+// RankInfo is one entry of the /milpacs/ranks reference list.
+type RankInfo struct {
+	RankShort        string `json:"rankShort"`
+	RankFull         string `json:"rankFull"`
+	RankDisplayOrder int    `json:"rankDisplayOrder"`
+	RankID           string `json:"rankId"`
+}
+
+type RanksResponse struct {
+	Ranks []RankInfo `json:"ranks"`
+}
+
+// GetRanks fetches the rank reference list (short/full names + display order).
+func GetRanks(ctx context.Context) (*RanksResponse, error) {
+	return makeAPIRequest[RanksResponse](ctx, "milpacs/ranks", "ranks")
+}
+
 func GetMilpacByUsername(ctx context.Context, username string) (*ProfileResponse, error) {
 	return makeAPIRequest[ProfileResponse](ctx,
 		fmt.Sprintf("milpacs/profile/username/%s", username),
@@ -152,6 +170,15 @@ func GetMilpacByDiscordID(ctx context.Context, discordID string) (*ProfileRespon
 	return makeAPIRequest[ProfileResponse](ctx,
 		fmt.Sprintf("milpac/discord/%s", discordID),
 		discordID)
+}
+
+// GetLiteRoster fetches a whole roster by RosterType enum name (e.g.
+// "ROSTER_TYPE_COMBAT" = Active Duty) with minimal per-profile data — same
+// response shape as the fuzzy position search.
+func GetLiteRoster(ctx context.Context, rosterType string) (*LiteRosterResponse, error) {
+	return makeAPIRequest[LiteRosterResponse](ctx,
+		fmt.Sprintf("roster/%s/lite", rosterType),
+		rosterType)
 }
 
 func GetRosterByFuzzyPositionSearch(ctx context.Context, position string) (*LiteRosterResponse, error) {


### PR DESCRIPTION
Closes #4.

## What

Adds `/promo`, an S1 tool that reports who is eligible for promotion, plus a weekly background sweep that posts the same report to a channel automatically. It reads milpac records and the rank ladder and returns, per candidate, the next rank and which requirements are met or outstanding.

## Promotion paths

- **Automatic** PVT to PFC and PFC to SPC are time-in-grade only; SPC to CPL/WO1 is also automatic but gated on courses (NCOA I/II + SAC).
- **Discretionary** TIG + TIS + billet gates (e.g. CPL to SGT needs time-in-service plus an ASL or SL billet). COL to BG is additionally gated on a regiment-HQ MOS (00B, 00Z, 01A).
- **Lateral** CPL to WO1 rank retention for flight-wing aviators.
- **Veteran Rank Retention (Chapter 4 Section VII)** a returning veteran may be restored toward a prior rank. Gated on a qualifying departure (retirement, or reserves while retirement-eligible); departmental service counts toward the retirement timer; billets drop on retirement, discharge, RIP, or Arlington. The billet-ceiling table is cited to R-023.

## Command options

| Option | Purpose |
|--------|---------|
| `position` | Fuzzy unit/position scope; defaults to `activeduty` (whole combat roster) |
| `rank` | Every active-duty trooper at this rank (milpac short form) |
| `user` | One trooper, full verdict breakdown |
| `type` | Show only one path: automatic, discretionary, vii, lateral |
| `exclude` | Hide one path (e.g. `exclude:vii`) |
| `as_of` | Eligibility as of a date (`DDMMMYY`, e.g. `30JUL26`; default today) |
| `force_file_output` | Always attach the full candidate list as a file |

`position` and `rank` combine (e.g. all PVTs in `activeduty`). Results sort by rank seniority then alphabetically, and the full set always ships. Short lists render inline; long ones keep the inline list plus an "and N more" notice and attach an interactive HTML report (client-side filter and column sort) alongside a CSV.

## Weekly sweep

A background scheduler runs the eligibility pass for the configured scope every week and posts the result to a configured channel, so S1 is told rather than having to ask. It mirrors the Star Citizen joiner-report scheduler (sleep-until-fire loop, per-fire panic recovery, `now` seam). Channel, scope, cadence, and a kill switch are compile-time constants; changing them is a code change and redeploy. There is no manual slash-command trigger.

Two decisions flagged for S1 review:
- Scope is the whole `activeduty` roster unfiltered for now, at the cost of fetching the entire active-duty set weekly.
- Cadence (Mondays 0900 UTC) is a placeholder (marked with a `TODO(S1)`); we should probably ask S1 when they would like this to happen.

`standardPathPossible` and `lateralPathPossible` decide from lite data alone (rank, dates, billet title). They skip anyone whose rank/TIG/billet already rules them out, so they discard most of the roster. But `viiPathPossible` can only skip someone whose billet ceiling is at or below their current rank; it cannot see departure/return history (that lives in the full record stream), so for almost everyone it has to fetch.

What I would send to S1 as recommendations are:
- Weekly: everything but VII
- Every 4th week: everything including VII

## Pre-filter

`promo_eligibility.go` includes a cheap pre-filter that skips the milpac profile fetch for candidates the lite roster already rules out. Invariant: it never drops a candidate the full evaluator would return, so it fails toward fetching. Covered by `TestPreFilterNeverDropsACandidate`.

Sweep API load, measured against the current active duty roster:

| /promo activeduty mode | Profiles pulled | % saved by pre-filter |
|------------------------|-----------------|-----------------------|
| unfiltered (incl. §VII) | 755 | 6.7% |
| exclude:vii             | 379 | 53.2% |
| type:discretionary      | 36  | 95.6% |
| type:vii                | 649 | 19.8% |

## Verification

- Tested in test env.
- `golangci-lint run --timeout=5m` - 0 issues.
- `go test ./...` - commands 90.5%, utils 90.5% (floors 81% / 87%).
- `go build -o cavbot2 .` - OK.