### PR TITLE
chore(repo): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo.
+# Routing only — `require_code_owner_review` is intentionally left off.
+*       @SyniRon


### PR DESCRIPTION
Adds a routing-only `.github/CODEOWNERS` naming the sole active maintainer.

`require_code_owner_review` stays **off**: with one owner who is also the usual PR author, GitHub's "authors cannot approve their own pull requests" rule would make every PR unmergeable without an admin bypass. This file is for review routing only.

## Context

Branch protection was migrated from classic protection to rulesets today:

- **`release-tags`** — blocks deletion and non-fast-forward on all tags. Release tags drive the Docker publish (`build_and_push.yml` bakes `github.ref_name` into the image and pings Watchtower), so a re-pointed tag could ship different code under the same version.
- **`default-branch`** — everything classic protection enforced, plus PR required, linear history, squash-only merges, conversation resolution, and `strict` status checks.

This PR is also the live check on the new ruleset before the classic branch protection rule is retired.

> *This was generated by AI*