### PR TITLE
Fill in setup steps and command list in the README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ go build -o cavbot2 .                     # build the binary (CI uses this exact
 go run .                                  # run locally (requires env vars; see below)
 go mod tidy                               # sync deps after changing imports
 golangci-lint run --timeout=5m            # lint (no .golangci config; uses defaults — same as CI)
-docker compose up --build                 # run via Docker (requires .env; image must be built locally first or pulled)
+docker build -t cavbot2:latest . && docker compose up   # run via Docker (see README step 4)
 ```
 
 Tests live in `*_test.go` files alongside the code they cover. Run them with `go test ./...`. CI runs the suite with coverage enforcement — see the Testing section of README.md and `.github/scripts/check-coverage-floors.sh` for the floor policy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,11 @@ Optional but feature-gating:
 
 - `BEARER` — bearer token for `api.7cav.us` (milpacs lookups will fail without it)
 - `FORUM_DB_DSN` — MySQL DSN for the Xenforo forum DB. The production DSN points at host `xenforo-db`, which resolves **only inside the `xenforo_internal` Docker network** (declared `external: true` in `docker-compose.yml`). Running `go run .` outside that network won't error at startup — `sql.Open` defers the connection — but every `Refresh` will log `"LOA cache refresh failed"` at WARN and the cache will stay empty. To test LOA locally, either run via `docker compose` or substitute a reachable DSN.
-- `LOA_NODE_IDS` — comma-separated Xenforo node IDs to scan for LOA threads. Code default is `180`; **production scans 5 nodes** (`180,400,540,178,369`). `.env.example` is out of date here (it shows `LOA_NODE_ID=180`, singular and wrong-named).
+- `LOA_NODE_IDS` — comma-separated Xenforo node IDs to scan for LOA threads. Code default is `180`; **production scans 5 nodes** (`180,400,540,178,369`), which is what `.env.example` sets, so a copied `.env` never hits the code default.
 - `GITHUB_APP_KEY` (base64-encoded PEM), `GITHUB_APP_CLIENT_ID` — needed for `/apps_beta_deploy`
 - `LOG_LEVEL` — `DEBUG` / `INFO` / `WARN` / `ERROR` (default `INFO`)
 
-`.env.example` lists all of these but is partly stale (see `LOA_NODE_IDS` above). Copy to `.env` for local Docker runs.
+`.env.example` lists all of these. Copy it to `.env` — `init()` in `main.go` loads that file via `godotenv` before reading any variable, so it serves local `go run .` and `docker compose` alike. Anything already exported in the environment takes precedence over the file, and a missing file is not an error (that is the container and CI case). A malformed one panics rather than starting with partial configuration.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,98 @@ A Discord bot built for the 7th Cavalry Gaming Regiment using Go and DiscordGo, 
 
 ## Prerequisites
 
-- Go 1.23 or higher
-- DiscordGo library
-- A working Go development environment
+- Go 1.25.0 or higher (see `go` directive in `go.mod`)
+- [golangci-lint](https://golangci-lint.run/) 2.5.0+, built with Go 1.25 or newer
+- A C compiler (gcc) if you want to run the tests with `-race`
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/milpac` | Return a user's milpac |
+| `/zulu` | Current Zulu time |
+| `/gamertag_search` | Find a user by gamertag |
+| `/awol` | AWOL troopers for a position |
+| `/loa` | Active and upcoming LOAs for a position |
+| `/afsm` | Members eligible for the AFSM in a department |
+| `/s3aar` | Attendance list for events and operations |
+| `/promo` | Tools to gauge promotion eligibility across the regiment |
+| `/billetaudit` | Several audit tools to flag discrepancies in MILPAC |
+| `/apps_beta_deploy` | Deploy the Apps beta version |
+| `/s6-it-check` | S6 IT members eligible for full status |
+| `/warden` | Warden role management |
+| `/warden-bulkadd-internal` | Add a validated unit roster to Verified Warden Internal |
+| `/apps_beta_deploy` | Deploy the Apps beta version |
 
 ## Setup
 
-Under Construction due to rewrite of bot
-TODO: Add setup steps and list out functionality
+### 1. Discord application
+
+At <https://discord.com/developers/applications>:
+
+1. 'New Application', then open the 'Bot' tab.
+2. 'Reset Token' and copy it. This is `DISCORD_TOKEN`. It is only shown once!
+3. On the same tab, enable the 'Server Members Intent' under Privileged Gateway
+   Intents. The bot requests `IntentsGuildMembers`; without this the gateway
+   connection fails at startup. A guild is a Discord server.
+4. Create (if you don't have one already) a Discord server that will serve as your test environment for the bot.
+5. Under 'OAuth2 -> URL Generator', select the `bot` and `applications.commands`
+   scopes plus the 'View Channels', 'Send Messages', 'Attach Files' and 'Embed Links'
+   permissions, then open the generated URL to invite the bot to your test environment server.
+
+`applications.commands` is what allows slash commands to register.
+
+### 2. IDs
+
+Enable 'Developer Mode' in the Discord client ('User Settings' -> 'Advanced'), then
+right-click a server or channel and choose Copy ID.
+
+Commands register per guild, so `GUILD_ID` must be the server you are testing in.
+Guild commands appear immediately.
+
+### 3. Environment
+
+Rename `.env.example` to `.env` and fill it in.
+
+Startup fails without these:
+
+| Variable | Source |
+|----------|--------|
+| `DISCORD_TOKEN` | Developer Portal -> Bot -> Reset Token |
+| `GUILD_ID` | Right-click the server -> Copy Server ID |
+| `BM_TOKEN` | [BattleMetrics](https://www.battlemetrics.com) -> Account -> Developers. Only `/s3aar` uses it; any non-empty placeholder works otherwise. |
+
+Not checked at startup, but required in practice:
+
+| Variable | Source |
+|----------|--------|
+| `BEARER` | API token for `api.7cav.us`. Every api call fails without it, and there is no startup error. Check this if lookups fail. |
+
+When adding a new variable, add it to both `.env.example` and the
+`environment:` block in `docker-compose.yml`. Compose does not pass through
+variables that are not listed, so skipping the second step means the value never
+reaches the container.
+
+### 4. Run
+
+```bash
+go build -o cavbot2 .
+go run .
+```
+
+A healthy startup logs `Registering commands`, then
+`Bot is now running. Press CTRL-C to exit`.
+
+### Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Panic naming `DISCORD_TOKEN`, `GUILD_ID` or `BM_TOKEN` | Variable missing from `.env` |
+| Gateway connection fails | Server Members Intent not enabled |
+| Commands never appear | Bot invited without `applications.commands`, or `GUILD_ID` is not the server you are in |
+| Every milpac lookup fails | `BEARER` missing or expired |
+| `FORUM_DB_DSN not set` warning | Expected without a forum database; only affects LOA |
+| golangci-lint reports a Go version mismatch | Binary was built with an older Go than `go.mod` targets; reinstall 2.5.0+ |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ At <https://discord.com/developers/applications>:
 1. 'New Application', then open the 'Bot' tab.
 2. 'Reset Token' and copy it. This is `DISCORD_TOKEN`. It is only shown once!
 3. On the same tab, enable the 'Server Members Intent' under Privileged Gateway
-   Intents. The bot requests `IntentsGuildMembers`, and Discord rejects the
-   connection without it — see the troubleshooting table for what that looks
-   like, because it is not an obvious error message. A guild is a Discord server.
+   Intents. The bot requests `IntentsGuildMembers` and will not start without
+   it. A guild is a Discord server.
 4. Create (if you don't have one already) a Discord server that will serve as your test environment for the bot.
 5. Under 'OAuth2 -> URL Generator', select the `bot` and `applications.commands`
    scopes, then the permissions below, then open the generated URL to invite the
@@ -153,7 +152,7 @@ Sunday, a real person gets your test output. Prefer a test guild.
 | Symptom | Likely cause |
 |---------|--------------|
 | Panic naming `DISCORD_TOKEN`, `GUILD_ID` or `BM_TOKEN` | The variable is not in the environment. Filling in `.env` is not enough for `go run .` — export it first (step 4) |
-| `nil pointer dereference` at `main.go` right after `Removing deprecated commands` | Discord accepted the connection but never completed the handshake, so the session has no user to read. Two causes, same crash: a stale or truncated `DISCORD_TOKEN`, or the Server Members Intent left off in the Developer Portal. Check both — neither produces a readable error |
+| Startup stops before `Bot is now running` | Discord refused the handshake. Re-copy `DISCORD_TOKEN` (it may be stale or truncated) and confirm the Server Members Intent is enabled |
 | `FORUM_DB_DSN not set` at startup, or `LOA cache refresh failed` every 15 minutes | Expected without a reachable forum database; only affects `/loa` |
 | `/warden` fails with a permissions error | Bot invited without Manage Roles / Manage Channels, or its own role sits below the role it is editing |
 | Commands never appear | Bot invited without `applications.commands`, or `GUILD_ID` is not the server you are in |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ At <https://discord.com/developers/applications>:
 | Permission | Needed for |
 |------------|-----------|
 | View Channels, Send Messages, Embed Links, Attach Files | Every command's response |
-| Manage Roles | `/warden` and `/warden-bulkadd-internal` add and remove roles, and `/warden` can create one |
+| Manage Roles | `/warden` adds, removes and creates roles; `/warden-bulkadd-internal` adds them |
 | Manage Channels | `/warden` sets per-channel permission overwrites |
 
 `applications.commands` is what allows slash commands to register. Discord will
@@ -88,7 +88,7 @@ Not checked at startup, but each one silently disables something:
 |----------|-----------------|
 | `BEARER` | API token for `api.7cav.us`. Every milpac lookup fails with no startup error — check this first if `/milpac`, `/awol` or `/afsm` come back empty. |
 | `GITHUB_APP_KEY`, `GITHUB_APP_CLIENT_ID` | `/apps_beta_deploy` cannot authenticate. The key is a base64-encoded PEM. |
-| `FORUM_DB_DSN` | LOA cache stays empty, so `/loa` returns nothing. Left blank the bot logs `FORUM_DB_DSN not set, LOA cache disabled` once at startup — but `.env.example` ships a placeholder DSN, so after `cp` you instead get a `LOA cache refresh failed` warning every 15 minutes. Both mean the same thing. The production host `xenforo-db` resolves only inside the `xenforo_internal` Docker network. |
+| `FORUM_DB_DSN` | LOA cache stays empty, so `/loa` returns nothing. Left blank the bot logs `FORUM_DB_DSN not set, LOA cache disabled` once at startup — but `.env.example` ships a placeholder DSN, which is syntactically valid, so after `cp` you instead get `LOA cache refresh failed` once per node ID, immediately at startup and every 15 minutes after. Both mean the same thing. The production host `xenforo-db` resolves only inside the `xenforo_internal` Docker network. |
 | `LOA_NODE_IDS` | The code default is `180` alone, though `.env.example` already sets the five nodes production scans (`180,400,540,178,369`), so a copied `.env` never falls back. |
 | `LOG_LEVEL` | Defaults to `INFO`. Accepts `DEBUG`, `INFO`, `WARN`, `ERROR` — **uppercase only**, anything else silently means `INFO` (including the `default` that `.env.example` ships). `DEBUG` shows per-post LOA parse failures. |
 | `SENTRY_DSN` | Sentry stays off; the bot logs `Sentry disabled (SENTRY_DSN not set)`. |
@@ -133,10 +133,12 @@ docker compose up
 Only the real `xenforo_internal` network reaches the forum database; a network
 you created yourself gets the bot running, but `/loa` stays empty.
 
-A healthy startup logs `Logger initialized` and `Sentry disabled (SENTRY_DSN not
-set)`, then `CavBot2 starting`, `Removing deprecated commands`, `Registering
-commands`, and finally `Bot is now running. Press CTRL-C to exit`. Anything that
-stops before that last line is a failed start — see below.
+A healthy startup logs, in order: `Logger initialized`, `Sentry disabled
+(SENTRY_DSN not set)`, `CavBot2 starting`, the LOA cache line for whichever
+`FORUM_DB_DSN` case you are in, `Removing deprecated commands`, `Registering
+commands`, `Starting Star Citizen joiner report scheduler`, and finally `Bot is
+now running. Press CTRL-C to exit`. That last line is the success signal —
+anything that stops earlier is a failed start.
 
 ### One thing that is not a command
 
@@ -152,7 +154,8 @@ Sunday, a real person gets your test output. Prefer a test guild.
 | Symptom | Likely cause |
 |---------|--------------|
 | Panic naming `DISCORD_TOKEN`, `GUILD_ID` or `BM_TOKEN` | The variable is not in the environment. Filling in `.env` is not enough for `go run .` — export it first (step 4) |
-| Startup stops before `Bot is now running` | Discord refused the handshake. Re-copy `DISCORD_TOKEN` (it may be stale or truncated) and confirm the Server Members Intent is enabled |
+| `Error opening connection: websocket: close 4004` | Discord rejected the token. Re-copy `DISCORD_TOKEN` — a truncated paste or a token reset since you last copied it both land here |
+| `Error opening connection: websocket: close 4014` | Disallowed intent. Enable the Server Members Intent in the Developer Portal |
 | `FORUM_DB_DSN not set` at startup, or `LOA cache refresh failed` every 15 minutes | Expected without a reachable forum database; only affects `/loa` |
 | `/warden` fails with a permissions error | Bot invited without Manage Roles / Manage Channels, or its own role sits below the role it is editing |
 | Commands never appear | Bot invited without `applications.commands`, or `GUILD_ID` is not the server you are in |

--- a/README.md
+++ b/README.md
@@ -41,14 +41,23 @@ At <https://discord.com/developers/applications>:
 1. 'New Application', then open the 'Bot' tab.
 2. 'Reset Token' and copy it. This is `DISCORD_TOKEN`. It is only shown once!
 3. On the same tab, enable the 'Server Members Intent' under Privileged Gateway
-   Intents. The bot requests `IntentsGuildMembers`; without this the gateway
-   connection fails at startup. A guild is a Discord server.
+   Intents. The bot requests `IntentsGuildMembers`, and Discord rejects the
+   connection without it — see the troubleshooting table for what that looks
+   like, because it is not an obvious error message. A guild is a Discord server.
 4. Create (if you don't have one already) a Discord server that will serve as your test environment for the bot.
 5. Under 'OAuth2 -> URL Generator', select the `bot` and `applications.commands`
-   scopes plus the 'View Channels', 'Send Messages', 'Attach Files' and 'Embed Links'
-   permissions, then open the generated URL to invite the bot to your test environment server.
+   scopes, then the permissions below, then open the generated URL to invite the
+   bot to your test environment server.
 
-`applications.commands` is what allows slash commands to register.
+| Permission | Needed for |
+|------------|-----------|
+| View Channels, Send Messages, Embed Links, Attach Files | Every command's response |
+| Manage Roles | `/warden` and `/warden-bulkadd-internal` add and remove roles, and `/warden` can create one |
+| Manage Channels | `/warden` sets per-channel permission overwrites |
+
+`applications.commands` is what allows slash commands to register. Discord will
+not let the bot grant a role positioned above its own, so drag the bot's role
+high in the server's role list before testing `/warden`.
 
 ### 2. IDs
 
@@ -80,10 +89,11 @@ Not checked at startup, but each one silently disables something:
 |----------|-----------------|
 | `BEARER` | API token for `api.7cav.us`. Every milpac lookup fails with no startup error — check this first if `/milpac`, `/awol` or `/afsm` come back empty. |
 | `GITHUB_APP_KEY`, `GITHUB_APP_CLIENT_ID` | `/apps_beta_deploy` cannot authenticate. The key is a base64-encoded PEM. |
-| `FORUM_DB_DSN` | LOA cache stays empty, so `/loa` returns nothing. Logs `FORUM_DB_DSN not set, LOA cache disabled` at startup. The production host `xenforo-db` only resolves inside the `xenforo_internal` Docker network. |
-| `LOA_NODE_IDS` | Defaults to `180`; production scans `180,400,540,178,369`. |
-| `LOG_LEVEL` | Defaults to `INFO`. Use `DEBUG` to see per-post LOA parse failures. |
-| `SENTRY_DSN`, `APP_ENV` | Sentry stays off; the bot logs `Sentry disabled (SENTRY_DSN not set)`. |
+| `FORUM_DB_DSN` | LOA cache stays empty, so `/loa` returns nothing. Left blank the bot logs `FORUM_DB_DSN not set, LOA cache disabled` once at startup — but `.env.example` ships a placeholder DSN, so after `cp` you instead get a `LOA cache refresh failed` warning every 15 minutes. Both mean the same thing. The production host `xenforo-db` resolves only inside the `xenforo_internal` Docker network. |
+| `LOA_NODE_IDS` | The code default is `180` alone, though `.env.example` already sets the five nodes production scans (`180,400,540,178,369`), so a copied `.env` never falls back. |
+| `LOG_LEVEL` | Defaults to `INFO`. Accepts `DEBUG`, `INFO`, `WARN`, `ERROR` — **uppercase only**, anything else silently means `INFO` (including the `default` that `.env.example` ships). `DEBUG` shows per-post LOA parse failures. |
+| `SENTRY_DSN` | Sentry stays off; the bot logs `Sentry disabled (SENTRY_DSN not set)`. |
+| `APP_ENV` | Only tags Sentry events with an environment. No effect unless `SENTRY_DSN` is also set. |
 
 When adding a new variable, add it to both `.env.example` and the
 `environment:` block in `docker-compose.yml`. Compose does not pass through
@@ -124,19 +134,30 @@ docker compose up
 Only the real `xenforo_internal` network reaches the forum database; a network
 you created yourself gets the bot running, but `/loa` stays empty.
 
-A healthy startup logs `CavBot2 starting`, `Removing deprecated commands`,
-`Registering commands`, then `Bot is now running. Press CTRL-C to exit`.
+A healthy startup logs `Logger initialized` and `Sentry disabled (SENTRY_DSN not
+set)`, then `CavBot2 starting`, `Removing deprecated commands`, `Registering
+commands`, and finally `Bot is now running. Press CTRL-C to exit`. Anything that
+stops before that last line is a failed start — see below.
+
+### One thing that is not a command
+
+`main.go` starts a weekly Star Citizen joiner report unconditionally, with no
+env var to disable it. It fires Sundays at 04:20 UTC and DMs a **hardcoded
+production user ID** (`commands/star_citizen_joiners.go`). Against your own test
+guild the DM simply fails, since the bot shares no server with that person. If
+you point `GUILD_ID` at the live 7Cav server and leave the bot running over a
+Sunday, a real person gets your test output. Prefer a test guild.
 
 ### Troubleshooting
 
 | Symptom | Likely cause |
 |---------|--------------|
 | Panic naming `DISCORD_TOKEN`, `GUILD_ID` or `BM_TOKEN` | The variable is not in the environment. Filling in `.env` is not enough for `go run .` — export it first (step 4) |
-| `nil pointer dereference` at `main.go` right after `Removing deprecated commands` | The token was rejected, so the session never received a user. Re-copy `DISCORD_TOKEN` — a stale or truncated token lands here rather than on a clean error |
-| Gateway connection fails | Server Members Intent not enabled |
+| `nil pointer dereference` at `main.go` right after `Removing deprecated commands` | Discord accepted the connection but never completed the handshake, so the session has no user to read. Two causes, same crash: a stale or truncated `DISCORD_TOKEN`, or the Server Members Intent left off in the Developer Portal. Check both — neither produces a readable error |
+| `FORUM_DB_DSN not set` at startup, or `LOA cache refresh failed` every 15 minutes | Expected without a reachable forum database; only affects `/loa` |
+| `/warden` fails with a permissions error | Bot invited without Manage Roles / Manage Channels, or its own role sits below the role it is editing |
 | Commands never appear | Bot invited without `applications.commands`, or `GUILD_ID` is not the server you are in |
 | Every milpac lookup fails | `BEARER` missing or expired |
-| `FORUM_DB_DSN not set` warning | Expected without a forum database; only affects `/loa` |
 | Compose says `pull access denied` for `cavbot2:latest` | The image was never built locally — run `docker build -t cavbot2:latest .` |
 | Compose says network `xenforo_internal` not found | Create it, or join the host that has it |
 | golangci-lint reports a Go version mismatch | Your golangci-lint was built with an older Go than `go.mod` targets; install a build made with Go 1.25+ |

--- a/README.md
+++ b/README.md
@@ -101,28 +101,27 @@ reaches the container.
 
 ### 4. Run
 
-Nothing in the bot reads `.env` — there is no dotenv loader, `main.go` calls
-`os.Getenv` directly. `.env` is a file Docker Compose reads, not one Go reads. So
-pick a path:
-
-**Locally** — export the file into your shell first, or the bot panics on
-`DISCORD_TOKEN` even though `.env` is filled in:
+**Locally** — the bot reads `.env` from the working directory at startup, so
+having filled it in is enough:
 
 ```bash
-set -a; source .env; set +a
 go run .
 ```
 
-`set -a` marks everything sourced for export; without it the values stay shell
-variables the process never sees. To run the compiled binary instead:
+Or build and run the binary:
 
 ```bash
 go build -o cavbot2 . && ./cavbot2
 ```
 
-**In Docker** — Compose reads `.env` itself, so no exporting. It does not build
-the image (the service declares `image:` with no `build:`), and the network is
-external, so both exist before `up`:
+Anything already exported in your shell wins over the file, which is how the
+container gets its configuration. If you export `DISCORD_TOKEN` and then wonder
+why editing `.env` changes nothing, that is why.
+
+**In Docker** — Compose reads `.env` itself and injects the values, and `.env`
+is excluded from the image by `.dockerignore`, so nothing secret is baked in.
+Compose does not build the image (the service declares `image:` with no
+`build:`), and the network is external, so make sure both exist before `up`:
 
 ```bash
 docker build -t cavbot2:latest .
@@ -153,7 +152,8 @@ Sunday, a real person gets your test output. Prefer a test guild.
 
 | Symptom | Likely cause |
 |---------|--------------|
-| Panic naming `DISCORD_TOKEN`, `GUILD_ID` or `BM_TOKEN` | The variable is not in the environment. Filling in `.env` is not enough for `go run .` — export it first (step 4) |
+| Panic naming `DISCORD_TOKEN`, `GUILD_ID` or `BM_TOKEN` | The variable is blank in `.env`, or you are running from a directory that has no `.env` |
+| `Found .env but could not load it` | The file exists but is malformed — usually an unquoted value containing `#`, or a stray line with no `=` |
 | `Error opening connection: websocket: close 4004` | Discord rejected the token. Re-copy `DISCORD_TOKEN` — a truncated paste or a token reset since you last copied it both land here |
 | `Error opening connection: websocket: close 4014` | Disallowed intent. Enable the Server Members Intent in the Developer Portal |
 | `FORUM_DB_DSN not set` at startup, or `LOA cache refresh failed` every 15 minutes | Expected without a reachable forum database; only affects `/loa` |

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ commands`, `Starting Star Citizen joiner report scheduler`, and finally `Bot is
 now running. Press CTRL-C to exit`. That last line is the success signal —
 anything that stops earlier is a failed start.
 
+Expect a pause of roughly 40 seconds on `Registering commands`. The eleven
+commands are created one at a time and Discord rate-limits them, so a silent
+console there is normal, not a hang.
+
 ### One thing that is not a command
 
 `main.go` starts a weekly Star Citizen joiner report unconditionally, with no

--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ A Discord bot built for the 7th Cavalry Gaming Regiment using Go and DiscordGo, 
 
 ## Prerequisites
 
-- Go 1.25.0 or higher (see `go` directive in `go.mod`)
-- [golangci-lint](https://golangci-lint.run/) 2.5.0+, built with Go 1.25 or newer
-- A C compiler (gcc) if you want to run the tests with `-race`
+- Go 1.25.0 or higher (see the `go` directive in `go.mod`)
+- [golangci-lint](https://golangci-lint.run/) — CI installs the latest release
+  (`.github/workflows/build_test.yml`), so track that. It must be built with a Go
+  at least as new as `go.mod` targets, or it refuses to run.
+- A C compiler (gcc/clang) if you want to run the tests with `-race`
+- Docker, only if you want the container path in step 4
 
 ## Commands
 
@@ -17,18 +20,17 @@ A Discord bot built for the 7th Cavalry Gaming Regiment using Go and DiscordGo, 
 |---------|---------|
 | `/milpac` | Return a user's milpac |
 | `/zulu` | Current Zulu time |
-| `/gamertag_search` | Find a user by gamertag |
+| `/gamertag_search` | Search for a user by gamertag |
 | `/awol` | AWOL troopers for a position |
 | `/loa` | Active and upcoming LOAs for a position |
-| `/afsm` | Members eligible for the AFSM in a department |
+| `/afsm` | Users eligible for the AFSM in a department |
 | `/s3aar` | Attendance list for events and operations |
-| `/promo` | Tools to gauge promotion eligibility across the regiment |
-| `/billetaudit` | Several audit tools to flag discrepancies in MILPAC |
-| `/apps_beta_deploy` | Deploy the Apps beta version |
 | `/s6-it-check` | S6 IT members eligible for full status |
 | `/warden` | Warden role management |
-| `/warden-bulkadd-internal` | Add a validated unit roster to Verified Warden Internal |
+| `/warden-bulkadd-internal` | Add a validated unit's roster to Verified Warden Internal |
 | `/apps_beta_deploy` | Deploy the Apps beta version |
+
+The registered set lives in `commands/registry.go` — update this table when it changes.
 
 ## Setup
 
@@ -58,9 +60,13 @@ Guild commands appear immediately.
 
 ### 3. Environment
 
-Rename `.env.example` to `.env` and fill it in.
+Copy the template — keep `.env.example` in place, it is tracked:
 
-Startup fails without these:
+```bash
+cp .env.example .env
+```
+
+Startup panics without these three:
 
 | Variable | Source |
 |----------|--------|
@@ -68,11 +74,16 @@ Startup fails without these:
 | `GUILD_ID` | Right-click the server -> Copy Server ID |
 | `BM_TOKEN` | [BattleMetrics](https://www.battlemetrics.com) -> Account -> Developers. Only `/s3aar` uses it; any non-empty placeholder works otherwise. |
 
-Not checked at startup, but required in practice:
+Not checked at startup, but each one silently disables something:
 
-| Variable | Source |
-|----------|--------|
-| `BEARER` | API token for `api.7cav.us`. Every api call fails without it, and there is no startup error. Check this if lookups fail. |
+| Variable | Effect if unset |
+|----------|-----------------|
+| `BEARER` | API token for `api.7cav.us`. Every milpac lookup fails with no startup error — check this first if `/milpac`, `/awol` or `/afsm` come back empty. |
+| `GITHUB_APP_KEY`, `GITHUB_APP_CLIENT_ID` | `/apps_beta_deploy` cannot authenticate. The key is a base64-encoded PEM. |
+| `FORUM_DB_DSN` | LOA cache stays empty, so `/loa` returns nothing. Logs `FORUM_DB_DSN not set, LOA cache disabled` at startup. The production host `xenforo-db` only resolves inside the `xenforo_internal` Docker network. |
+| `LOA_NODE_IDS` | Defaults to `180`; production scans `180,400,540,178,369`. |
+| `LOG_LEVEL` | Defaults to `INFO`. Use `DEBUG` to see per-post LOA parse failures. |
+| `SENTRY_DSN`, `APP_ENV` | Sentry stays off; the bot logs `Sentry disabled (SENTRY_DSN not set)`. |
 
 When adding a new variable, add it to both `.env.example` and the
 `environment:` block in `docker-compose.yml`. Compose does not pass through
@@ -81,24 +92,54 @@ reaches the container.
 
 ### 4. Run
 
+Nothing in the bot reads `.env` — there is no dotenv loader, `main.go` calls
+`os.Getenv` directly. `.env` is a file Docker Compose reads, not one Go reads. So
+pick a path:
+
+**Locally** — export the file into your shell first, or the bot panics on
+`DISCORD_TOKEN` even though `.env` is filled in:
+
 ```bash
-go build -o cavbot2 .
+set -a; source .env; set +a
 go run .
 ```
 
-A healthy startup logs `Registering commands`, then
-`Bot is now running. Press CTRL-C to exit`.
+`set -a` marks everything sourced for export; without it the values stay shell
+variables the process never sees. To run the compiled binary instead:
+
+```bash
+go build -o cavbot2 . && ./cavbot2
+```
+
+**In Docker** — Compose reads `.env` itself, so no exporting. It does not build
+the image (the service declares `image:` with no `build:`), and the network is
+external, so both exist before `up`:
+
+```bash
+docker build -t cavbot2:latest .
+docker network create xenforo_internal   # once, if you don't already have it
+docker compose up
+```
+
+Only the real `xenforo_internal` network reaches the forum database; a network
+you created yourself gets the bot running, but `/loa` stays empty.
+
+A healthy startup logs `CavBot2 starting`, `Removing deprecated commands`,
+`Registering commands`, then `Bot is now running. Press CTRL-C to exit`.
 
 ### Troubleshooting
 
 | Symptom | Likely cause |
 |---------|--------------|
-| Panic naming `DISCORD_TOKEN`, `GUILD_ID` or `BM_TOKEN` | Variable missing from `.env` |
+| Panic naming `DISCORD_TOKEN`, `GUILD_ID` or `BM_TOKEN` | The variable is not in the environment. Filling in `.env` is not enough for `go run .` — export it first (step 4) |
+| `nil pointer dereference` at `main.go` right after `Removing deprecated commands` | The token was rejected, so the session never received a user. Re-copy `DISCORD_TOKEN` — a stale or truncated token lands here rather than on a clean error |
 | Gateway connection fails | Server Members Intent not enabled |
 | Commands never appear | Bot invited without `applications.commands`, or `GUILD_ID` is not the server you are in |
 | Every milpac lookup fails | `BEARER` missing or expired |
-| `FORUM_DB_DSN not set` warning | Expected without a forum database; only affects LOA |
-| golangci-lint reports a Go version mismatch | Binary was built with an older Go than `go.mod` targets; reinstall 2.5.0+ |
+| `FORUM_DB_DSN not set` warning | Expected without a forum database; only affects `/loa` |
+| Compose says `pull access denied` for `cavbot2:latest` | The image was never built locally — run `docker build -t cavbot2:latest .` |
+| Compose says network `xenforo_internal` not found | Create it, or join the host that has it |
+| golangci-lint reports a Go version mismatch | Your golangci-lint was built with an older Go than `go.mod` targets; install a build made with Go 1.25+ |
 
 ## Testing
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-resty/resty/v2 v2.17.2
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/joho/godotenv v1.5.1
 	golang.org/x/sync v0.22.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/7cav/cavbot2/commands"
 	"github.com/bwmarrin/discordgo"
+	"github.com/joho/godotenv"
 )
 
 
@@ -31,6 +32,19 @@ var (
 )
 
 func init() {
+	// Load .env before the reads below so `go run .` works from a filled-in
+	// .env alone. godotenv.Load never overwrites a variable already in the
+	// environment, so Docker and CI — which inject env directly and ship no
+	// .env — behave exactly as they did before. A missing file is the normal
+	// case there and not an error; anything else means the file exists but
+	// could not be read, which is worth failing on rather than starting with
+	// half the configuration silently missing.
+	//
+	// This must stay in init(), not main(): the panics below run first.
+	if err := godotenv.Load(); err != nil && !os.IsNotExist(err) {
+		panic(fmt.Sprintf("Found .env but could not load it: %v", err))
+	}
+
 	Token = os.Getenv("DISCORD_TOKEN")
 	GuildID = os.Getenv("GUILD_ID")
 	LogLevel = os.Getenv("LOG_LEVEL")


### PR DESCRIPTION
Replaces the "Under Construction" placeholder in the README with real onboarding docs, so a new contributor can go from clean checkout to a running bot without reading `main.go`.