### PR TITLE
chore(ci): auto-merge Dependabot minor and patch updates

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+# Workflows triggered by Dependabot get a read-only GITHUB_TOKEN regardless of
+# the repository default, so these have to be declared explicitly or the
+# `gh pr merge` step fails with a permissions error.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Auto-merge
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3.1.0
+
+      # Majors are deliberately excluded — dependabot.yml keeps them as
+      # individual PRs so they get scrutinized on their own.
+      - name: Enable auto-merge for minor and patch updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that arms GitHub's auto-merge on Dependabot PRs, so grouped minor/patch bumps merge themselves once `Lint` and `Build` pass.

## How it works

Auto-merge **waits for** required conditions rather than bypassing them. With `required_approving_review_count: 0` on the `default-branch` ruleset, the conditions are: `Lint` passes, `Build` passes, conversations resolved, branch up to date. So this changes who clicks merge, not what gates the merge.

Majors are excluded via `fetch-metadata`'s `update-type` output, matching the intent already documented in `dependabot.yml` — majors land as individual PRs so they get scrutinized on their own.

## Notes

- The explicit `permissions:` block is **required**, not boilerplate. Dependabot-triggered workflows get a read-only `GITHUB_TOKEN` regardless of repository defaults; without it the merge step fails on permissions.
- `allow_auto_merge` is already enabled on the repo, so no settings change is needed.
- The job name (`Auto-merge`) is unique across workflows, so it can't create ambiguous required-status-check results.
- Expect some CI churn on grouped batches: `strict` status checks mean merging one PR makes the others stale. Dependabot rebases its own PRs, so this resolves itself, but the batch serializes rather than landing together.

## Trade-off worth naming

`dependabot.yml`'s 7-day cooldown exists so bumps "wait for supply-chain-attack flagging before hitting the review queue." With auto-merge, nothing reaches a review queue — the cooldown becomes the only control on a compromised release rather than a delay before human eyes. Deliberate trade, not a free win.

> *This was generated by AI*